### PR TITLE
Implement flip camera

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="401594821">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_6_Pro_API_30" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="2043991187">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_6_Pro_API_30" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/JcaSettingsSerializer.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/JcaSettingsSerializer.kt
@@ -33,6 +33,8 @@ object JcaSettingsSerializer : Serializer<JcaSettings> {
     override val defaultValue: JcaSettings = JcaSettings.newBuilder()
         .setDarkModeStatus(DarkModeProto.DARK_MODE_SYSTEM)
         .setDefaultFrontCamera(false)
+        .setBackCameraAvailable(true)
+        .setFrontCameraAvailable(true)
         .setFlashModeStatus(FlashModeProto.FLASH_MODE_OFF)
         .build()
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -48,14 +48,20 @@ class LocalSettingsRepository @Inject constructor(
                     FlashModeProto.FLASH_MODE_OFF,
                     FlashModeProto.UNRECOGNIZED,
                     null -> FlashModeStatus.OFF
-                }, front_camera_available = it.frontCameraAvailable,
+                },
+                front_camera_available = it.frontCameraAvailable,
                 back_camera_available = it.backCameraAvailable
             )
         }
 
+    override suspend fun getCameraAppSettings(): CameraAppSettings = cameraAppSettings.first()
+
+
     override suspend fun updateDefaultToFrontCamera() {
-        jcaSettings.updateData {
-            it.copy { this.defaultFrontCamera = !this.defaultFrontCamera }
+        jcaSettings.updateData { currentSettings ->
+            currentSettings.toBuilder()
+                .setDefaultFrontCamera(!currentSettings.defaultFrontCamera)
+                .build()
         }
     }
 
@@ -65,8 +71,10 @@ class LocalSettingsRepository @Inject constructor(
             DarkModeStatus.LIGHT -> DarkModeProto.DARK_MODE_LIGHT
             DarkModeStatus.SYSTEM -> DarkModeProto.DARK_MODE_SYSTEM
         }
-        jcaSettings.updateData {
-            it.copy { this.darkModeStatus = newStatus }
+        jcaSettings.updateData { currentSettings ->
+            currentSettings.toBuilder()
+                .setDarkModeStatus(newStatus)
+                .build()
         }
     }
 
@@ -76,12 +84,12 @@ class LocalSettingsRepository @Inject constructor(
             FlashModeStatus.ON -> FlashModeProto.FLASH_MODE_ON
             FlashModeStatus.OFF -> FlashModeProto.FLASH_MODE_OFF
         }
-        jcaSettings.updateData {
-            it.copy { this.flashModeStatus = newStatus }
+        jcaSettings.updateData { currentSettings ->
+            currentSettings.toBuilder()
+                .setFlashModeStatus(newStatus)
+                .build()
         }
     }
-
-    override suspend fun getSettings(): CameraAppSettings = cameraAppSettings.first()
 
     override suspend fun updateAvailableCameraLens(
         frontLensAvailable: Boolean,
@@ -89,21 +97,12 @@ class LocalSettingsRepository @Inject constructor(
     ) {
         // if a front or back lens is not present, the option to change
         // the direction of the camera should be disabled
-        if (!(frontLensAvailable && backLensAvailable)) {
-            jcaSettings.updateData { currentSettings ->
-                currentSettings.toBuilder()
-                    .setDefaultFrontCamera(frontLensAvailable)
-                    .setFrontCameraAvailable(frontLensAvailable)
-                    .setBackCameraAvailable(backLensAvailable)
-                    .build()
-            }
-        } else {
-            jcaSettings.updateData { currentSettings ->
-                currentSettings.toBuilder()
-                    .setFrontCameraAvailable(true)
-                    .setBackCameraAvailable(true)
-                    .build()
-            }
+        jcaSettings.updateData { currentSettings ->
+            currentSettings.toBuilder()
+                .setDefaultFrontCamera(frontLensAvailable)
+                .setFrontCameraAvailable(frontLensAvailable)
+                .setBackCameraAvailable(backLensAvailable)
+                .build()
         }
     }
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -48,7 +48,8 @@ class LocalSettingsRepository @Inject constructor(
                     FlashModeProto.FLASH_MODE_OFF,
                     FlashModeProto.UNRECOGNIZED,
                     null -> FlashModeStatus.OFF
-                }
+                }, front_camera_available = it.frontCameraAvailable,
+                back_camera_available = it.backCameraAvailable
             )
         }
 
@@ -81,4 +82,28 @@ class LocalSettingsRepository @Inject constructor(
     }
 
     override suspend fun getSettings(): CameraAppSettings = cameraAppSettings.first()
