### PR TITLE
fix bug when navigating to preview from settings screen

### DIFF
--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -56,6 +56,9 @@ private fun JetpackCameraNavHost(
                 onNavigateToSettings = { navController.navigate(SettingsRoute) }
             )
         }
-        composable(SettingsRoute) { SettingsScreen(navController = navController) }
+        composable(SettingsRoute) {
+            SettingsScreen(onNavigateToPreview = { navController.navigate(PreviewRoute) }
+            )
+        }
     }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
 import com.google.jetpackcamera.settings.ui.DarkModeSetting
 import com.google.jetpackcamera.settings.ui.DefaultCameraFacing
 import com.google.jetpackcamera.settings.ui.FlashModeSetting
@@ -41,7 +40,7 @@ private const val TAG = "SettingsScreen"
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
-    navController: NavController) {
+    onNavigateToPreview: () -> Unit ) {
     val settingsUiState by viewModel.settingsUiState.collectAsState()
 
     Column(
@@ -50,9 +49,7 @@ fun SettingsScreen(
     ) {
         SettingsPageHeader(
             title = stringResource(id = R.string.settings_title),
-            navBack = {
-                navController.popBackStack()
-            }
+            navBack = onNavigateToPreview
         )
         SettingsList(uiState = settingsUiState, viewModel = viewModel)
     }


### PR DESCRIPTION
Fix crashing bug that occurs when attempting to navigate back to the preview screen _after_ using a quick setting that rebinds use cases