### PR TITLE
Refactor Preview UI

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -19,23 +19,13 @@ package com.google.jetpackcamera.feature.preview
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import android.view.View
 import androidx.camera.core.Preview.SurfaceProvider
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -59,18 +49,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import com.google.jetpackcamera.feature.preview.ui.CaptureButton
+import com.google.jetpackcamera.feature.preview.ui.FlipCameraButton
+import com.google.jetpackcamera.feature.preview.ui.PreviewDisplay
+import com.google.jetpackcamera.feature.preview.ui.SettingsNavButton
+import com.google.jetpackcamera.feature.preview.ui.ZoomScaleText
 import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreen
-import com.google.jetpackcamera.viewfinder.CameraPreview
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 
@@ -79,8 +69,6 @@ private const val TAG = "PreviewScreen"
 /**
  * Screen used for the Preview feature.
  */
-@OptIn(ExperimentalComposeUiApi::class)
-@ExperimentalMaterial3Api
 @Composable
 fun PreviewScreen(
     onNavigateToSettings: () -> Unit,
@@ -93,19 +81,19 @@ fun PreviewScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val deferredSurfaceProvider = remember { CompletableDeferred<SurfaceProvider>() }
-    val onSurfaceProviderReady: (SurfaceProvider) -> Unit = {
-        Log.d(TAG, "onSurfaceProviderReady")
-        deferredSurfaceProvider.complete(it)
-    }
-    lateinit var viewInfo: View
+
     var zoomScale by remember { mutableStateOf(1f) }
+
     var zoomScaleShow by remember { mutableStateOf(false) }
+
     val zoomHandler = Handler(Looper.getMainLooper())
-    val transformableState = rememberTransformableState(onTransformation = { zoomChange, _, _ ->
-        zoomScale = viewModel.setZoomScale(zoomChange)
-        zoomScaleShow = true
-        zoomHandler.postDelayed({ zoomScaleShow = false }, 3000)
-    })
+
+    val transformableState = rememberTransformableState(
+        onTransformation = { zoomChange, _, _ ->
+            zoomScale = viewModel.setZoomScale(zoomChange)
+            zoomScaleShow = true
+            zoomHandler.postDelayed({ zoomScaleShow = false }, 3000)
+        })
 
     LaunchedEffect(lifecycleOwner) {
         val surfaceProvider = deferredSurfaceProvider.await()
@@ -118,71 +106,22 @@ fun PreviewScreen(
             }
         }
     }
-
     if (previewUiState.cameraState == CameraState.NOT_READY) {
         Text(text = stringResource(R.string.camera_not_ready))
     } else if (previewUiState.cameraState == CameraState.READY) {
-        BoxWithConstraints(
-            Modifier
-                .background(Color.Black)
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onDoubleTap = { offset ->
-                            Log.d(TAG, "onDoubleTap $offset")
-                            viewModel.flipCamera()
-                        },
-                        onTap = { offset ->
-                            // tap to focus
-                            try {
-                                viewModel.tapToFocus(
-                                    viewInfo.display,
-                                    viewInfo.width,
-                                    viewInfo.height,
-                                    offset.x, offset.y
-                                )
-                                Log.d(TAG, "onTap $offset")
-                            } catch (e: UninitializedPropertyAccessException) {
-                                Log.d(TAG, "onTap $offset")
-                                e.printStackTrace()
-                            }
-                        }
-                    )
-                },
-
-            contentAlignment = Alignment.Center
+        // display camera feed. this stays behind everything else
+        PreviewDisplay(
+            viewModel = viewModel,
+            transformableState = transformableState,
+            previewUiState = previewUiState,
+            deferredSurfaceProvider = deferredSurfaceProvider
+        )
+        // overlay
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
         ) {
-            val maxAspectRatio: Float = maxWidth / maxHeight
-            val aspectRatio: Float =
-                previewUiState.currentCameraSettings.aspect_ratio.ratio.toFloat()
-            val shouldUseMaxWidth = maxAspectRatio <= aspectRatio
-            val width = if (shouldUseMaxWidth) maxWidth else maxHeight * aspectRatio
-            val height = if (!shouldUseMaxWidth) maxHeight else maxWidth / aspectRatio
-            Box(
-                modifier = Modifier
-                    .width(width)
-                    .height(height)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .transformable(state = transformableState)
-                ) {
-                    CameraPreview(
-                        modifier = Modifier
-                            .fillMaxSize(),
-                        onSurfaceProviderReady = onSurfaceProviderReady,
-                        onRequestBitmapReady = {
-                            val bitmap = it.invoke()
-                        },
-                        setSurfaceView = { s: View ->
-                            viewInfo = s
-                        }
-                    )
-                }
-            }
-
             QuickSettingsScreen(
-                modifier = Modifier.fillMaxSize(),
                 isOpen = previewUiState.quickSettingsIsOpen,
                 toggleIsOpen = { viewModel.toggleQuickSettings() },
                 currentCameraSettings = previewUiState.currentCameraSettings,
@@ -194,18 +133,12 @@ fun PreviewScreen(
                 //onTimerClick = {}/*TODO*/
             )
 
-            IconButton(
+            SettingsNavButton(
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .padding(12.dp),
-                onClick = onNavigateToSettings,
-            ) {
-                Icon(
-                    Icons.Filled.Settings,
-                    contentDescription = stringResource(R.string.settings_content_description),
-                    modifier = Modifier.size(72.dp)
-                )
-            }
+                onNavigateToSettings = onNavigateToSettings
+            )
 
                 SuggestionChip(
                     onClick = { viewModel.toggleCaptureMode() },
@@ -233,18 +166,26 @@ fun PreviewScreen(
                     zoomScale = zoomScale,
                     show = zoomScaleShow
                 )
+
                 Row(
-                    horizontalArrangement = Arrangement.SpaceAround
+                    modifier = Modifier
+                        .align(Alignment.End)
                 ) {
-                    Row {
-                        CaptureButton(
-                            onClick = { onImageCapture(viewModel) },
-                            onLongPress = { onStartRecording(viewModel) },
-                            onRelease = { onStopRecording(viewModel) },
-                            state = previewUiState.videoRecordingState
-                        )
-                    }
+                    FlipCameraButton(
+                        onClick = { viewModel.flipCamera() },
+                        //enable only when phone has front and rear camera
+                        enabledCondition =
+                        previewUiState.currentCameraSettings.back_camera_available
+                                && previewUiState.currentCameraSettings.front_camera_available
+                    )
+                    CaptureButton(
+                        onClick = { onImageCapture(viewModel) },
+                        onLongPress = { onStartRecording(viewModel) },
+                        onRelease = { onStopRecording(viewModel) },
+                        state = previewUiState.videoRecordingState
+                    )
                 }
+
             }
         }
     }
