### PR TITLE
implement tap to focus

### DIFF
--- a/camera-viewfinder-compose/build.gradle
+++ b/camera-viewfinder-compose/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     implementation composeBom
     androidTestImplementation composeBom
 
+    // Compose - Material Design 3
+    implementation 'androidx.compose.material3:material3'
+
     // Compose - Testing
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/CameraPreview.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/CameraPreview.kt
@@ -19,9 +19,7 @@ package com.google.jetpackcamera.viewfinder
 import android.graphics.Bitmap
 import android.util.Log
 import android.view.Surface
-import com.google.jetpackcamera.viewfinder.surface.CombinedSurface
-import com.google.jetpackcamera.viewfinder.surface.CombinedSurfaceEvent
-import com.google.jetpackcamera.viewfinder.surface.SurfaceType
+import android.view.View
 import androidx.camera.core.Preview.SurfaceProvider
 import androidx.camera.core.SurfaceRequest
 import androidx.camera.view.PreviewView.ImplementationMode
@@ -34,6 +32,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import com.google.jetpackcamera.viewfinder.surface.CombinedSurface
+import com.google.jetpackcamera.viewfinder.surface.CombinedSurfaceEvent
+import com.google.jetpackcamera.viewfinder.surface.SurfaceType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.flow.mapNotNull
@@ -45,7 +46,8 @@ fun CameraPreview(
     modifier: Modifier,
     implementationMode: ImplementationMode = ImplementationMode.COMPATIBLE,
     onSurfaceProviderReady: (SurfaceProvider) -> Unit = {},
-    onRequestBitmapReady: (() -> Bitmap?) -> Unit
+    onRequestBitmapReady: (() -> Bitmap?) -> Unit,
+    setSurfaceView: (View) -> Unit
 ) {
     Log.d(TAG, "CameraPreview")
 
@@ -58,6 +60,7 @@ fun CameraPreview(
 
     PreviewSurface(
         surfaceRequest = surfaceRequest,
+        setView = setSurfaceView
     )
 
 }
@@ -68,6 +71,7 @@ fun PreviewSurface(
 //    onRequestBitmapReady: (() -> Bitmap?) -> Unit,
     type: SurfaceType = SurfaceType.TEXTURE_VIEW,
     implementationMode: ImplementationMode = ImplementationMode.COMPATIBLE,
+    setView: (View) -> Unit
 ) {
     Log.d(TAG, "PreviewSurface")
 
@@ -89,6 +93,7 @@ fun PreviewSurface(
     when (implementationMode) {
         ImplementationMode.PERFORMANCE -> TODO()
         ImplementationMode.COMPATIBLE -> CombinedSurface(
+            setView = setView,
             onSurfaceEvent = { event ->
                 surface = when (event) {
                     is CombinedSurfaceEvent.SurfaceAvailable -> {

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/CombinedSurface.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/CombinedSurface.kt
@@ -19,6 +19,7 @@ package com.google.jetpackcamera.viewfinder.surface
 import android.graphics.Bitmap
 import android.util.Log
 import android.view.Surface
+import android.view.View
 import androidx.compose.runtime.Composable
 import com.google.jetpackcamera.viewfinder.surface.SurfaceType.*
 
@@ -29,6 +30,7 @@ fun CombinedSurface(
     onSurfaceEvent: (CombinedSurfaceEvent) -> Unit,
     onRequestBitmapReady: (() -> Bitmap?) -> Unit = {},
     type: SurfaceType = TEXTURE_VIEW,
+    setView: (View) -> Unit
 ) {
     Log.d(TAG, "PreviewTexture")
 
@@ -46,10 +48,12 @@ fun CombinedSurface(
                 is SurfaceHolderEvent.SurfaceChanged -> {
                     // TODO(yasith@)
                 }
+
             }
         }
 
         TEXTURE_VIEW -> Texture(
+
             {
                 when (it) {
                     is SurfaceTextureEvent.SurfaceTextureAvailable -> {
@@ -70,7 +74,8 @@ fun CombinedSurface(
                 }
                 true
             },
-            onRequestBitmapReady
+            onRequestBitmapReady,
+            setView = setView
         )
     }
 }

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Texture.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Texture.kt
@@ -93,7 +93,7 @@ fun Texture(
             }
         }, update = {
             textureView = it
-            setView(textureView!!)
+            setView(it)
             onRequestBitmapReady { -> it.bitmap }
         }
     )

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Texture.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Texture.kt
@@ -20,6 +20,7 @@ import android.graphics.Bitmap
 import android.graphics.SurfaceTexture
 import android.util.Log
 import android.view.TextureView
+import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.compose.runtime.Composable
@@ -34,8 +35,9 @@ private const val TAG = "Texture"
 @Composable
 fun Texture(
     onSurfaceTextureEvent: (SurfaceTextureEvent) -> Boolean = { _ -> true },
-    onRequestBitmapReady: (() -> Bitmap?) -> Unit
-) {
+    onRequestBitmapReady: (() -> Bitmap?) -> Unit,
+    setView: (View) -> Unit,
+    ) {
     Log.d(TAG, "Texture")
 
     var textureView: TextureView? by remember { mutableStateOf(null) }
@@ -91,9 +93,11 @@ fun Texture(
             }
         }, update = {
             textureView = it
+            setView(textureView!!)
             onRequestBitmapReady { -> it.bitmap }
         }
     )
+
 }
 
 sealed interface SurfaceTextureEvent {

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -16,6 +16,7 @@
 
 package com.google.jetpackcamera.domain.camera
 
+import android.view.Display
 import androidx.camera.core.Preview
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
@@ -54,7 +55,10 @@ interface CameraUseCase {
     fun setFlashMode(flashModeStatus: FlashModeStatus)
 
     suspend fun setAspectRatio(aspectRatio: AspectRatio, isFrontFacing: Boolean)
+
     suspend fun flipCamera(isFrontFacing: Boolean)
+
+    fun tapToFocus(display: Display, surfaceWidth: Int, surfaceHeight: Int, x: Float, y: Float)
 
     companion object {
         const val INVALID_ZOOM_SCALE = -1f

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -21,9 +21,12 @@ import android.content.ContentValues
 import android.provider.MediaStore
 import android.util.Log
 import android.util.Rational
+import android.view.Display
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.CameraSelector.LensFacing
+import androidx.camera.core.DisplayOrientedMeteringPointFactory
+import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.ImageProxy
@@ -184,6 +187,29 @@ class CameraXCameraUseCase @Inject constructor(
                 getLensFacing(isFrontFacing)
             )
         )
+    }
+
+    override fun tapToFocus(
+        display: Display,
+        surfaceWidth: Int,
+        surfaceHeight: Int,
+        x: Float,
+        y: Float
+    ) {
+        if (camera != null) {
+            val meteringPoint = DisplayOrientedMeteringPointFactory(
+                display,
+                camera!!.cameraInfo,
+                surfaceWidth.toFloat(),
+                surfaceHeight.toFloat()
+            )
+                .createPoint(x, y);
+
+            val action = FocusMeteringAction.Builder(meteringPoint).build()
+
+            camera!!.cameraControl.startFocusAndMetering(action)
+            Log.d(TAG, "Tap to focus on: $meteringPoint")
+        }
     }
 
     override fun setFlashMode(flashModeStatus: FlashModeStatus) {

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -16,6 +16,7 @@
 
 package com.google.jetpackcamera.domain.camera.test
 
+import android.view.Display
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import com.google.jetpackcamera.domain.camera.CameraUseCase
@@ -95,5 +96,15 @@ class FakeCameraUseCase : CameraUseCase {
 
     override suspend fun flipCamera(isFrontFacing: Boolean) {
         isLensFacingFront = isFrontFacing
+    }
+
+    override fun tapToFocus(
+        display: Display,
+        surfaceWidth: Int,
+        surfaceHeight: Int,
+        x: Float,
+        y: Float
+    ) {
+        TODO("Not yet implemented")
     }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -17,6 +17,7 @@
 package com.google.jetpackcamera.feature.preview
 
 import android.util.Log
+import android.view.Display
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview.SurfaceProvider
 import androidx.lifecycle.ViewModel
@@ -224,5 +225,15 @@ class PreviewViewModel @Inject constructor(
                 )
             )
         }
+    }
+
+    fun tapToFocus(display: Display, surfaceWidth: Int, surfaceHeight: Int, x: Float, y: Float) {
+        cameraUseCase.tapToFocus(
+            display = display,
+            surfaceWidth = surfaceWidth,
+            surfaceHeight = surfaceHeight,
+            x = x,
+            y = y
+        )
     }
 }


### PR DESCRIPTION
In the `PreviewScreen`, I created a value that keeps track of the View information from the CameraPreview composable. I just pass down a callback function from CameraPreview -> PreviewSurface -> CombinedSurface -> Texture to set that value.

When the screen is tapped, then the display, height, and width information of the view is provided to `PreviewViewModel`'s tapToFocus(), which is then provides that info to `cameraUseCase.tapToFocus` to create a metering point and action to focus.
