### PR TITLE
Connect CameraUseCase to settings data and implement rear camera flash

### DIFF
--- a/app/src/main/java/com/google/jetpackcamera/MainActivity.kt
+++ b/app/src/main/java/com/google/jetpackcamera/MainActivity.kt
@@ -92,7 +92,7 @@ class MainActivity : ComponentActivity() {
 private fun isInDarkMode(uiState: MainActivityUiState):Boolean =
     when (uiState) {
         Loading -> isSystemInDarkTheme()
-        is Success -> when (uiState.settings.dark_mode_status) {
+        is Success -> when (uiState.cameraAppSettings.dark_mode_status) {
             DarkModeStatus.DARK -> true
             DarkModeStatus.LIGHT -> false
             DarkModeStatus.SYSTEM -> isSystemInDarkTheme()

--- a/app/src/main/java/com/google/jetpackcamera/MainActivityViewModel.kt
+++ b/app/src/main/java/com/google/jetpackcamera/MainActivityViewModel.kt
@@ -19,7 +19,7 @@ package com.google.jetpackcamera
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.jetpackcamera.settings.SettingsRepository
-import com.google.jetpackcamera.settings.model.Settings
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -33,7 +33,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository
 ) : ViewModel(){
-    val uiState: StateFlow<MainActivityUiState> = settingsRepository.settings.map {
+    val uiState: StateFlow<MainActivityUiState> = settingsRepository.cameraAppSettings.map {
         Success(it)
     }.stateIn(
         scope = viewModelScope,
@@ -43,6 +43,6 @@ class MainActivityViewModel @Inject constructor(
 }
 sealed interface MainActivityUiState {
     object Loading : MainActivityUiState
-    data class Success(val settings: Settings) : MainActivityUiState
+    data class Success(val cameraAppSettings: CameraAppSettings) : MainActivityUiState
 }
 

--- a/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalCameraAppSettingsRepositoryInstrumentedTest.kt
+++ b/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalCameraAppSettingsRepositoryInstrumentedTest.kt
@@ -21,39 +21,46 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.jetpackcamera.settings.DataStoreModule.provideDataStore
 import com.google.jetpackcamera.settings.model.DarkModeStatus
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.getDefaultSettings
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import java.io.File
 
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class SettingsViewModelTest {
-    private val testContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+@RunWith(AndroidJUnit4::class)
+class LocalCameraAppSettingsRepositoryInstrumentedTest {
+    private val testContext: Context = ApplicationProvider.getApplicationContext()
     private lateinit var testDataStore: DataStore<JcaSettings>
     private lateinit var datastoreScope: CoroutineScope
     private lateinit var repository: LocalSettingsRepository
-    private lateinit var settingsViewModel: SettingsViewModel
-
 
     @Before
     fun setup() = runTest(StandardTestDispatcher()) {
         Dispatchers.setMain(StandardTestDispatcher())
+        testDataStore = provideDataStore(testContext)
         datastoreScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
         testDataStore = DataStoreFactory.create(
@@ -63,7 +70,6 @@ internal class SettingsViewModelTest {
             testContext.dataStoreFile("test_jca_settings.pb")
         }
         repository = LocalSettingsRepository(testDataStore)
-        settingsViewModel = SettingsViewModel(repository)
         advanceUntilIdle()
     }
 
@@ -78,41 +84,35 @@ internal class SettingsViewModelTest {
     }
 
     @Test
-    fun getSettingsUiState() = runTest(StandardTestDispatcher()) {
-        // giving viewmodel time to call init, otherwise settings will stay disabled
-        delay(100)
-        val uiState = settingsViewModel.settingsUiState.value
+    fun repository_can_fetch_initial_datastore() = runTest(StandardTestDispatcher()) {
+        var cameraAppSettings: CameraAppSettings = repository.getSettings()
+
         advanceUntilIdle()
-        assertEquals(
-            uiState,
-            SettingsUiState(settings = getDefaultSettings(), disabled = false)
-        )
+        assertTrue(cameraAppSettings == getDefaultSettings())
     }
 
     @Test
-    fun setDefaultToFrontCamera() = runTest(StandardTestDispatcher()) {
-        val initialFrontCameraValue =
-            settingsViewModel.settingsUiState.value.settings.default_front_camera
-        settingsViewModel.setDefaultToFrontCamera()
+    fun can_update_dark_mode() = runTest(StandardTestDispatcher()) {
+        var initialDarkModeStatus = repository.getSettings().dark_mode_status
+        repository.updateDarkModeStatus(DarkModeStatus.LIGHT)
+        val newDarkModeStatus = repository.getSettings().dark_mode_status
 
         advanceUntilIdle()
-
-        val newFrontCameraValue =
-            settingsViewModel.settingsUiState.value.settings.default_front_camera
-
-        assertFalse(initialFrontCameraValue)
-        assertTrue(newFrontCameraValue)
+        assertFalse(initialDarkModeStatus == newDarkModeStatus)
+        assertTrue(initialDarkModeStatus == DarkModeStatus.SYSTEM)
+        assertTrue(newDarkModeStatus == DarkModeStatus.LIGHT)
     }
 
     @Test
-    fun setDarkMode() = runTest(StandardTestDispatcher()) {
-        val initialDarkMode = settingsViewModel.settingsUiState.value.settings.dark_mode_status
-        settingsViewModel.setDarkMode(DarkModeStatus.DARK)
+    fun can_update_default_to_front_camera() = runTest(StandardTestDispatcher()) {
+        // default to front camera starts false
+        val initalFrontCameraDefault = repository.getSettings().default_front_camera
+        repository.updateDefaultToFrontCamera()
+        // default to front camera is now true
+        val frontCameraDefault = repository.getSettings().default_front_camera
         advanceUntilIdle()
 
-        val newDarkMode = settingsViewModel.settingsUiState.value.settings.dark_mode_status
-
-        assertEquals(initialDarkMode, DarkModeStatus.SYSTEM)
-        assertEquals(DarkModeStatus.DARK, newDarkMode)
+        assertFalse(initalFrontCameraDefault)
+        assertTrue(frontCameraDefault)
     }
 }

--- a/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalCameraAppSettingsRepositoryInstrumentedTest.kt
+++ b/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalCameraAppSettingsRepositoryInstrumentedTest.kt
@@ -25,7 +25,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.jetpackcamera.settings.DataStoreModule.provideDataStore
 import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.getDefaultSettings
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -88,7 +88,7 @@ class LocalCameraAppSettingsRepositoryInstrumentedTest {
         var cameraAppSettings: CameraAppSettings = repository.getSettings()
 
         advanceUntilIdle()
-        assertTrue(cameraAppSettings == getDefaultSettings())
+        assertTrue(cameraAppSettings == DEFAULT_CAMERA_APP_SETTINGS)
     }
 
     @Test

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/JcaSettingsSerializer.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/JcaSettingsSerializer.kt
@@ -33,6 +33,7 @@ object JcaSettingsSerializer : Serializer<JcaSettings> {
     override val defaultValue: JcaSettings = JcaSettings.newBuilder()
         .setDarkModeStatus(DarkModeProto.DARK_MODE_SYSTEM)
         .setDefaultFrontCamera(false)
+        .setFlashModeStatus(FlashModeProto.FLASH_MODE_OFF)
         .build()
 
     override suspend fun readFrom(input: InputStream): JcaSettings {

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -18,7 +18,7 @@ package com.google.jetpackcamera.settings
 
 import androidx.datastore.core.DataStore
 import com.google.jetpackcamera.settings.model.DarkModeStatus
-import com.google.jetpackcamera.settings.model.Settings
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -30,9 +30,9 @@ class LocalSettingsRepository @Inject constructor(
     private val jcaSettings: DataStore<JcaSettings>
 ) : SettingsRepository {
 
-    override val settings = jcaSettings.data
+    override val cameraAppSettings = jcaSettings.data
         .map {
-            Settings(
+            CameraAppSettings(
                 default_front_camera = it.defaultFrontCamera,
                 dark_mode_status = when (it.darkModeStatus){
                     DarkModeProto.DARK_MODE_DARK -> DarkModeStatus.DARK
@@ -61,7 +61,7 @@ class LocalSettingsRepository @Inject constructor(
         }
     }
 
-    override suspend fun getSettings(): Settings {
-        return settings.first()
+    override suspend fun getSettings(): CameraAppSettings {
+        return cameraAppSettings.first()
     }
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -19,6 +19,7 @@ package com.google.jetpackcamera.settings
 import androidx.datastore.core.DataStore
 import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -40,6 +41,13 @@ class LocalSettingsRepository @Inject constructor(
                     DarkModeProto.DARK_MODE_SYSTEM,
                     DarkModeProto.UNRECOGNIZED,
                     null  -> DarkModeStatus.SYSTEM
+                },
+                flash_mode_status = when (it.flashModeStatus){
+                    FlashModeProto.FLASH_MODE_AUTO -> FlashModeStatus.AUTO
+                    FlashModeProto.FLASH_MODE_ON -> FlashModeStatus.ON
+                    FlashModeProto.FLASH_MODE_OFF,
+                    FlashModeProto.UNRECOGNIZED,
+                    null -> FlashModeStatus.OFF
                 }
             )
         }
@@ -58,6 +66,17 @@ class LocalSettingsRepository @Inject constructor(
         }
         jcaSettings.updateData {
             it.copy { this.darkModeStatus = newStatus }
+        }
+    }
+
+    override suspend fun updateFlashModeStatus(flashModeStatus: FlashModeStatus) {
+        val newStatus = when (flashModeStatus) {
+            FlashModeStatus.AUTO -> FlashModeProto.FLASH_MODE_AUTO
+                FlashModeStatus.ON -> FlashModeProto.FLASH_MODE_ON
+                FlashModeStatus.OFF -> FlashModeProto.FLASH_MODE_OFF
+        }
+        jcaSettings.updateData {
+            it.copy { this.flashModeStatus = newStatus }
         }
     }
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -17,8 +17,8 @@
 package com.google.jetpackcamera.settings
 
 import androidx.datastore.core.DataStore
-import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.FlashModeStatus
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -35,14 +35,14 @@ class LocalSettingsRepository @Inject constructor(
         .map {
             CameraAppSettings(
                 default_front_camera = it.defaultFrontCamera,
-                dark_mode_status = when (it.darkModeStatus){
+                dark_mode_status = when (it.darkModeStatus) {
                     DarkModeProto.DARK_MODE_DARK -> DarkModeStatus.DARK
                     DarkModeProto.DARK_MODE_LIGHT -> DarkModeStatus.LIGHT
                     DarkModeProto.DARK_MODE_SYSTEM,
                     DarkModeProto.UNRECOGNIZED,
-                    null  -> DarkModeStatus.SYSTEM
+                    null -> DarkModeStatus.SYSTEM
                 },
-                flash_mode_status = when (it.flashModeStatus){
+                flash_mode_status = when (it.flashModeStatus) {
                     FlashModeProto.FLASH_MODE_AUTO -> FlashModeStatus.AUTO
                     FlashModeProto.FLASH_MODE_ON -> FlashModeStatus.ON
                     FlashModeProto.FLASH_MODE_OFF,
@@ -59,7 +59,7 @@ class LocalSettingsRepository @Inject constructor(
     }
 
     override suspend fun updateDarkModeStatus(status: DarkModeStatus) {
-        val newStatus = when (status){
+        val newStatus = when (status) {
             DarkModeStatus.DARK -> DarkModeProto.DARK_MODE_DARK
             DarkModeStatus.LIGHT -> DarkModeProto.DARK_MODE_LIGHT
             DarkModeStatus.SYSTEM -> DarkModeProto.DARK_MODE_SYSTEM
@@ -72,15 +72,13 @@ class LocalSettingsRepository @Inject constructor(
     override suspend fun updateFlashModeStatus(flashModeStatus: FlashModeStatus) {
         val newStatus = when (flashModeStatus) {
             FlashModeStatus.AUTO -> FlashModeProto.FLASH_MODE_AUTO
-                FlashModeStatus.ON -> FlashModeProto.FLASH_MODE_ON
-                FlashModeStatus.OFF -> FlashModeProto.FLASH_MODE_OFF
+            FlashModeStatus.ON -> FlashModeProto.FLASH_MODE_ON
+            FlashModeStatus.OFF -> FlashModeProto.FLASH_MODE_OFF
         }
         jcaSettings.updateData {
             it.copy { this.flashModeStatus = newStatus }
         }
     }
 
-    override suspend fun getSettings(): CameraAppSettings {
-        return cameraAppSettings.first()
-    }
+    override suspend fun getSettings(): CameraAppSettings = cameraAppSettings.first()
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera.settings
 
 import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -30,6 +31,8 @@ interface SettingsRepository {
     suspend fun updateDefaultToFrontCamera()
 
     suspend fun updateDarkModeStatus(darkmodeStatus: DarkModeStatus)
+
+    suspend fun updateFlashModeStatus(flashModeStatus: FlashModeStatus)
 
     suspend fun getSettings(): CameraAppSettings
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
@@ -17,7 +17,7 @@
 package com.google.jetpackcamera.settings
 
 import com.google.jetpackcamera.settings.model.DarkModeStatus
-import com.google.jetpackcamera.settings.model.Settings
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -25,11 +25,11 @@ import kotlinx.coroutines.flow.Flow
  */
 interface SettingsRepository {
 
-    val settings : Flow<Settings>
+    val cameraAppSettings : Flow<CameraAppSettings>
 
     suspend fun updateDefaultToFrontCamera()
 
     suspend fun updateDarkModeStatus(darkmodeStatus: DarkModeStatus)
 
-    suspend fun getSettings(): Settings
+    suspend fun getSettings(): CameraAppSettings
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -19,15 +19,15 @@ package com.google.jetpackcamera.settings.model
 /**
  * Data layer representation for settings.
  */
-data class Settings(
+data class CameraAppSettings(
     val default_front_camera : Boolean,
     val dark_mode_status : DarkModeStatus,
     val field : String = "todo"
 )
 
 
-fun getDefaultSettings(): Settings{
-    return Settings(
+fun getDefaultSettings(): CameraAppSettings{
+    return CameraAppSettings(
         default_front_camera = false,
         dark_mode_status = DarkModeStatus.SYSTEM
     )

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -22,13 +22,14 @@ package com.google.jetpackcamera.settings.model
 data class CameraAppSettings(
     val default_front_camera : Boolean,
     val dark_mode_status : DarkModeStatus,
-    val field : String = "todo"
+    val flash_mode_status : FlashModeStatus
 )
 
 
 fun getDefaultSettings(): CameraAppSettings{
     return CameraAppSettings(
         default_front_camera = false,
-        dark_mode_status = DarkModeStatus.SYSTEM
+        dark_mode_status = DarkModeStatus.SYSTEM,
+        flash_mode_status = FlashModeStatus.OFF
     )
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -20,16 +20,9 @@ package com.google.jetpackcamera.settings.model
  * Data layer representation for settings.
  */
 data class CameraAppSettings(
-    val default_front_camera : Boolean,
-    val dark_mode_status : DarkModeStatus,
-    val flash_mode_status : FlashModeStatus
+    val default_front_camera: Boolean = false,
+    val dark_mode_status: DarkModeStatus = DarkModeStatus.SYSTEM,
+    val flash_mode_status: FlashModeStatus = FlashModeStatus.OFF
 )
 
-
-fun getDefaultSettings(): CameraAppSettings{
-    return CameraAppSettings(
-        default_front_camera = false,
-        dark_mode_status = DarkModeStatus.SYSTEM,
-        flash_mode_status = FlashModeStatus.OFF
-    )
-}
+val DEFAULT_CAMERA_APP_SETTINGS = CameraAppSettings()

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/FlashModeStatus.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/FlashModeStatus.kt
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
-import "com/google/jetpackcamera/settings/dark_mode.proto";
-import "com/google/jetpackcamera/settings/flash_mode.proto";
+package com.google.jetpackcamera.settings.model
 
-
-option java_package = "com.google.jetpackcamera.settings";
-option java_multiple_files = true;
-
-message JcaSettings {
-  bool default_front_camera = 2;
-  DarkModeProto dark_mode_status = 3;
-  FlashModeProto flash_mode_status = 4;
+enum class FlashModeStatus {
+    OFF, ON, AUTO
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
@@ -18,14 +18,14 @@ package com.google.jetpackcamera.settings.test
 
 import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.FlashModeStatus
-import com.google.jetpackcamera.settings.model.getDefaultSettings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 object FakeSettingsRepository : SettingsRepository {
-    var currentCameraSettings: CameraAppSettings = getDefaultSettings()
+    var currentCameraSettings: CameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
 
     override val cameraAppSettings: Flow<CameraAppSettings> = flow { emit(currentCameraSettings) }
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera.settings.test
+
+import com.google.jetpackcamera.settings.SettingsRepository
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.DarkModeStatus
+import com.google.jetpackcamera.settings.model.FlashModeStatus
+import com.google.jetpackcamera.settings.model.getDefaultSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+object FakeSettingsRepository : SettingsRepository {
+    var currentCameraSettings: CameraAppSettings = getDefaultSettings()
+
+    override val cameraAppSettings: Flow<CameraAppSettings> = flow { emit(currentCameraSettings) }
+
+    override suspend fun updateDefaultToFrontCamera() {
+        val newLensFacing = !currentCameraSettings.default_front_camera
+        currentCameraSettings = currentCameraSettings.copy(default_front_camera = newLensFacing)
+    }
+
+    override suspend fun updateDarkModeStatus(darkmodeStatus: DarkModeStatus) {
+        currentCameraSettings = currentCameraSettings.copy(dark_mode_status = darkmodeStatus)
+    }
+
+    override suspend fun updateFlashModeStatus(flashModeStatus: FlashModeStatus) {
+        currentCameraSettings = currentCameraSettings.copy(flash_mode_status = flashModeStatus)
+    }
+
+    override suspend fun getSettings(): CameraAppSettings {
+        return currentCameraSettings
+    }
+}

--- a/data/settings/src/main/proto/com/google/jetpackcamera/settings/flash_mode.proto
+++ b/data/settings/src/main/proto/com/google/jetpackcamera/settings/flash_mode.proto
@@ -15,15 +15,12 @@
  */
 
 syntax = "proto3";
-import "com/google/jetpackcamera/settings/dark_mode.proto";
-import "com/google/jetpackcamera/settings/flash_mode.proto";
-
 
 option java_package = "com.google.jetpackcamera.settings";
 option java_multiple_files = true;
 
-message JcaSettings {
-  bool default_front_camera = 2;
-  DarkModeProto dark_mode_status = 3;
-  FlashModeProto flash_mode_status = 4;
+enum FlashModeProto {
+  FLASH_MODE_AUTO = 0;
+  FLASH_MODE_ON = 1;
+  FLASH_MODE_OFF = 2;
 }

--- a/domain/camera/build.gradle
+++ b/domain/camera/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
 
+    // access settings data
+    implementation project(path: ':data:settings')
+
     implementation(project(":core:common"))
 }
 

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -18,6 +18,8 @@ package com.google.jetpackcamera.domain.camera
 
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 
 /**
  * Data layer for camera.
@@ -29,7 +31,7 @@ interface CameraUseCase {
      *
      * @return list of available lenses.
      */
-    suspend fun initialize(): List<Int>
+    suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int>
 
     /**
      * Starts the camera with [lensFacing] with the provided [Preview.SurfaceProvider].
@@ -38,6 +40,7 @@ interface CameraUseCase {
      */
     suspend fun runCamera(
         surfaceProvider: Preview.SurfaceProvider,
+        currentCameraSettings: CameraAppSettings,
         @CameraSelector.LensFacing lensFacing: Int
     )
 
@@ -48,4 +51,6 @@ interface CameraUseCase {
     fun stopVideoRecording()
 
     fun setZoomScale(scale: Float)
+
+    fun setFlashMode(flashModeStatus: FlashModeStatus)
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -37,16 +37,16 @@ import androidx.camera.video.Recorder
 import androidx.camera.video.Recording
 import androidx.camera.video.VideoCapture
 import androidx.concurrent.futures.await
-import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.FlashModeStatus
 import androidx.core.content.ContextCompat
 import androidx.core.util.Consumer
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asExecutor
-import java.util.Date
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.coroutineScope
+import java.util.Date
 import javax.inject.Inject
 
 private const val TAG = "CameraXCameraUseCase"
@@ -78,7 +78,7 @@ class CameraXCameraUseCase @Inject constructor(
         .addUseCase(videoCaptureUseCase)
         .build()
 
-    private var recording : Recording? = null
+    private var recording: Recording? = null
 
     private var camera: Camera? = null
     override suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int> {
@@ -137,18 +137,20 @@ class CameraXCameraUseCase @Inject constructor(
         val contentValues = ContentValues().apply {
             put(MediaStore.Video.Media.DISPLAY_NAME, name)
         }
-        val mediaStoreOutput = MediaStoreOutputOptions.Builder(application.contentResolver,
-                MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
-                .setContentValues(contentValues)
-                .build()
+        val mediaStoreOutput = MediaStoreOutputOptions.Builder(
+            application.contentResolver,
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+        )
+            .setContentValues(contentValues)
+            .build()
 
         recording = videoCaptureUseCase.output
-                .prepareRecording(application, mediaStoreOutput)
-                .start(ContextCompat.getMainExecutor(application), Consumer { videoRecordEvent ->
-                    run {
-                        Log.d(TAG, videoRecordEvent.toString())
-                    }
-                })
+            .prepareRecording(application, mediaStoreOutput)
+            .start(ContextCompat.getMainExecutor(application), Consumer { videoRecordEvent ->
+                run {
+                    Log.d(TAG, videoRecordEvent.toString())
+                }
+            })
     }
 
     override fun stopVideoRecording() {
@@ -165,14 +167,13 @@ class CameraXCameraUseCase @Inject constructor(
 
     private fun getZoomState(): ZoomState? = camera?.cameraInfo?.zoomState?.value
 
-     override fun setFlashMode(flashModeStatus: FlashModeStatus){
-        val newFlashMode = when (flashModeStatus) {
+    override fun setFlashMode(flashModeStatus: FlashModeStatus) {
+        imageCaptureUseCase.flashMode = when (flashModeStatus) {
             FlashModeStatus.OFF -> ImageCapture.FLASH_MODE_OFF // 2
             FlashModeStatus.ON -> ImageCapture.FLASH_MODE_ON // 1
             FlashModeStatus.AUTO -> ImageCapture.FLASH_MODE_AUTO // 0
         }
-        imageCaptureUseCase.flashMode = newFlashMode
-        Log.d(TAG, "Set flash mode to: " + imageCaptureUseCase.flashMode)
+        Log.d(TAG, "Set flash mode to: ${imageCaptureUseCase.flashMode}")
     }
 
     private fun cameraLensToSelector(@LensFacing lensFacing: Int): CameraSelector =

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -18,8 +18,9 @@ package com.google.jetpackcamera.domain.camera.test
 
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
-import androidx.lifecycle.LifecycleOwner
 import com.google.jetpackcamera.domain.camera.CameraUseCase
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 import kotlin.IllegalStateException
 
 class FakeCameraUseCase : CameraUseCase {
@@ -33,14 +34,15 @@ class FakeCameraUseCase : CameraUseCase {
 
     var recordingInProgress = false
 
-    override suspend fun initialize(): List<Int> {
+    override suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int> {
         initialized = true
         return availableLenses
     }
 
     override suspend fun runCamera(
         surfaceProvider: Preview.SurfaceProvider,
-        lensFacing: Int
+        currentCameraSettings: CameraAppSettings,
+        @CameraSelector.LensFacing lensFacing: Int
     ) {
         if (!initialized)     {
             throw IllegalStateException("CameraProvider not initialized")
@@ -68,5 +70,9 @@ class FakeCameraUseCase : CameraUseCase {
     }
 
     override fun setZoomScale(scale: Float) {
+    }
+
+    override fun setFlashMode(flashModeStatus: FlashModeStatus) {
+        TODO("Not yet implemented")
     }
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -33,9 +33,11 @@ class FakeCameraUseCase : CameraUseCase {
     var numPicturesTaken = 0
 
     var recordingInProgress = false
+    private var flashMode = FlashModeStatus.OFF
 
     override suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int> {
         initialized = true
+        flashMode = currentCameraSettings.flash_mode_status
         return availableLenses
     }
 
@@ -73,6 +75,6 @@ class FakeCameraUseCase : CameraUseCase {
     }
 
     override fun setFlashMode(flashModeStatus: FlashModeStatus) {
-        TODO("Not yet implemented")
+        flashMode = flashModeStatus
     }
 }

--- a/feature/preview/build.gradle
+++ b/feature/preview/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
 
+    // access settings data
+    implementation project(path: ':data:settings')
+
     implementation(project(":domain:camera"))
     implementation(project(':camera-viewfinder-compose'))
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -17,6 +17,7 @@
 package com.google.jetpackcamera.feature.preview
 
 import androidx.camera.core.CameraSelector
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 
 
 /**
@@ -24,7 +25,8 @@ import androidx.camera.core.CameraSelector
  */
 data class PreviewUiState(
     val cameraState: CameraState = CameraState.NOT_READY,
-    val lensFacing: Int = CameraSelector.LENS_FACING_FRONT,
+    val currentCameraSettings: CameraAppSettings, // "quick" settings
+    val lensFacing: Int = CameraSelector.LENS_FACING_BACK,
     val videoRecordingState: VideoRecordingState = VideoRecordingState.INACTIVE,
 )
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -58,7 +58,6 @@ class PreviewViewModel @Inject constructor(
                 // currently resets all "quick" settings to stored settings
                     settings -> _previewUiState
                 .emit(previewUiState.value.copy(currentCameraSettings = settings))
-                setFlash(previewUiState.value.currentCameraSettings.flash_mode_status)
             }
         }
         initializeCamera()

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import com.google.jetpackcamera.settings.SettingsRepository
-import com.google.jetpackcamera.settings.model.getDefaultSettings
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashModeStatus
 
 private const val TAG = "PreviewViewModel"
@@ -44,7 +44,7 @@ class PreviewViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _previewUiState: MutableStateFlow<PreviewUiState> =
-        MutableStateFlow(PreviewUiState(currentCameraSettings = getDefaultSettings()))
+        MutableStateFlow(PreviewUiState(currentCameraSettings = DEFAULT_CAMERA_APP_SETTINGS))
 
     val previewUiState: StateFlow<PreviewUiState> = _previewUiState
     var runningCameraJob: Job? = null
@@ -109,9 +109,9 @@ class PreviewViewModel @Inject constructor(
                         )
                 )
             )
+            // apply to cameraUseCase
+            cameraUseCase.setFlashMode(previewUiState.value.currentCameraSettings.flash_mode_status)
         }
-        // apply to cameraUseCase
-        cameraUseCase.setFlashMode(previewUiState.value.currentCameraSettings.flash_mode_status)
     }
 
     fun flipCamera() {

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -19,6 +19,8 @@ package com.google.jetpackcamera.feature.preview
 
 import com.google.jetpackcamera.domain.camera.test.FakeCameraUseCase
 import androidx.camera.core.Preview.SurfaceProvider
+import com.google.jetpackcamera.settings.model.FlashModeStatus
+import com.google.jetpackcamera.settings.test.FakeSettingsRepository
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -39,7 +41,7 @@ class PreviewViewModelTest {
     @Before
     fun setup() = runTest(StandardTestDispatcher()) {
         Dispatchers.setMain(StandardTestDispatcher())
-        previewViewModel = PreviewViewModel(cameraUseCase)
+        previewViewModel = PreviewViewModel(cameraUseCase, FakeSettingsRepository)
         advanceUntilIdle()
     }
 
@@ -84,6 +86,15 @@ class PreviewViewModelTest {
         previewViewModel.stopVideoRecording()
         assertEquals(cameraUseCase.recordingInProgress, false)
 
+    }
+
+    @Test
+    fun setFlash() = runTest(StandardTestDispatcher()) {
+        previewViewModel.runCamera(mock())
+        previewViewModel.setFlash(FlashModeStatus.AUTO)
+        advanceUntilIdle()
+        assertEquals(previewViewModel.previewUiState.value.currentCameraSettings.flash_mode_status,
+        FlashModeStatus.AUTO)
     }
 
     @Test

--- a/feature/settings/src/androidTest/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/androidTest/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -22,8 +22,8 @@ import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkModeStatus
-import com.google.jetpackcamera.settings.model.getDefaultSettings
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -85,7 +85,7 @@ internal class CameraAppSettingsViewModelTest {
         advanceUntilIdle()
         assertEquals(
             uiState,
-            SettingsUiState(cameraAppSettings = getDefaultSettings(), disabled = false)
+            SettingsUiState(cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS, disabled = false)
         )
     }
 

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.google.jetpackcamera.settings.ui.DarkModeSetting
 import com.google.jetpackcamera.settings.ui.DefaultCameraFacing
+import com.google.jetpackcamera.settings.ui.FlashModeSetting
 import com.google.jetpackcamera.settings.ui.SectionHeader
 import com.google.jetpackcamera.settings.ui.SettingsPageHeader
 
@@ -66,8 +67,14 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
         onClick = viewModel::setDefaultToFrontCamera
     )
 
+    FlashModeSetting(
+        uiState = uiState,
+        setFlashMode = viewModel::setFlashMode
+    )
+
     SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
     DarkModeSetting(
         uiState = uiState,
-        setDarkMode = viewModel::setDarkMode)
+        setDarkMode = viewModel::setDarkMode
+    )
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -62,7 +62,7 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
     SectionHeader(title = stringResource(id = R.string.section_title_camera_settings))
 
     DefaultCameraFacing(
-        settings = uiState.settings,
+        cameraAppSettings = uiState.cameraAppSettings,
         onClick = viewModel::setDefaultToFrontCamera
     )
 

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
@@ -16,7 +16,7 @@
 
 package com.google.jetpackcamera.settings
 
-import com.google.jetpackcamera.settings.model.Settings
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 
 private const val TAG = "SettingsUiState"
 
@@ -24,6 +24,6 @@ private const val TAG = "SettingsUiState"
  * Defines the current state of the [SettingsScreen].
  */
 data class SettingsUiState(
-    val settings: Settings,
+    val cameraAppSettings: CameraAppSettings,
     var disabled: Boolean = false
 )

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.jetpackcamera.settings.model.DarkModeStatus
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 import com.google.jetpackcamera.settings.model.getDefaultSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -86,6 +87,12 @@ class SettingsViewModel @Inject constructor(
             Log.d(
                 TAG, "set dark mode theme: " + settingsRepository.getSettings().dark_mode_status
             )
+        }
+    }
+
+    fun setFlashMode(flashModeStatus: FlashModeStatus) {
+        viewModelScope.launch {
+            settingsRepository.updateFlashModeStatus(flashModeStatus)
         }
     }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -50,10 +50,10 @@ class SettingsViewModel @Inject constructor(
     init {
         // updates our viewmodel as soon as datastore is updated
         viewModelScope.launch {
-            settingsRepository.settings.collect { updatedSettings ->
+            settingsRepository.cameraAppSettings.collect { updatedSettings ->
                 _settingsUiState.emit(
                     settingsUiState.value.copy(
-                        settings = updatedSettings,
+                        cameraAppSettings = updatedSettings,
                         disabled = false
                     )
                 )

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -19,9 +19,9 @@ package com.google.jetpackcamera.settings
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.FlashModeStatus
-import com.google.jetpackcamera.settings.model.getDefaultSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -42,7 +42,7 @@ class SettingsViewModel @Inject constructor(
     private val _settingsUiState: MutableStateFlow<SettingsUiState> =
         MutableStateFlow(
             SettingsUiState(
-                getDefaultSettings(),
+                DEFAULT_CAMERA_APP_SETTINGS,
                 disabled = true
             )
         )

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -50,6 +50,7 @@ import com.google.jetpackcamera.settings.R
 import com.google.jetpackcamera.settings.SettingsUiState
 import com.google.jetpackcamera.settings.model.DarkModeStatus
 import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.FlashModeStatus
 
 
 /**
@@ -117,6 +118,35 @@ fun DarkModeSetting(uiState: SettingsUiState, setDarkMode: (DarkModeStatus) -> U
                 ChoiceRow(text = stringResource(id = R.string.dark_mode_selector_system),
                     selected = uiState.cameraAppSettings.dark_mode_status == DarkModeStatus.SYSTEM,
                     onClick = { setDarkMode(DarkModeStatus.SYSTEM) }
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun FlashModeSetting(uiState: SettingsUiState, setFlashMode: (FlashModeStatus) -> Unit) {
+    BasicPopupSetting(
+        title = stringResource(id = R.string.flash_mode_title),
+        leadingIcon = null,
+        description = when (uiState.cameraAppSettings.flash_mode_status) {
+            FlashModeStatus.AUTO -> stringResource(id = R.string.flash_mode_status_auto)
+            FlashModeStatus.ON -> stringResource(id = R.string.flash_mode_status_on)
+            FlashModeStatus.OFF -> stringResource(id = R.string.flash_mode_status_off)
+        },
+        popupContents = {
+            Column(Modifier.selectableGroup()) {
+                ChoiceRow(text = stringResource(id = R.string.flash_mode_selector_auto),
+                    selected = uiState.cameraAppSettings.flash_mode_status == FlashModeStatus.AUTO,
+                    onClick = { setFlashMode(FlashModeStatus.AUTO) }
+                )
+                ChoiceRow(text = stringResource(id = R.string.flash_mode_selector_on),
+                    selected = uiState.cameraAppSettings.flash_mode_status == FlashModeStatus.ON,
+                    onClick = { setFlashMode(FlashModeStatus.ON) }
+                )
+                ChoiceRow(text = stringResource(id = R.string.flash_mode_selector_off),
+                    selected = uiState.cameraAppSettings.flash_mode_status == FlashModeStatus.OFF,
+                    onClick = { setFlashMode(FlashModeStatus.OFF) }
                 )
             }
         }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.settings.R
 import com.google.jetpackcamera.settings.SettingsUiState
 import com.google.jetpackcamera.settings.model.DarkModeStatus
-import com.google.jetpackcamera.settings.model.Settings
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 
 
 /**
@@ -84,13 +84,13 @@ fun SectionHeader(title: String) {
 }
 
 @Composable
-fun DefaultCameraFacing(settings: Settings, onClick: () -> Unit) {
+fun DefaultCameraFacing(cameraAppSettings: CameraAppSettings, onClick: () -> Unit) {
     SwitchSettingUI(
         title = stringResource(id = R.string.default_facing_camera_title),
         description = null,
         leadingIcon = null,
         onClick = { onClick() },
-        settingValue = settings.default_front_camera
+        settingValue = cameraAppSettings.default_front_camera
     )
 }
 
@@ -99,7 +99,7 @@ fun DarkModeSetting(uiState: SettingsUiState, setDarkMode: (DarkModeStatus) -> U
     BasicPopupSetting(
         title = stringResource(id = R.string.dark_mode_title),
         leadingIcon = null,
-        description = when (uiState.settings.dark_mode_status) {
+        description = when (uiState.cameraAppSettings.dark_mode_status) {
             DarkModeStatus.SYSTEM -> stringResource(id = R.string.dark_mode_status_system)
             DarkModeStatus.DARK -> stringResource(id = R.string.dark_mode_status_dark)
             DarkModeStatus.LIGHT -> stringResource(id = R.string.dark_mode_status_light)
@@ -107,15 +107,15 @@ fun DarkModeSetting(uiState: SettingsUiState, setDarkMode: (DarkModeStatus) -> U
         popupContents = {
             Column(Modifier.selectableGroup()) {
                 ChoiceRow(text = stringResource(id = R.string.dark_mode_selector_dark),
-                    selected = uiState.settings.dark_mode_status == DarkModeStatus.DARK,
+                    selected = uiState.cameraAppSettings.dark_mode_status == DarkModeStatus.DARK,
                     onClick = { setDarkMode(DarkModeStatus.DARK) }
                 )
                 ChoiceRow(text = stringResource(id = R.string.dark_mode_selector_light),
-                    selected = uiState.settings.dark_mode_status == DarkModeStatus.LIGHT,
+                    selected = uiState.cameraAppSettings.dark_mode_status == DarkModeStatus.LIGHT,
                     onClick = { setDarkMode(DarkModeStatus.LIGHT) }
                 )
                 ChoiceRow(text = stringResource(id = R.string.dark_mode_selector_system),
-                    selected = uiState.settings.dark_mode_status == DarkModeStatus.SYSTEM,
+                    selected = uiState.cameraAppSettings.dark_mode_status == DarkModeStatus.SYSTEM,
                     onClick = { setDarkMode(DarkModeStatus.SYSTEM) }
                 )
             }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="default_facing_camera_description">Default Front</string>
     <string name="default_facing_camera_description_off">Default Back</string>
 
+    <!-- Dark mode setting strings -->
     <string name="dark_mode_title">Set Dark Mode</string>
     <string name="dark_mode_selector_dark">On</string>
     <string name="dark_mode_selector_light">Off</string>
@@ -36,5 +37,15 @@
     <string name="dark_mode_status_dark">On</string>
     <string name="dark_mode_status_light">Off</string>
     <string name="dark_mode_status_system">System</string>
+
+    <!-- Flash mode setting strings -->
+    <string name="flash_mode_title">Set Flash Mode</string>
+    <string name="flash_mode_selector_auto">Auto</string>
+    <string name="flash_mode_selector_on">On</string>
+    <string name="flash_mode_selector_off">Off</string>
+
+    <string name="flash_mode_status_auto">Flash is set to Auto</string>
+    <string name="flash_mode_status_on">Flash is On</string>
+    <string name="flash_mode_status_off">Flash is Off</string>
 
 </resources>


### PR DESCRIPTION
This is a PR that enables the user to change the default flash mode of the rear camera from the Settings Screen. Here is some info on the more notable changes in the files.

**Misc. Changes**
changed the name of the `Settings` class to `CameraAppSettings`

**Changes to Datastore**
created `flash_mode.proto` enum schema representing flash mode status of on, off, and auto
added `flash_mode_status` value to `jca_settings.proto`
add `flash_mode_status` to `CameraAppSettings`
add `updateFlashModeStatus` to `LocalSettingsRepository`

**Changes connecting cameraUseCase to settings values**
_PreviewViewModel.kt_ & _PreviewUiState.kt_

- added settingsRepository as parameter for PreviewViewModel (read-only) 
- add currentCameraSettings value to PreviewUiState. ViewModel will provide the value of the settingsRepository as the initial value of currentCameraSettings. This can be regarded as our "Quick Settings" values
- add `setFlashMode` function. Changes the value of the flash mode in currentCameraSettings and then calls cameraUseCase.setFlashMode to rebind the use cases with the updated setting.

_CameraXCameraUseCase.kt_

- `setFlashMode` function takes a FlashModeStatus enum and applies it to the imageCaptureUseCase
- adds currentCameraSettings parameter to initialize. when first opening the app this will ensure the default stored flash mode is applied


**UI functionality**
- `setFlashMode` in _SettingsViewmodel_ to update datastore value 
- Flash Setting composable component