@@ -260,52 +201,4 @@ fun onStopRecording(viewModel: PreviewViewModel) {
 
 fun onImageCapture(viewModel: PreviewViewModel) {
     viewModel.captureImage()
-}
-
-@Composable
-fun ZoomScaleText(zoomScale: Float, show: Boolean) {
-    val contentAlpha = animateFloatAsState(
-        targetValue = if (show) 1f else 0f, label = "zoomScaleAlphaAnimation",
-        animationSpec = tween()
-    )
-    Text(
-        modifier = Modifier.alpha(contentAlpha.value),
-        text = String.format("%.1fx", zoomScale),
-        fontSize = 20.sp,
-        color = Color.White
-    )
-}
-
-@Composable
-fun CaptureButton(
-    onClick: () -> Unit,
-    onLongPress: () -> Unit,
-    onRelease: () -> Unit,
-    state: VideoRecordingState
-) {
-    Box(
-        modifier = Modifier
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onLongPress = {
-                        onLongPress()
-                    }, onPress = {
-                        awaitRelease()
-                        onRelease()
-                    }, onTap = { onClick() })
-            }
-            .size(120.dp)
-            .padding(18.dp)
-            .border(4.dp, Color.White, CircleShape)
-    ) {
-        Canvas(modifier = Modifier.size(110.dp), onDraw = {
-            drawCircle(
-                color =
-                when (state) {
-                    VideoRecordingState.INACTIVE -> Color.Transparent
-                    VideoRecordingState.ACTIVE -> Color.Red
-                }
-            )
-        })
-    }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -21,11 +21,15 @@ import android.os.Looper
 import android.util.Log
 import androidx.camera.core.Preview.SurfaceProvider
 import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -47,7 +51,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
@@ -122,6 +125,8 @@ fun PreviewScreen(
                 .fillMaxSize()
         ) {
             QuickSettingsScreen(
+                modifier = Modifier
+                    .align(Alignment.TopCenter),
                 isOpen = previewUiState.quickSettingsIsOpen,
                 toggleIsOpen = { viewModel.toggleQuickSettings() },
                 currentCameraSettings = previewUiState.currentCameraSettings,
@@ -167,25 +172,42 @@ fun PreviewScreen(
                     show = zoomScaleShow
                 )
 
+
                 Row(
-                    modifier = Modifier
-                        .align(Alignment.End)
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Min),
                 ) {
                     FlipCameraButton(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
                         onClick = { viewModel.flipCamera() },
                         //enable only when phone has front and rear camera
                         enabledCondition =
                         previewUiState.currentCameraSettings.back_camera_available
                                 && previewUiState.currentCameraSettings.front_camera_available
                     )
+                    /*todo: close quick settings on start record/image capture*/
                     CaptureButton(
+                        modifier = Modifier
+                            .fillMaxHeight(),
                         onClick = { onImageCapture(viewModel) },
                         onLongPress = { onStartRecording(viewModel) },
                         onRelease = { onStopRecording(viewModel) },
                         state = previewUiState.videoRecordingState
                     )
+                    /* spacer is a placeholder to maintain the proportionate location of this row of
+                     UI elements. if you want to  add another element, replace it with ONE element.
+                     If you want to add multiple components, use a container (Box, Row, Column, etc.)
+                    */
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .weight(1f)
+                    )
                 }
-
             }
         }
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -238,9 +238,9 @@ fun PreviewScreen(
                 ) {
                     Row {
                         CaptureButton(
-                            onClick = { viewModel.captureImage() },
-                            onLongPress = { viewModel.startVideoRecording() },
-                            onRelease = { viewModel.stopVideoRecording() },
+                            onClick = { onImageCapture(viewModel) },
+                            onLongPress = { onStartRecording(viewModel) },
+                            onRelease = { onStopRecording(viewModel) },
                             state = previewUiState.videoRecordingState
                         )
                     }
@@ -248,6 +248,18 @@ fun PreviewScreen(
             }
         }
     }