+
+    override suspend fun updateAvailableCameraLens(
+        frontLensAvailable: Boolean,
+        backLensAvailable: Boolean
+    ) {
+        // if a front or back lens is not present, the option to change
+        // the direction of the camera should be disabled
+        if (!(frontLensAvailable && backLensAvailable)) {
+            jcaSettings.updateData { currentSettings ->
+                currentSettings.toBuilder()
+                    .setDefaultFrontCamera(frontLensAvailable)
+                    .setFrontCameraAvailable(frontLensAvailable)
+                    .setBackCameraAvailable(backLensAvailable)
+                    .build()
+            }
+        } else {
+            jcaSettings.updateData { currentSettings ->
+                currentSettings.toBuilder()
+                    .setFrontCameraAvailable(true)
+                    .setBackCameraAvailable(true)
+                    .build()
+            }
+        }
+    }
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
@@ -34,7 +34,7 @@ interface SettingsRepository {
 
     suspend fun updateFlashModeStatus(flashModeStatus: FlashModeStatus)
 
-    suspend fun getSettings(): CameraAppSettings
+    suspend fun getCameraAppSettings(): CameraAppSettings
 
 // set device values from cameraUseCase
     suspend fun updateAvailableCameraLens(frontLensAvailable: Boolean, backLensAvailable: Boolean)

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
@@ -35,4 +35,8 @@ interface SettingsRepository {
     suspend fun updateFlashModeStatus(flashModeStatus: FlashModeStatus)
 
     suspend fun getSettings(): CameraAppSettings
+
+// set device values from cameraUseCase
+    suspend fun updateAvailableCameraLens(frontLensAvailable: Boolean, backLensAvailable: Boolean)
+
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -21,6 +21,8 @@ package com.google.jetpackcamera.settings.model
  */
 data class CameraAppSettings(
     val default_front_camera: Boolean = false,
+    val front_camera_available: Boolean = true,
+    val back_camera_available: Boolean = true,
     val dark_mode_status: DarkModeStatus = DarkModeStatus.SYSTEM,
     val flash_mode_status: FlashModeStatus = FlashModeStatus.OFF
 )

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
@@ -45,4 +45,11 @@ object FakeSettingsRepository : SettingsRepository {
     override suspend fun getSettings(): CameraAppSettings {
         return currentCameraSettings
     }
+
+    override suspend fun updateAvailableCameraLens(
+        frontLensAvailable: Boolean,
+        backLensAvailable: Boolean
+    ) {
+        TODO("Not yet implemented")
+    }
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
@@ -42,7 +42,7 @@ object FakeSettingsRepository : SettingsRepository {
         currentCameraSettings = currentCameraSettings.copy(flash_mode_status = flashModeStatus)
     }
 
-    override suspend fun getSettings(): CameraAppSettings {
+    override suspend fun getCameraAppSettings(): CameraAppSettings {
         return currentCameraSettings
     }
 

--- a/data/settings/src/main/proto/com/google/jetpackcamera/settings/jca_settings.proto
+++ b/data/settings/src/main/proto/com/google/jetpackcamera/settings/jca_settings.proto
@@ -24,6 +24,8 @@ option java_multiple_files = true;
 
 message JcaSettings {
   bool default_front_camera = 2;
-  DarkModeProto dark_mode_status = 3;
-  FlashModeProto flash_mode_status = 4;
+  bool front_camera_available = 3;
+  bool back_camera_available = 4;
+  DarkModeProto dark_mode_status = 5;
+  FlashModeProto flash_mode_status = 6;
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -51,4 +51,5 @@ interface CameraUseCase {
     fun setZoomScale(scale: Float)
 
     fun setFlashMode(flashModeStatus: FlashModeStatus)
+    suspend fun flipCamera(isFrontFacing: Boolean)
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -16,7 +16,6 @@
 
 package com.google.jetpackcamera.domain.camera
 
-import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.FlashModeStatus
@@ -40,8 +39,7 @@ interface CameraUseCase {
      */
     suspend fun runCamera(
         surfaceProvider: Preview.SurfaceProvider,
-        currentCameraSettings: CameraAppSettings,
-        @CameraSelector.LensFacing lensFacing: Int
+        currentCameraSettings: CameraAppSettings
     )
 
     suspend fun takePicture()

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -197,13 +197,11 @@ class CameraXCameraUseCase @Inject constructor(
     }
 
     // converts LensFacing from datastore to @LensFacing Int value
-    private fun getLensFacing(isFrontFacing: Boolean): Int {
-        val newLensFacing = when (isFrontFacing) {
+    private fun getLensFacing(isFrontFacing: Boolean): Int =
+        when (isFrontFacing) {
             true -> CameraSelector.LENS_FACING_FRONT
             false -> CameraSelector.LENS_FACING_BACK
         }
-        return newLensFacing
-    }
 
     private suspend fun rebindUseCases(cameraSelector: CameraSelector) {
         cameraProvider.runWith(cameraSelector, useCaseGroup) {

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -21,11 +21,11 @@ import androidx.camera.core.Preview
 import com.google.jetpackcamera.domain.camera.CameraUseCase
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.FlashModeStatus
-import kotlin.IllegalStateException
 
 class FakeCameraUseCase : CameraUseCase {
 
-    private val availableLenses = listOf(CameraSelector.LENS_FACING_FRONT, CameraSelector.LENS_FACING_BACK)
+    private val availableLenses =
+        listOf(CameraSelector.LENS_FACING_FRONT, CameraSelector.LENS_FACING_BACK)
     private var initialized = false
     private var useCasesBinded = false
 
@@ -44,9 +44,13 @@ class FakeCameraUseCase : CameraUseCase {
     override suspend fun runCamera(
         surfaceProvider: Preview.SurfaceProvider,
         currentCameraSettings: CameraAppSettings,
-        @CameraSelector.LensFacing lensFacing: Int
     ) {
-        if (!initialized)     {
+        val lensFacing = when (currentCameraSettings.default_front_camera) {
+            true -> CameraSelector.LENS_FACING_FRONT
+            false -> CameraSelector.LENS_FACING_BACK
+        }
+
+        if (!initialized) {
             throw IllegalStateException("CameraProvider not initialized")
         }
         if (!availableLenses.contains(lensFacing)) {
@@ -57,7 +61,7 @@ class FakeCameraUseCase : CameraUseCase {
     }
 
     override suspend fun takePicture() {
-        if(!useCasesBinded) {
+        if (!useCasesBinded) {
             throw IllegalStateException("Usecases not binded")
         }
         numPicturesTaken += 1

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -33,11 +33,14 @@ class FakeCameraUseCase : CameraUseCase {
     var numPicturesTaken = 0
 
     var recordingInProgress = false
+
+    var isLensFacingFront = false
     private var flashMode = FlashModeStatus.OFF
 
     override suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int> {
         initialized = true
         flashMode = currentCameraSettings.flash_mode_status
+        isLensFacingFront = currentCameraSettings.default_front_camera
         return availableLenses
     }
 
@@ -83,6 +86,6 @@ class FakeCameraUseCase : CameraUseCase {
     }
 
     override suspend fun flipCamera(isFrontFacing: Boolean) {
-        TODO("Not yet implemented")
+        isLensFacingFront = isFrontFacing
     }
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -81,4 +81,8 @@ class FakeCameraUseCase : CameraUseCase {
     override fun setFlashMode(flashModeStatus: FlashModeStatus) {
         flashMode = flashModeStatus
     }
+
+    override suspend fun flipCamera(isFrontFacing: Boolean) {
+        TODO("Not yet implemented")
+    }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -21,6 +21,7 @@ import androidx.camera.core.Preview.SurfaceProvider
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
@@ -136,11 +137,20 @@ fun PreviewScreen(
                 )
             }
 
-            Box(
-                modifier = Modifier.align(Alignment.BottomCenter)
+            //TODO: styling
+            Row(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                horizontalArrangement = Arrangement.SpaceAround
             ) {
                 Row {
-                    FlipCameraButton(onClick = { viewModel.flipCamera() } )
+                    FlipCameraButton(
+                        onClick = { viewModel.flipCamera() },
+                        //enable only when phone has front and rear camera
+                        enabledCondition =
+                        previewUiState.currentCameraSettings.back_camera_available
+                                && previewUiState.currentCameraSettings.front_camera_available
+                    )
+
                     CaptureButton(
                         onClick = { viewModel.captureImage() },
                         onLongPress = { viewModel.startVideoRecording() },
@@ -188,8 +198,8 @@ fun CaptureButton(
 }
 
 @Composable
-fun FlipCameraButton(onClick: () -> Unit) {
-    IconButton(onClick = onClick) {
+fun FlipCameraButton(enabledCondition: Boolean, onClick: () -> Unit) {
+    IconButton(onClick = onClick, enabled = enabledCondition) {
         Icon(
             Icons.Filled.Refresh,
             contentDescription = "Flip Camera",

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -140,7 +140,7 @@ fun PreviewScreen(
                 modifier = Modifier.align(Alignment.BottomCenter)
             ) {
                 Row {
-                    // FlipCameraButton(onClick = { viewModel.flipCamera() } )
+                    FlipCameraButton(onClick = { viewModel.flipCamera() } )
                     CaptureButton(
                         onClick = { viewModel.captureImage() },
                         onLongPress = { viewModel.startVideoRecording() },

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -24,11 +24,13 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -137,12 +139,15 @@ fun PreviewScreen(
             Box(
                 modifier = Modifier.align(Alignment.BottomCenter)
             ) {
-                CaptureButton(
-                    onClick = { viewModel.captureImage() },
-                    onLongPress = { viewModel.startVideoRecording() },
-                    onRelease = { viewModel.stopVideoRecording() },
-                    state = previewUiState.videoRecordingState
-                )
+                Row {
+                    // FlipCameraButton(onClick = { viewModel.flipCamera() } )
+                    CaptureButton(
+                        onClick = { viewModel.captureImage() },
+                        onLongPress = { viewModel.startVideoRecording() },
+                        onRelease = { viewModel.stopVideoRecording() },
+                        state = previewUiState.videoRecordingState
+                    )
+                }
             }
         }
     }
@@ -179,5 +184,16 @@ fun CaptureButton(
                 }
             )
         })
+    }
+}
+
+@Composable
+fun FlipCameraButton(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        Icon(
+            Icons.Filled.Refresh,
+            contentDescription = "Flip Camera",
+            modifier = Modifier.size(72.dp)
+        )
     }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -113,17 +113,20 @@ class PreviewViewModel @Inject constructor(
         }
     }
 
+    // flips the camera opposite to its current direction
     fun flipCamera() {
-        // TODO(yasith)
-
+        flipCamera(!previewUiState.value
+            .currentCameraSettings.default_front_camera)
+    }
+    // sets the camera to a designated direction
+    fun flipCamera(isFacingFront: Boolean) {
         //update viewmodel value
          viewModelScope.launch {
              _previewUiState.emit(
                  previewUiState.value.copy(
                      currentCameraSettings =
                      previewUiState.value.currentCameraSettings.copy(
-                         default_front_camera = !previewUiState.value
-                             .currentCameraSettings.default_front_camera
+                         default_front_camera = isFacingFront
                      )
                  )
              )

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -117,17 +117,19 @@ class PreviewViewModel @Inject constructor(
         // TODO(yasith)
 
         //update viewmodel value
-        /* viewModelScope.launch {
-            _previewUiState.emit(
-                previewUiState.value.copy(
-                    currentCameraSettings =
-                    previewUiState.value.currentCameraSettings.copy(
-                        default_front_camera = !previewUiState.value
-                            .currentCameraSettings.default_front_camera
-                    )
-                )
-            )
-         */
+         viewModelScope.launch {
+             _previewUiState.emit(
+                 previewUiState.value.copy(
+                     currentCameraSettings =
+                     previewUiState.value.currentCameraSettings.copy(
+                         default_front_camera = !previewUiState.value
+                             .currentCameraSettings.default_front_camera
+                     )
+                 )
+             )
+             // apply to cameraUseCase
+             cameraUseCase.flipCamera(previewUiState.value.currentCameraSettings.default_front_camera)
+         }
     }
 
     fun captureImage() {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -40,7 +40,7 @@ private const val TAG = "PreviewViewModel"
 @HiltViewModel
 class PreviewViewModel @Inject constructor(
     private val cameraUseCase: CameraUseCase,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository // only reads from settingsRepository. do not push changes to repository from here
 ) : ViewModel() {
 
     private val _previewUiState: MutableStateFlow<PreviewUiState> =
@@ -83,8 +83,7 @@ class PreviewViewModel @Inject constructor(
             // TODO(yasith): Handle Exceptions from binding use cases
             cameraUseCase.runCamera(
                 surfaceProvider,
-                previewUiState.value.currentCameraSettings,
-                previewUiState.value.lensFacing
+                previewUiState.value.currentCameraSettings
             )
         }
     }
@@ -116,6 +115,19 @@ class PreviewViewModel @Inject constructor(
 
     fun flipCamera() {
         // TODO(yasith)
+
+        //update viewmodel value
+        /* viewModelScope.launch {
+            _previewUiState.emit(
+                previewUiState.value.copy(
+                    currentCameraSettings =
+                    previewUiState.value.currentCameraSettings.copy(
+                        default_front_camera = !previewUiState.value
+                            .currentCameraSettings.default_front_camera
+                    )
+                )
+            )
+         */
     }
 
     fun captureImage() {

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -98,7 +98,15 @@ class PreviewViewModelTest {
     }
 
     @Test
-    fun flipCamera() {
-        // TODO(yasith)
+    fun flipCamera() = runTest(StandardTestDispatcher()) {
+        // initial default value should be back
+        previewViewModel.runCamera(mock())
+        assertEquals(previewViewModel.previewUiState.value.currentCameraSettings.default_front_camera, false)
+        previewViewModel.flipCamera()
+
+        advanceUntilIdle()
+        //ui state and camera should both be true now
+        assertEquals(previewViewModel.previewUiState.value.currentCameraSettings.default_front_camera, true)
+        assertEquals(true, cameraUseCase.isLensFacingFront )
     }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -75,7 +75,7 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.updateDefaultToFrontCamera()
             Log.d(
                 TAG,
-                "set camera default facing: " + settingsRepository.getSettings().default_front_camera
+                "set camera default facing: " + settingsRepository.getCameraAppSettings().default_front_camera
             )
         }
     }
@@ -85,7 +85,7 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.updateDarkModeStatus(darkModeStatus)
             Log.d(
-                TAG, "set dark mode theme: " + settingsRepository.getSettings().dark_mode_status
+                TAG, "set dark mode theme: " + settingsRepository.getCameraAppSettings().dark_mode_status
             )
         }
     }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -91,7 +91,8 @@ fun DefaultCameraFacing(cameraAppSettings: CameraAppSettings, onClick: () -> Uni
         description = null,
         leadingIcon = null,
         onClick = { onClick() },
-        settingValue = cameraAppSettings.default_front_camera
+        settingValue = cameraAppSettings.default_front_camera,
+        enabled =  cameraAppSettings.back_camera_available && cameraAppSettings.front_camera_available
     )
 }
 
@@ -202,15 +203,17 @@ fun SwitchSettingUI(
     description: String?,
     leadingIcon: @Composable (() -> Unit)?,
     onClick: () -> Unit,
-    settingValue: Boolean
+    settingValue: Boolean,
+    enabled: Boolean
 ) {
     SettingUI(
+        enabled = enabled,
         title = title,
         description = description,
         leadingIcon = leadingIcon,
         onClick = onClick,
         trailingContent = {
-            SettingSwitch(settingValue, onClick)
+            SettingSwitch(settingValue, onClick, enabled)
         }
     )
 }
@@ -225,11 +228,12 @@ fun SettingUI(
     description: String? = null,
     leadingIcon: @Composable (() -> Unit)?,
     trailingContent: @Composable (() -> Unit)?,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    enabled: Boolean = true
 ) {
     Box(modifier = Modifier) {
         ListItem(
-            modifier = Modifier.clickable { onClick() },
+            modifier = Modifier.clickable(enabled = enabled) { onClick() },
             headlineText = { Text(title) },
             supportingText = {
                 when (description) {
@@ -249,10 +253,10 @@ fun SettingUI(
  * A component for a switch
  */
 @Composable
-fun SettingSwitch(settingValue: Boolean, onClick: () -> Unit) {
+fun SettingSwitch(settingValue: Boolean, onClick: () -> Unit, enabled: Boolean = true) {
     Switch(
         modifier = Modifier,
-        enabled = true,
+        enabled = enabled,
         checked = settingValue,
         onCheckedChange = {
             onClick()


### PR DESCRIPTION
This change enables user to set default startup camera orientation front settings screen, and an on-screen button to flip camera. Styling is still WIP but functionality is complete.

Heres pointers for the notable changes here:
**Store available lens information**
_LocalSettingsRepository_
`updateAvailableCameraLens` function stores the availability status of the front and rear camera into datastore. this information can be used as a condition to disable elements within the app from changing the current lens should only one be available.
_CameraXCameraUseCase_ 
* add coroutine dispatcher and settingsRepository parameter to constructor
* launches a coroutine to  set the  available camera lens in settingsRepository

**Functionality to designate front/rear camera**
_CameraXCameraUseCase_
* supplies lens direction value  from `previewUiState.currentCameraSettings` to cameraLensToSelector on init
* `flipCamera` function to rebind use cases with designated lens direction
_PreviewViewModel_
* function to set UI state value and have camera use case flip the camera

and i added a button to the preview that is supplied the viewModel's flip camera function