+}
+
+fun onStartRecording(viewModel: PreviewViewModel) {
+    viewModel.startVideoRecording()
+}
+
+fun onStopRecording(viewModel: PreviewViewModel) {
+    viewModel.stopVideoRecording()
+}
+
+fun onImageCapture(viewModel: PreviewViewModel) {
+    viewModel.captureImage()
 }
 
 @Composable

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -20,7 +20,6 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.camera.core.Preview.SurfaceProvider
-import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -82,12 +81,6 @@ fun PreviewScreen(
 
     val zoomHandler = Handler(Looper.getMainLooper())
 
-    val transformableState = rememberTransformableState(
-        onTransformation = { zoomChange, _, _ ->
-            zoomScale = viewModel.setZoomScale(zoomChange)
-            zoomScaleShow = true
-            zoomHandler.postDelayed({ zoomScaleShow = false }, ZOOM_SCALE_SHOW_TIMEOUT_MS)
-        })
 
     LaunchedEffect(lifecycleOwner) {
         val surfaceProvider = deferredSurfaceProvider.await()
@@ -107,8 +100,12 @@ fun PreviewScreen(
         PreviewDisplay(
             onFlipCamera = viewModel::flipCamera,
             onTapToFocus = viewModel::tapToFocus,
-            transformableState = transformableState,
-            previewUiState = previewUiState,
+            onZoomChange = { zoomChange: Float ->
+                viewModel.setZoomScale(zoomChange)
+                zoomScaleShow = true
+                zoomHandler.postDelayed({ zoomScaleShow = false }, ZOOM_SCALE_SHOW_TIMEOUT_MS)
+            },
+            aspectRatio = previewUiState.currentCameraSettings.aspect_ratio,
             deferredSurfaceProvider = deferredSurfaceProvider
         )
         // overlay
@@ -184,7 +181,7 @@ fun PreviewScreen(
                         onClick = { viewModel.captureImage() },
                         onLongPress = { viewModel.startVideoRecording() },
                         onRelease = { viewModel.stopVideoRecording() },
-                        state = previewUiState.videoRecordingState
+                        videoRecordingState = previewUiState.videoRecordingState
                     )
                     /* spacer is a placeholder to maintain the proportionate location of this row of
                      UI elements. if you want to  add another element, replace it with ONE element.

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -31,16 +31,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Button
-import androidx.compose.material3.ChipColors
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -147,23 +137,23 @@ fun PreviewScreen(
                 onNavigateToSettings = onNavigateToSettings
             )
 
-                SuggestionChip(
-                    onClick = { viewModel.toggleCaptureMode() },
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(12.dp),
-                    label = {
-                        Text(
-                            stringResource(
-                                if (previewUiState.singleStreamCapture) {
-                                    R.string.capture_mode_single_stream
-                                } else {
-                                    R.string.capture_mode_multi_stream
-                                }
-                            )
+            SuggestionChip(
+                onClick = { viewModel.toggleCaptureMode() },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(12.dp),
+                label = {
+                    Text(
+                        stringResource(
+                            if (previewUiState.singleStreamCapture) {
+                                R.string.capture_mode_single_stream
+                            } else {
+                                R.string.capture_mode_multi_stream
+                            }
                         )
-                    }
-                )
+                    )
+                }
+            )
 
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -191,9 +181,9 @@ fun PreviewScreen(
                     )
                     /*todo: close quick settings on start record/image capture*/
                     CaptureButton(
-                        onClick = { onImageCapture(viewModel) },
-                        onLongPress = { onStartRecording(viewModel) },
-                        onRelease = { onStopRecording(viewModel) },
+                        onClick = { viewModel.captureImage() },
+                        onLongPress = { viewModel.startVideoRecording() },
+                        onRelease = { viewModel.stopVideoRecording() },
                         state = previewUiState.videoRecordingState
                     )
                     /* spacer is a placeholder to maintain the proportionate location of this row of
@@ -209,16 +199,4 @@ fun PreviewScreen(
             }
         }
     }
-}
-
-fun onStartRecording(viewModel: PreviewViewModel) {
-    viewModel.startVideoRecording()
-}
-
-fun onStopRecording(viewModel: PreviewViewModel) {
-    viewModel.stopVideoRecording()
-}
-
-fun onImageCapture(viewModel: PreviewViewModel) {
-    viewModel.captureImage()
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -25,8 +25,8 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.TransformableState
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -52,9 +52,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.jetpackcamera.feature.preview.PreviewUiState
 import com.google.jetpackcamera.feature.preview.R
 import com.google.jetpackcamera.feature.preview.VideoRecordingState
+import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.viewfinder.CameraPreview
 import kotlinx.coroutines.CompletableDeferred
 
@@ -66,11 +66,16 @@ private const val TAG = "PreviewScreen"
 fun PreviewDisplay(
     onTapToFocus: (Display, Int, Int, Float, Float) -> Unit,
     onFlipCamera: () -> Unit,
-
-    transformableState: TransformableState,
-    previewUiState: PreviewUiState,
+    onZoomChange: (Float) -> Unit,
+    aspectRatio: AspectRatio,
     deferredSurfaceProvider: CompletableDeferred<Preview.SurfaceProvider>
 ) {
+
+    val transformableState = rememberTransformableState(
+        onTransformation = { zoomChange, _, _ ->
+            onZoomChange(zoomChange)
+
+        })
     val onSurfaceProviderReady: (Preview.SurfaceProvider) -> Unit = {
         Log.d(TAG, "onSurfaceProviderReady")
         deferredSurfaceProvider.complete(it)
@@ -109,8 +114,7 @@ fun PreviewDisplay(
         contentAlignment = Alignment.Center
     ) {
         val maxAspectRatio: Float = maxWidth / maxHeight
-        val aspectRatio: Float =
-            previewUiState.currentCameraSettings.aspect_ratio.ratio.toFloat()
+        val aspectRatio: Float = aspectRatio.ratio.toFloat()
         val shouldUseMaxWidth = maxAspectRatio <= aspectRatio
         val width = if (shouldUseMaxWidth) maxWidth else maxHeight * aspectRatio
         val height = if (!shouldUseMaxWidth) maxHeight else maxWidth / aspectRatio
@@ -196,7 +200,7 @@ fun CaptureButton(
     onClick: () -> Unit,
     onLongPress: () -> Unit,
     onRelease: () -> Unit,
-    state: VideoRecordingState
+    videoRecordingState: VideoRecordingState
 ) {
     Box(
         modifier = modifier
@@ -217,7 +221,7 @@ fun CaptureButton(
         Canvas(modifier = Modifier.size(110.dp), onDraw = {
             drawCircle(
                 color =
-                when (state) {
+                when (videoRecordingState) {
                     VideoRecordingState.INACTIVE -> Color.Transparent
                     VideoRecordingState.ACTIVE -> Color.Red
                 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -133,13 +133,26 @@ fun PreviewDisplay(
 }
 
 @Composable
-fun FlipCameraButton(enabledCondition: Boolean, onClick: () -> Unit) {
-    IconButton(onClick = onClick, enabled = enabledCondition) {
-        Icon(
-            Icons.Filled.Refresh,
-            contentDescription = "Flip Camera",
-            modifier = Modifier.size(72.dp)
-        )
+fun FlipCameraButton(
+    modifier: Modifier = Modifier,
+    enabledCondition: Boolean,
+    onClick: () -> Unit
+) {
+    Box(modifier = modifier) {
+        IconButton(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(40.dp),
+            onClick = onClick,
+            enabled = enabledCondition
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Refresh,
+                tint = Color.White,
+                contentDescription = stringResource(id = R.string.flip_camera_content_description),
+                modifier = Modifier.size(72.dp)
+            )
+        }
     }
 }
 
@@ -175,13 +188,14 @@ fun ZoomScaleText(zoomScale: Float, show: Boolean) {
 
 @Composable
 fun CaptureButton(
+    modifier: Modifier = Modifier,
     onClick: () -> Unit,
     onLongPress: () -> Unit,
     onRelease: () -> Unit,
     state: VideoRecordingState
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .pointerInput(Unit) {
                 detectTapGestures(
                     onLongPress = {
@@ -193,7 +207,9 @@ fun CaptureButton(
             }
             .size(120.dp)
             .padding(18.dp)
-            .border(4.dp, Color.White, CircleShape)
+            .border(4.dp, Color.White, CircleShape),
+        // verticalArrangement = Arrangement.Bottom,
+        // horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Canvas(modifier = Modifier.size(110.dp), onDraw = {
             drawCircle(

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -169,7 +169,6 @@ fun SettingsNavButton(modifier: Modifier, onNavigateToSettings: () -> Unit) {
             modifier = Modifier.size(72.dp)
         )
     }
-
 }
 
 @Composable

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera.feature.preview.ui
+
+import android.util.Log
+import android.view.View
+import androidx.camera.core.Preview
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.TransformableState
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.jetpackcamera.feature.preview.PreviewUiState
+import com.google.jetpackcamera.feature.preview.PreviewViewModel
+import com.google.jetpackcamera.feature.preview.R
+import com.google.jetpackcamera.feature.preview.VideoRecordingState
+import com.google.jetpackcamera.viewfinder.CameraPreview
+import kotlinx.coroutines.CompletableDeferred
+
+private const val TAG = "PreviewScreen"
+
+// this is the preview surface display. It implements tap to focus, tap to zoom, and the
+@Composable
+fun PreviewDisplay(
+    viewModel: PreviewViewModel,
+    transformableState: TransformableState,
+    previewUiState: PreviewUiState,
+    deferredSurfaceProvider: CompletableDeferred<Preview.SurfaceProvider>
+) {
+    val onSurfaceProviderReady: (Preview.SurfaceProvider) -> Unit = {
+        Log.d(TAG, "onSurfaceProviderReady")
+        deferredSurfaceProvider.complete(it)
+    }
+    lateinit var viewInfo: View
+
+    BoxWithConstraints(
+        Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onDoubleTap = { offset ->
+                        // double tap to flip camera
+                        Log.d(TAG, "onDoubleTap $offset")
+                        viewModel.flipCamera()
+                    },
+                    onTap = { offset ->
+                        // tap to focus
+                        try {
+                            viewModel.tapToFocus(
+                                viewInfo.display,
+                                viewInfo.width,
+                                viewInfo.height,
+                                offset.x, offset.y
+                            )
+                            Log.d(TAG, "onTap $offset")
+                        } catch (e: UninitializedPropertyAccessException) {
+                            Log.d(TAG, "onTap $offset")
+                            e.printStackTrace()
+                        }
+                    }
+                )
+            },
+
+        contentAlignment = Alignment.Center
+    ) {
+        val maxAspectRatio: Float = maxWidth / maxHeight
+        val aspectRatio: Float =
+            previewUiState.currentCameraSettings.aspect_ratio.ratio.toFloat()
+        val shouldUseMaxWidth = maxAspectRatio <= aspectRatio
+        val width = if (shouldUseMaxWidth) maxWidth else maxHeight * aspectRatio
+        val height = if (!shouldUseMaxWidth) maxHeight else maxWidth / aspectRatio
+        Box(
+            modifier = Modifier
+                .width(width)
+                .height(height)
+                .transformable(state = transformableState)
+
+        ) {
+            CameraPreview(
+                modifier = Modifier
+                    .fillMaxSize(),
+                onSurfaceProviderReady = onSurfaceProviderReady,
+                onRequestBitmapReady = {
+                    val bitmap = it.invoke()
+                },
+                setSurfaceView = { s: View ->
+                    viewInfo = s
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun FlipCameraButton(enabledCondition: Boolean, onClick: () -> Unit) {
+    IconButton(onClick = onClick, enabled = enabledCondition) {
+        Icon(
+            Icons.Filled.Refresh,
+            contentDescription = "Flip Camera",
+            modifier = Modifier.size(72.dp)
+        )
+    }
+}
+
+@Composable
+fun SettingsNavButton(modifier: Modifier, onNavigateToSettings: () -> Unit) {
+    IconButton(
+        modifier = modifier,
+        onClick = onNavigateToSettings,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Settings,
+            tint = Color.White,
+            contentDescription = stringResource(R.string.settings_content_description),
+            modifier = Modifier.size(72.dp)
+        )
+    }
+
+}
+
+@Composable
+fun ZoomScaleText(zoomScale: Float, show: Boolean) {
+    val contentAlpha = animateFloatAsState(
+        targetValue = if (show) 1f else 0f, label = "zoomScaleAlphaAnimation",
+        animationSpec = tween()
+    )
+    Text(
+        modifier = Modifier.alpha(contentAlpha.value),
+        text = String.format("%.1fx", zoomScale),
+        fontSize = 20.sp,
+        color = Color.White
+    )
+}
+
+@Composable
+fun CaptureButton(
+    onClick: () -> Unit,
+    onLongPress: () -> Unit,
+    onRelease: () -> Unit,
+    state: VideoRecordingState
+) {
+    Box(
+        modifier = Modifier
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onLongPress = {
+                        onLongPress()
+                    }, onPress = {
+                        awaitRelease()
+                        onRelease()
+                    }, onTap = { onClick() })
+            }
+            .size(120.dp)
+            .padding(18.dp)
+            .border(4.dp, Color.White, CircleShape)
+    ) {
+        Canvas(modifier = Modifier.size(110.dp), onDraw = {
+            drawCircle(
+                color =
+                when (state) {
+                    VideoRecordingState.INACTIVE -> Color.Transparent
+                    VideoRecordingState.ACTIVE -> Color.Red
+                }
+            )
+        })
+    }
+}

--- a/feature/preview/src/main/res/values/strings.xml
+++ b/feature/preview/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="settings_content_description">Settings</string>
     <string name="capture_mode_single_stream">Single Stream</string>
     <string name="capture_mode_multi_stream">Multi Stream</string>
+    <string name="flip_camera_content_description">Flip Camera</string>
 </resources>

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -108,7 +108,8 @@ fun QuickSettingsScreen(
     DropDownIcon(
         modifier = modifier,
         toggleDropDown = toggleIsOpen,
-        isOpen = isOpen)
+        isOpen = isOpen
+    )
 }
 
 // enum representing which individual quick setting is currently expanded
@@ -170,6 +171,5 @@ private fun ExpandedQuickSettingsUi(
                 )
             }
         }
-        //Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.quick_settings_spacer_height)))
     }
 }

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -78,12 +78,11 @@ fun QuickSettingsScreen(
 
     Column(
         modifier = modifier
-            .fillMaxSize()
             .background(color = backgroundColor.value),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        DropDownIcon(toggleIsOpen, isOpen = isOpen)
+        DropDownIcon(toggleDropDown = toggleIsOpen, isOpen = isOpen)
 
         if (isOpen) {
             Column(
@@ -91,7 +90,7 @@ fun QuickSettingsScreen(
                     .fillMaxSize()
                     .alpha(alpha = contentAlpha.value)
                     .clickable {
-                        // if a setting is expanded, close it. if no other settings are expanded, then close out of the popup
+                        // if a setting is expanded, click on the background to close it. if no other settings are expanded, then close the popup
                         if (shouldShowQuickSetting == IsExpandedQuickSetting.NONE) toggleIsOpen() else shouldShowQuickSetting =
                             IsExpandedQuickSetting.NONE
                     },
@@ -107,7 +106,6 @@ fun QuickSettingsScreen(
                     onLensFaceClick = onLensFaceClick,
                     onFlashModeClick = onFlashModeClick,
                     onAspectRatioClick = onAspectRatioClick,
-                    //onTimerClick = onTimerClick,
                 )
             }
         } else {
@@ -137,7 +135,6 @@ private fun ExpandedQuickSettingsUi(
 
     Column(
         modifier = Modifier
-            .fillMaxWidth()
             .padding(horizontal = dimensionResource(id = R.dimen.quick_settings_ui_horizontal_padding))
     ) {
         // if no setting is chosen, display the grid of settings

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -23,10 +23,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -76,42 +73,42 @@ fun QuickSettingsScreen(
         animationSpec = tween()
     )
 
-    Column(
-        modifier = modifier
-            .background(color = backgroundColor.value),
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        DropDownIcon(toggleDropDown = toggleIsOpen, isOpen = isOpen)
-
-        if (isOpen) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .alpha(alpha = contentAlpha.value)
-                    .clickable {
-                        // if a setting is expanded, click on the background to close it. if no other settings are expanded, then close the popup
-                        if (shouldShowQuickSetting == IsExpandedQuickSetting.NONE) toggleIsOpen() else shouldShowQuickSetting =
-                            IsExpandedQuickSetting.NONE
-                    },
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                ExpandedQuickSettingsUi(
-                    currentCameraSettings = currentCameraSettings,
-                    shouldShowQuickSetting = shouldShowQuickSetting,
-                    setVisibleQuickSetting = { enum: IsExpandedQuickSetting ->
-                        shouldShowQuickSetting = enum
-                    },
-                    onLensFaceClick = onLensFaceClick,
-                    onFlashModeClick = onFlashModeClick,
-                    onAspectRatioClick = onAspectRatioClick,
-                )
-            }
-        } else {
-            shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+    if (isOpen) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = backgroundColor.value)
+                .alpha(alpha = contentAlpha.value)
+                .clickable {
+                    // if a setting is expanded, click on the background to close it.
+                    // if no other settings are expanded, then close the popup
+                    if (shouldShowQuickSetting == IsExpandedQuickSetting.NONE)
+                        toggleIsOpen()
+                    else
+                        shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+                },
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            ExpandedQuickSettingsUi(
+                currentCameraSettings = currentCameraSettings,
+                shouldShowQuickSetting = shouldShowQuickSetting,
+                setVisibleQuickSetting = { enum: IsExpandedQuickSetting ->
+                    shouldShowQuickSetting = enum
+                },
+                onLensFaceClick = onLensFaceClick,
+                onFlashModeClick = onFlashModeClick,
+                onAspectRatioClick = onAspectRatioClick,
+            )
         }
+    } else {
+        shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+
     }
+    DropDownIcon(
+        modifier = modifier,
+        toggleDropDown = toggleIsOpen,
+        isOpen = isOpen)
 }
 
 // enum representing which individual quick setting is currently expanded
@@ -173,6 +170,6 @@ private fun ExpandedQuickSettingsUi(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.quick_settings_spacer_height)))
+        //Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.quick_settings_spacer_height)))
     }
 }

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -82,10 +82,10 @@ fun QuickSettingsScreen(
                 .clickable {
                     // if a setting is expanded, click on the background to close it.
                     // if no other settings are expanded, then close the popup
-                    if (shouldShowQuickSetting == IsExpandedQuickSetting.NONE)
-                        toggleIsOpen()
-                    else
-                        shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+                    when (shouldShowQuickSetting) {
+                        IsExpandedQuickSetting.NONE -> toggleIsOpen()
+                        else -> shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+                    }
                 },
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -24,12 +24,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -53,7 +51,6 @@ import kotlin.math.min
 
 // completed components ready to go into preview screen
 
-//TODO: Implement Set Ratio
 @Composable
 fun ExpandedQuickSetRatio(
     setRatio: (aspectRatio: AspectRatio) -> Unit,
@@ -88,7 +85,6 @@ fun ExpandedQuickSetRatio(
     ExpandedQuickSetting(quickSettingButtons = buttons)
 }
 
-//TODO: Implement Set Ratio
 @Composable
 fun QuickSetRatio(
     onClick: () -> Unit,
@@ -143,11 +139,9 @@ fun QuickFlipCamera(flipCamera: (Boolean) -> Unit, currentFacingFront: Boolean) 
 }
 
 @Composable
-fun DropDownIcon(toggleDropDown: () -> Unit, isOpen: Boolean) {
+fun DropDownIcon(modifier: Modifier = Modifier, toggleDropDown: () -> Unit, isOpen: Boolean) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .wrapContentHeight(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -87,6 +87,7 @@ fun ExpandedQuickSetRatio(
 
 @Composable
 fun QuickSetRatio(
+    modifier: Modifier = Modifier,
     onClick: () -> Unit,
     ratio: AspectRatio,
     currentRatio: AspectRatio,
@@ -99,6 +100,7 @@ fun QuickSetRatio(
         else -> CameraAspectRatio.ONE_ONE
     }
     QuickSettingUiItem(
+        modifier = modifier,
         enum = enum,
         onClick = { onClick() },
         isHighLighted = isHighlightEnabled && (ratio == currentRatio)
@@ -106,13 +108,17 @@ fun QuickSetRatio(
 }
 
 @Composable
-fun QuickSetFlash(onClick: (FlashModeStatus) -> Unit, currentFlashMode: FlashModeStatus) {
+fun QuickSetFlash(
+    modifier: Modifier = Modifier,
+    onClick: (FlashModeStatus) -> Unit, currentFlashMode: FlashModeStatus
+) {
     val enum = when (currentFlashMode) {
         FlashModeStatus.OFF -> CameraFlashMode.OFF
         FlashModeStatus.AUTO -> CameraFlashMode.AUTO
         FlashModeStatus.ON -> CameraFlashMode.ON
     }
     QuickSettingUiItem(
+        modifier = modifier,
         enum = enum,
         isHighLighted = currentFlashMode == FlashModeStatus.ON,
         onClick =
@@ -127,19 +133,28 @@ fun QuickSetFlash(onClick: (FlashModeStatus) -> Unit, currentFlashMode: FlashMod
 }
 
 @Composable
-fun QuickFlipCamera(flipCamera: (Boolean) -> Unit, currentFacingFront: Boolean) {
+fun QuickFlipCamera(
+    modifier: Modifier = Modifier,
+    flipCamera: (Boolean) -> Unit,
+    currentFacingFront: Boolean
+) {
     val enum = when (currentFacingFront) {
         true -> CameraLensFace.FRONT
         false -> CameraLensFace.BACK
     }
     QuickSettingUiItem(
+        modifier = modifier,
         enum = enum,
         onClick = { flipCamera(!currentFacingFront) }
     )
 }
 
 @Composable
-fun DropDownIcon(modifier: Modifier = Modifier, toggleDropDown: () -> Unit, isOpen: Boolean) {
+fun DropDownIcon(
+    modifier: Modifier = Modifier,
+    toggleDropDown: () -> Unit,
+    isOpen: Boolean
+) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.Center,
@@ -164,11 +179,13 @@ fun DropDownIcon(modifier: Modifier = Modifier, toggleDropDown: () -> Unit, isOp
 
 @Composable
 fun QuickSettingUiItem(
+    modifier: Modifier = Modifier,
     enum: QuickSettingsEnum,
     onClick: () -> Unit,
     isHighLighted: Boolean = false
 ) {
     QuickSettingUiItem(
+        modifier = modifier,
         drawableResId = enum.getDrawableResId(),
         text = stringResource(id = enum.getTextResId()),
         accessibilityText = stringResource(id = enum.getDescriptionResId()),
@@ -182,6 +199,7 @@ fun QuickSettingUiItem(
  */
 @Composable
 fun QuickSettingUiItem(
+    modifier: Modifier = Modifier,
     @DrawableRes drawableResId: Int,
     text: String,
     accessibilityText: String,
@@ -189,7 +207,7 @@ fun QuickSettingUiItem(
     isHighLighted: Boolean = false
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .wrapContentSize()
             .padding(dimensionResource(id = R.dimen.quick_settings_ui_item_padding))
             .clickable {
@@ -215,7 +233,10 @@ fun QuickSettingUiItem(
  * Should you want to have an expanded view of a single quick setting
  */
 @Composable
-fun ExpandedQuickSetting(vararg quickSettingButtons: @Composable () -> Unit) {
+fun ExpandedQuickSetting(
+    modifier: Modifier = Modifier,
+    vararg quickSettingButtons: @Composable () -> Unit
+) {
     val expandedNumOfColumns =
         min(
             quickSettingButtons.size,
@@ -226,7 +247,7 @@ fun ExpandedQuickSetting(vararg quickSettingButtons: @Composable () -> Unit) {
                             (dimensionResource(id = R.dimen.quick_settings_ui_item_padding) * 2))).toInt()
         )
     LazyVerticalGrid(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         columns = GridCells.Fixed(count = expandedNumOfColumns)
     ) {
         items(quickSettingButtons.size) { i ->
@@ -239,7 +260,10 @@ fun ExpandedQuickSetting(vararg quickSettingButtons: @Composable () -> Unit) {
  * Algorithm to determine dimensions of QuickSettings Icon layout
  */
 @Composable
-fun QuickSettingsGrid(vararg quickSettingsButtons: @Composable () -> Unit) {
+fun QuickSettingsGrid(
+    modifier: Modifier = Modifier,
+    vararg quickSettingsButtons: @Composable () -> Unit
+) {
     val initialNumOfColumns =
         min(
             quickSettingsButtons.size,
@@ -251,7 +275,7 @@ fun QuickSettingsGrid(vararg quickSettingsButtons: @Composable () -> Unit) {
         )
 
     LazyVerticalGrid(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         columns = GridCells.Fixed(count = initialNumOfColumns)
     ) {
         items(quickSettingsButtons.size) { i ->

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -155,7 +155,7 @@ fun DropDownIcon(toggleDropDown: () -> Unit, isOpen: Boolean) {
         Icon(
             painter = painterResource(R.drawable.baseline_expand_more_72),
             contentDescription = stringResource(R.string.quick_settings_dropdown_description),
-            tint = if (isOpen) Color.White else LocalContentColor.current,
+            tint = Color.White,
             modifier = Modifier
                 .size(72.dp)
                 .clickable {

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -58,21 +58,22 @@ fun SettingsScreen(
 
 @Composable
 fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
-    SectionHeader(title = stringResource(id = R.string.section_title_camera_settings))
+        SectionHeader(title = stringResource(id = R.string.section_title_camera_settings))
 
-    DefaultCameraFacing(
-        cameraAppSettings = uiState.cameraAppSettings,
-        onClick = viewModel::setDefaultToFrontCamera
-    )
+        DefaultCameraFacing(
+            cameraAppSettings = uiState.cameraAppSettings,
+            onClick = viewModel::setDefaultToFrontCamera
+        )
 
-    FlashModeSetting(
-        currentFlashMode = uiState.cameraAppSettings.flash_mode_status,
-        setFlashMode = viewModel::setFlashMode
-    )
+        FlashModeSetting(
+            currentFlashMode = uiState.cameraAppSettings.flash_mode_status,
+            setFlashMode = viewModel::setFlashMode
+        )
 
-    SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
-    DarkModeSetting(
-        currentDarkModeStatus = uiState.cameraAppSettings.dark_mode_status,
-        setDarkMode = viewModel::setDarkMode
-    )
+        SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
+
+        DarkModeSetting(
+            currentDarkModeStatus = uiState.cameraAppSettings.dark_mode_status,
+            setDarkMode = viewModel::setDarkMode
+        )
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -60,9 +60,13 @@ import com.google.jetpackcamera.settings.model.FlashModeStatus
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsPageHeader(title: String, navBack: () -> Unit) {
+fun SettingsPageHeader(
+    modifier: Modifier = Modifier,
+    title: String,
+    navBack: () -> Unit
+) {
     TopAppBar(
-        modifier = Modifier,
+        modifier = modifier,
         title = {
             Text(title)
         },
@@ -75,11 +79,14 @@ fun SettingsPageHeader(title: String, navBack: () -> Unit) {
 }
 
 @Composable
-fun SectionHeader(title: String) {
+fun SectionHeader(
+    modifier: Modifier = Modifier,
+    title: String
+) {
     Text(
-        text = title,
-        modifier = Modifier
+        modifier = modifier
             .padding(start = 20.dp, top = 10.dp),
+        text = title,
         color = MaterialTheme.colorScheme.primary,
         fontSize = 18.sp
     )
@@ -87,10 +94,12 @@ fun SectionHeader(title: String) {
 
 @Composable
 fun DefaultCameraFacing(
+    modifier: Modifier = Modifier,
     cameraAppSettings: CameraAppSettings,
     onClick: () -> Unit
 ) {
     SwitchSettingUI(
+        modifier = modifier,
         title = stringResource(id = R.string.default_facing_camera_title),
         description = null,
         leadingIcon = null,
@@ -102,10 +111,12 @@ fun DefaultCameraFacing(
 
 @Composable
 fun DarkModeSetting(
+    modifier: Modifier = Modifier,
     currentDarkModeStatus: DarkModeStatus,
     setDarkMode: (DarkModeStatus) -> Unit
 ) {
     BasicPopupSetting(
+        modifier = modifier,
         title = stringResource(id = R.string.dark_mode_title),
         leadingIcon = null,
         description = when (currentDarkModeStatus) {
@@ -275,13 +286,14 @@ fun SettingUI(
  */
 @Composable
 fun SingleChoiceSelector(
+    modifier: Modifier = Modifier,
     text: String,
     selected: Boolean,
     onClick: () -> Unit,
     enabled: Boolean = true
 ) {
     Row(
-        Modifier
+        modifier
             .fillMaxWidth()
             .selectable(
                 selected = selected,

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -86,7 +86,10 @@ fun SectionHeader(title: String) {
 }
 
 @Composable
-fun DefaultCameraFacing(cameraAppSettings: CameraAppSettings, onClick: () -> Unit) {
+fun DefaultCameraFacing(
+    cameraAppSettings: CameraAppSettings,
+    onClick: () -> Unit
+) {
     SwitchSettingUI(
         title = stringResource(id = R.string.default_facing_camera_title),
         description = null,
@@ -98,7 +101,10 @@ fun DefaultCameraFacing(cameraAppSettings: CameraAppSettings, onClick: () -> Uni
 }
 
 @Composable
-fun DarkModeSetting(currentDarkModeStatus: DarkModeStatus, setDarkMode: (DarkModeStatus) -> Unit) {
+fun DarkModeSetting(
+    currentDarkModeStatus: DarkModeStatus,
+    setDarkMode: (DarkModeStatus) -> Unit
+) {
     BasicPopupSetting(
         title = stringResource(id = R.string.dark_mode_title),
         leadingIcon = null,
@@ -127,8 +133,13 @@ fun DarkModeSetting(currentDarkModeStatus: DarkModeStatus, setDarkMode: (DarkMod
 }
 
 @Composable
-fun FlashModeSetting(currentFlashMode: FlashModeStatus, setFlashMode: (FlashModeStatus) -> Unit) {
+fun FlashModeSetting(
+    modifier: Modifier = Modifier,
+    currentFlashMode: FlashModeStatus,
+    setFlashMode: (FlashModeStatus) -> Unit
+) {
     BasicPopupSetting(
+        modifier = modifier,
         title = stringResource(id = R.string.flash_mode_title),
         leadingIcon = null,
         description = when (currentFlashMode) {
@@ -165,18 +176,19 @@ fun FlashModeSetting(currentFlashMode: FlashModeStatus, setFlashMode: (FlashMode
 
 @Composable
 fun BasicPopupSetting(
+    modifier: Modifier = Modifier,
     title: String,
     description: String?,
+    enabled: Boolean = true,
     leadingIcon: @Composable (() -> Unit)?,
     popupContents: @Composable () -> Unit
 ) {
     val popupStatus = remember { mutableStateOf(false) }
     SettingUI(
-        modifier = Modifier.clickable() { popupStatus.value = true },
+        modifier = modifier.clickable(enabled = enabled) { popupStatus.value = true },
         title = title,
         description = description,
         leadingIcon = leadingIcon,
-        //onClick = { popupStatus.value = true },
         trailingContent = null
     )
     if (popupStatus.value) {
@@ -201,6 +213,7 @@ fun BasicPopupSetting(
  */
 @Composable
 fun SwitchSettingUI(
+    modifier: Modifier = Modifier,
     title: String,
     description: String?,
     leadingIcon: @Composable (() -> Unit)?,
@@ -209,19 +222,17 @@ fun SwitchSettingUI(
     enabled: Boolean
 ) {
     SettingUI(
-        modifier = Modifier.toggleable(
+        modifier = modifier.toggleable(
+            enabled = enabled,
             role = Role.Switch,
             value = settingValue,
             onValueChange = { _ -> onClick() }
         ),
-        //enabled = enabled,
         title = title,
         description = description,
         leadingIcon = leadingIcon,
-        //onClick = onClick,
         trailingContent = {
             Switch(
-                //modifier = Modifier,
                 enabled = enabled,
                 checked = settingValue,
                 onCheckedChange = {
@@ -243,11 +254,10 @@ fun SettingUI(
     description: String? = null,
     leadingIcon: @Composable (() -> Unit)?,
     trailingContent: @Composable (() -> Unit)?,
-    //onClick: () -> Unit,
-    //enabled: Boolean = true
-) {
+
+    ) {
     ListItem(
-        modifier = modifier, //Modifier.clickable(enabled = enabled) { onClick() },
+        modifier = modifier,
         headlineText = { Text(title) },
         supportingText = when (description) {
             null -> null

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -17,7 +17,6 @@
 package com.google.jetpackcamera.settings.ui
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,6 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -33,6 +33,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -79,6 +80,7 @@ fun SectionHeader(title: String) {
         text = title,
         modifier = Modifier
             .padding(start = 20.dp, top = 10.dp),
+        color = MaterialTheme.colorScheme.primary,
         fontSize = 18.sp
     )
 }
@@ -170,10 +172,11 @@ fun BasicPopupSetting(
 ) {
     val popupStatus = remember { mutableStateOf(false) }
     SettingUI(
+        modifier = Modifier.clickable() { popupStatus.value = true },
         title = title,
         description = description,
         leadingIcon = leadingIcon,
-        onClick = { popupStatus.value = true },
+        //onClick = { popupStatus.value = true },
         trailingContent = null
     )
     if (popupStatus.value) {
@@ -206,13 +209,25 @@ fun SwitchSettingUI(
     enabled: Boolean
 ) {
     SettingUI(
-        enabled = enabled,
+        modifier = Modifier.toggleable(
+            role = Role.Switch,
+            value = settingValue,
+            onValueChange = { _ -> onClick() }
+        ),
+        //enabled = enabled,
         title = title,
         description = description,
         leadingIcon = leadingIcon,
-        onClick = onClick,
+        //onClick = onClick,
         trailingContent = {
-            SettingSwitch(settingValue, onClick, enabled)
+            Switch(
+                //modifier = Modifier,
+                enabled = enabled,
+                checked = settingValue,
+                onCheckedChange = {
+                    onClick()
+                }
+            )
         }
     )
 }
@@ -223,43 +238,25 @@ fun SwitchSettingUI(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingUI(
+    modifier: Modifier = Modifier,
     title: String,
     description: String? = null,
     leadingIcon: @Composable (() -> Unit)?,
     trailingContent: @Composable (() -> Unit)?,
-    onClick: () -> Unit,
-    enabled: Boolean = true
+    //onClick: () -> Unit,
+    //enabled: Boolean = true
 ) {
-    Box(modifier = Modifier) {
-        ListItem(
-            modifier = Modifier.clickable(enabled = enabled) { onClick() },
-            headlineText = { Text(title) },
-            supportingText = {
-                when (description) {
-                    null -> {}
-                    else -> {
-                        Text(description)
-                    }
-                }
-            },
-            leadingContent = leadingIcon,
-            trailingContent = trailingContent
-        )
-    }
-}
-
-/**
- * A component for a switch
- */
-@Composable
-fun SettingSwitch(settingValue: Boolean, onClick: () -> Unit, enabled: Boolean = true) {
-    Switch(
-        modifier = Modifier,
-        enabled = enabled,
-        checked = settingValue,
-        onCheckedChange = {
-            onClick()
-        }
+    ListItem(
+        modifier = modifier, //Modifier.clickable(enabled = enabled) { onClick() },
+        headlineText = { Text(title) },
+        supportingText = when (description) {
+            null -> null
+            else -> {
+                { Text(description) }
+            }
+        },
+        leadingContent = leadingIcon,
+        trailingContent = trailingContent
     )
 }
 
@@ -280,13 +277,12 @@ fun SingleChoiceSelector(
                 selected = selected,
                 role = Role.RadioButton,
                 onClick = onClick,
-            )
-            .padding(12.dp),
+            ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         RadioButton(
             selected = selected,
-            onClick = null,
+            onClick = onClick,
             enabled = enabled
         )
         Spacer(Modifier.width(8.dp))


### PR DESCRIPTION
Refactored UI for better appearance, readability, and maintainability; _**There is no change in functionality and minimal change in appearance.**_ 

Here's a brief summary of the changes in this PR:

* Compartmentalized the logic that already exists within the `/preview/PreviewScreen.kt`, and moved most of it into `/preview/ui/PreviewScreenComponents.kt`. Big adjustments on use of containers and modifiers.

* Adjusted some modifiers for `QuickSettingsScreen.kt`; 

* I added a "flip camera" button to the preview screen for easier access

* I also added minor styling changes to the Settings screen; added colors and adjusted some spacing.