### PR TITLE
Add support for single stream capture

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.google.jetpackcamera"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera.ui
 
 import android.Manifest
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
@@ -45,6 +46,7 @@ fun JcaApp() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun JetpackCameraNavHost(
     modifier: Modifier,

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.0' apply false
-    id 'com.android.library' version '8.0.0' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
     id 'com.google.dagger.hilt.android' version '2.44' apply false
 }

--- a/camera-viewfinder-compose/build.gradle
+++ b/camera-viewfinder-compose/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.camerax'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.core.common'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/settings/build.gradle
+++ b/data/settings/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.data.settings'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/domain/camera/build.gradle
+++ b/domain/camera/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.data.camera'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -42,7 +42,7 @@ dependencies {
     implementation 'androidx.concurrent:concurrent-futures-ktx:1.1.0'
 
     // CameraX
-    def camerax_version = "1.3.0-alpha05"
+    def camerax_version = "1.3.0-SNAPSHOT"
     implementation "androidx.camera:camera-core:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -60,9 +60,9 @@ interface CameraUseCase {
 
     fun tapToFocus(display: Display, surfaceWidth: Int, surfaceHeight: Int, x: Float, y: Float)
 
+    suspend fun setSingleStreamCapture(singleStreamCapture: Boolean)
+
     companion object {
         const val INVALID_ZOOM_SCALE = -1f
     }
-
-    suspend fun toggleCaptureMode()
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -63,4 +63,6 @@ interface CameraUseCase {
     companion object {
         const val INVALID_ZOOM_SCALE = -1f
     }
+
+    suspend fun toggleCaptureMode()
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -146,8 +146,8 @@ class CameraXCameraUseCase @Inject constructor(
 
     override suspend fun startVideoRecording() {
         Log.d(TAG, "recordVideo")
-        val captureTypeString = if(singleStreamCaptureEnabled) "-SingleStream" else ""
-        val name = "JCA-recording-${Date()}$captureTypeString.mp4"
+        val captureTypeString = if(singleStreamCaptureEnabled) "SingleStream" else "MultiStream"
+        val name = "JCA-recording-${Date()}-$captureTypeString.mp4"
         val contentValues = ContentValues().apply {
             put(MediaStore.Video.Media.DISPLAY_NAME, name)
         }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -66,26 +66,28 @@ class CameraXCameraUseCase @Inject constructor(
     private val defaultDispatcher: CoroutineDispatcher,
     private val settingsRepository: SettingsRepository
 ) : CameraUseCase {
+
+    private var camera: Camera? = null
     private lateinit var cameraProvider: ProcessCameraProvider
 
     //TODO apply flash from settings
-    private val imageCaptureUseCase = ImageCapture.Builder()
-        .build()
-
-    private val previewUseCase = Preview.Builder()
-        .build()
+    private val imageCaptureUseCase = ImageCapture.Builder().build()
+    private val previewUseCase = Preview.Builder().build()
 
     private val recorder = Recorder.Builder().setExecutor(defaultDispatcher.asExecutor()).build()
     private val videoCaptureUseCase = VideoCapture.withOutput(recorder)
-
-    private var useCaseGroup: UseCaseGroup? = null
-
     private var recording: Recording? = null
 
-    private var camera: Camera? = null
+    private lateinit var useCaseGroup: UseCaseGroup
+
+    private lateinit var aspectRatio : AspectRatio
+    private var singleStreamCaptureEnabled = false
+    private var isFrontFacing = true
+
     override suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int> {
-        updateUseCaseGroup(currentCameraSettings.aspect_ratio)
+        this.aspectRatio = currentCameraSettings.aspect_ratio
         setFlashMode(currentCameraSettings.flash_mode_status)
+        updateUseCaseGroup()
         cameraProvider = ProcessCameraProvider.getInstance(application).await()
 
         val availableCameraLens =
@@ -118,7 +120,7 @@ class CameraXCameraUseCase @Inject constructor(
 
         previewUseCase.setSurfaceProvider(surfaceProvider)
 
-        cameraProvider.runWith(cameraSelector, useCaseGroup!!) {
+        cameraProvider.runWith(cameraSelector, useCaseGroup) {
             camera = it
             awaitCancellation()
         }
@@ -144,7 +146,8 @@ class CameraXCameraUseCase @Inject constructor(
 
     override suspend fun startVideoRecording() {
         Log.d(TAG, "recordVideo")
-        val name = "JCA-recording-${Date()}.mp4"
+        val captureTypeString = if(singleStreamCaptureEnabled) "-SingleStream" else ""
+        val name = "JCA-recording-${Date()}$captureTypeString.mp4"
         val contentValues = ContentValues().apply {
             put(MediaStore.Video.Media.DISPLAY_NAME, name)
         }
@@ -181,11 +184,9 @@ class CameraXCameraUseCase @Inject constructor(
 
     // flips the camera to the designated lensFacing direction
     override suspend fun flipCamera(isFrontFacing: Boolean) {
-        cameraProvider.unbindAll()
+        this.isFrontFacing = isFrontFacing
         rebindUseCases(
-            cameraLensToSelector(
-                getLensFacing(isFrontFacing)
-            )
+
         )
     }
 
@@ -222,22 +223,30 @@ class CameraXCameraUseCase @Inject constructor(
     }
 
     override suspend fun setAspectRatio(aspectRatio: AspectRatio, isFrontFacing: Boolean) {
-        updateUseCaseGroup(aspectRatio)
-        cameraProvider.unbindAll()
-        rebindUseCases(
-            cameraLensToSelector(
-                getLensFacing(isFrontFacing)
-            )
-        )
+        this.aspectRatio = aspectRatio
+        updateUseCaseGroup()
+        rebindUseCases()
     }
 
-    private fun updateUseCaseGroup(aspectRatio: AspectRatio) {
-        useCaseGroup = UseCaseGroup.Builder()
+    override suspend fun toggleCaptureMode() {
+        singleStreamCaptureEnabled = !singleStreamCaptureEnabled
+        Log.d(TAG, "Changing CaptureMode: singleStreamCaptureEnabled: $singleStreamCaptureEnabled")
+        updateUseCaseGroup()
+        rebindUseCases()
+    }
+
+    private fun updateUseCaseGroup() {
+        val useCaseGroupBuilder = UseCaseGroup.Builder()
             .setViewPort(ViewPort.Builder(aspectRatio.ratio, previewUseCase.targetRotation).build())
             .addUseCase(previewUseCase)
             .addUseCase(imageCaptureUseCase)
             .addUseCase(videoCaptureUseCase)
-            .build()
+
+        if (singleStreamCaptureEnabled) {
+            useCaseGroupBuilder.addEffect(SingleSurfaceForcingEffect())
+        }
+
+        useCaseGroup = useCaseGroupBuilder.build()
     }
 
     // converts LensFacing from datastore to @LensFacing Int value
@@ -247,8 +256,12 @@ class CameraXCameraUseCase @Inject constructor(
             false -> CameraSelector.LENS_FACING_BACK
         }
 
-    private suspend fun rebindUseCases(cameraSelector: CameraSelector) {
-        cameraProvider.runWith(cameraSelector, useCaseGroup!!) {
+    private suspend fun rebindUseCases() {
+        val cameraSelector = cameraLensToSelector(
+            getLensFacing(isFrontFacing)
+        )
+        cameraProvider.unbindAll()
+        cameraProvider.runWith(cameraSelector, useCaseGroup) {
             camera = it
             awaitCancellation()
         }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -228,8 +228,8 @@ class CameraXCameraUseCase @Inject constructor(
         rebindUseCases()
     }
 
-    override suspend fun toggleCaptureMode() {
-        singleStreamCaptureEnabled = !singleStreamCaptureEnabled
+    override suspend fun setSingleStreamCapture(singleStreamCapture: Boolean) {
+        singleStreamCaptureEnabled = singleStreamCapture
         Log.d(TAG, "Changing CaptureMode: singleStreamCaptureEnabled: $singleStreamCaptureEnabled")
         updateUseCaseGroup()
         rebindUseCases()

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/EmptySurfaceProcessor.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/EmptySurfaceProcessor.kt
@@ -28,11 +28,14 @@ import androidx.camera.core.SurfaceRequest
 import androidx.camera.core.impl.utils.executor.CameraXExecutors.newHandlerExecutor
 import androidx.camera.core.processing.OpenGlRenderer
 import androidx.camera.core.processing.ShaderProvider
-import androidx.core.util.Preconditions.checkState
 import java.util.concurrent.Executor
 
 private const val GL_THREAD_NAME = "EmptySurfaceProcessor"
 
+/**
+ * This is a [SurfaceProcessor] that passes on the same content from the input
+ * surface to the output surface. Used to make a copies of surfaces.
+ */
 @SuppressLint("RestrictedApi")
 class EmptySurfaceProcessor : SurfaceProcessor {
 
@@ -106,6 +109,13 @@ class EmptySurfaceProcessor : SurfaceProcessor {
         outputSurfaces[surfaceOutput] = surface
     }
 
+    /**
+     * Releases associated resources.
+     *
+     * Closes output surfaces.
+     * Releases the [OpenGlRenderer].
+     * Quits the GL HandlerThread.
+     */
     fun release() {
         glExecutor.execute {
             releaseInternal()
@@ -127,6 +137,6 @@ class EmptySurfaceProcessor : SurfaceProcessor {
     }
 
     private fun checkGlThread() {
-        checkState(GL_THREAD_NAME == Thread.currentThread().name)
+        check(GL_THREAD_NAME == Thread.currentThread().name)
     }
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/EmptySurfaceProcessor.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/EmptySurfaceProcessor.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera.domain.camera
+
+import android.annotation.SuppressLint
+import android.graphics.SurfaceTexture
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.Surface
+import androidx.camera.core.DynamicRange
+import androidx.camera.core.SurfaceOutput
+import androidx.camera.core.SurfaceProcessor
+import androidx.camera.core.SurfaceRequest
+import androidx.camera.core.impl.utils.executor.CameraXExecutors.newHandlerExecutor
+import androidx.camera.core.processing.OpenGlRenderer
+import androidx.camera.core.processing.ShaderProvider
+import androidx.core.util.Preconditions.checkState
+import java.util.concurrent.Executor
+
+private const val GL_THREAD_NAME = "EmptySurfaceProcessor"
+
+@SuppressLint("RestrictedApi")
+class EmptySurfaceProcessor : SurfaceProcessor {
+
+    private val glThread : HandlerThread = HandlerThread(GL_THREAD_NAME)
+    private var glHandler: Handler
+    var glExecutor: Executor
+        private set
+
+    // Members below are only accessed on GL thread.
+    private val glRenderer: OpenGlRenderer = OpenGlRenderer()
+    private val outputSurfaces: MutableMap<SurfaceOutput, Surface> = mutableMapOf()
+    private val textureTransform: FloatArray = FloatArray(16)
+    private val surfaceTransform: FloatArray = FloatArray(16)
+    private var isReleased = false
+
+    init {
+        glThread.start()
+        glHandler = Handler(glThread.looper)
+        glExecutor = newHandlerExecutor(glHandler)
+        glExecutor.execute {
+            glRenderer.init(
+                DynamicRange.SDR,
+                ShaderProvider.DEFAULT
+            )
+        }
+    }
+    override fun onInputSurface(surfaceRequest: SurfaceRequest) {
+        checkGlThread()
+        if (isReleased) {
+            surfaceRequest.willNotProvideSurface()
+            return
+        }
+        val surfaceTexture = SurfaceTexture(glRenderer.textureName)
+        surfaceTexture.setDefaultBufferSize(
+            surfaceRequest.resolution.width, surfaceRequest.resolution.height
+        )
+        val surface = Surface(surfaceTexture)
+        surfaceRequest.provideSurface(surface, glExecutor) {
+            surfaceTexture.setOnFrameAvailableListener(null)
+            surfaceTexture.release()
+            surface.release()
+        }
+        surfaceTexture.setOnFrameAvailableListener({
+            checkGlThread()
+            if (!isReleased) {
+                surfaceTexture.updateTexImage()
+                surfaceTexture.getTransformMatrix(textureTransform)
+                outputSurfaces.forEach {(surfaceOutput, surface) ->
+                    run {
+                        surfaceOutput.updateTransformMatrix(surfaceTransform, textureTransform)
+                        glRenderer.render(surfaceTexture.timestamp, surfaceTransform, surface)
+                    }
+                }
+            }
+        }, glHandler)
+    }
+
+    override fun onOutputSurface(surfaceOutput: SurfaceOutput) {
+        checkGlThread()
+        if (isReleased) {
+            surfaceOutput.close()
+            return
+        }
+        val surface = surfaceOutput.getSurface(glExecutor) {
+            surfaceOutput.close()
+            outputSurfaces.remove(surfaceOutput)?.let { removedSurface ->
+                glRenderer.unregisterOutputSurface(removedSurface)
+            }
+        }
+        glRenderer.registerOutputSurface(surface)
+        outputSurfaces[surfaceOutput] = surface
+    }
+
+    fun release() {
+        glExecutor.execute {
+            releaseInternal()
+        }
+    }
+
+    private fun releaseInternal() {
+        checkGlThread()
+        if (!isReleased) {
+            // Once release is called, we can stop sending frame to output surfaces.
+            for (surfaceOutput in outputSurfaces.keys) {
+                surfaceOutput.close()
+            }
+            outputSurfaces.clear()
+            glRenderer.release()
+            glThread.quitSafely()
+            isReleased = true
+        }
+    }
+
+    private fun checkGlThread() {
+        checkState(GL_THREAD_NAME == Thread.currentThread().name)
+    }
+}

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/SingleSurfaceForcingEffect.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/SingleSurfaceForcingEffect.kt
@@ -23,6 +23,14 @@ private const val TARGETS =
 
 private val emptySurfaceProcessor = EmptySurfaceProcessor()
 
+/**
+ * [CameraEffect] that applies a no-op effect.
+ *
+ * Essentially copying the camera input to the targets,
+ * Preview, VideoCapture and ImageCapture.
+ *
+ * Used as a workaround to force the above 3 use cases to use a single camera stream.
+ */
 class SingleSurfaceForcingEffect : CameraEffect(
     TARGETS,
     emptySurfaceProcessor.glExecutor,
@@ -33,4 +41,3 @@ class SingleSurfaceForcingEffect : CameraEffect(
         emptySurfaceProcessor.release()
     }
 }
-

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/SingleSurfaceForcingEffect.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/SingleSurfaceForcingEffect.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera.domain.camera
+
+import androidx.camera.core.CameraEffect
+
+private const val TARGETS =
+    CameraEffect.PREVIEW or CameraEffect.VIDEO_CAPTURE or CameraEffect.IMAGE_CAPTURE
+
+private val emptySurfaceProcessor = EmptySurfaceProcessor()
+
+class SingleSurfaceForcingEffect : CameraEffect(
+    TARGETS,
+    emptySurfaceProcessor.glExecutor,
+    emptySurfaceProcessor,
+    {}
+) {
+    fun release() {
+        emptySurfaceProcessor.release()
+    }
+}
+

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -107,4 +107,8 @@ class FakeCameraUseCase : CameraUseCase {
     ) {
         TODO("Not yet implemented")
     }
+
+    override suspend fun toggleCaptureMode() {
+        TODO("Not yet implemented")
+    }
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -108,7 +108,7 @@ class FakeCameraUseCase : CameraUseCase {
         TODO("Not yet implemented")
     }
 
-    override suspend fun toggleCaptureMode() {
+    override suspend fun setSingleStreamCapture(singleStreamCapture: Boolean) {
         TODO("Not yet implemented")
     }
 }

--- a/feature/preview/build.gradle
+++ b/feature/preview/build.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     // Compose
-    def composeBom = platform('androidx.compose:compose-bom:2022.12.00')
+    def composeBom = platform('androidx.compose:compose-bom:2023.08.00')
     implementation composeBom
     androidTestImplementation composeBom
 

--- a/feature/preview/build.gradle
+++ b/feature/preview/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.feature.preview'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -213,7 +213,15 @@ fun PreviewScreen(
                         .align(Alignment.TopEnd)
                         .padding(12.dp),
                     label = {
-                        Text(if(previewUiState.singleStreamCapture) "Single Stream" else "Regular")
+                        Text(
+                            stringResource(
+                                if (previewUiState.singleStreamCapture) {
+                                    R.string.capture_mode_single_stream
+                                } else {
+                                    R.string.capture_mode_multi_stream
+                                }
+                            )
+                        )
                     }
                 )
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -42,8 +42,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ChipColors
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -76,6 +80,7 @@ private const val TAG = "PreviewScreen"
  * Screen used for the Preview feature.
  */
 @OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalMaterial3Api
 @Composable
 fun PreviewScreen(
     onNavigateToSettings: () -> Unit,
@@ -118,31 +123,31 @@ fun PreviewScreen(
         Text(text = stringResource(R.string.camera_not_ready))
     } else if (previewUiState.cameraState == CameraState.READY) {
         BoxWithConstraints(
-            Modifier.background(Color.Black)
+            Modifier
+                .background(Color.Black)
                 .pointerInput(Unit) {
-                detectTapGestures(
-                    onDoubleTap = { offset ->
-                        // double tap to flip camera
-                        Log.d(TAG, "onDoubleTap $offset")
-                        viewModel.flipCamera()
-                    },
-                    onTap = { offset ->
-                        // tap to focus
-                        try {
-                            viewModel.tapToFocus(
-                                viewInfo.display,
-                                viewInfo.width,
-                                viewInfo.height,
-                                offset.x, offset.y
-                            )
-                            Log.d(TAG, "onTap $offset")
-                        } catch (e: UninitializedPropertyAccessException) {
-                            Log.d(TAG, "onTap $offset")
-                            e.printStackTrace()
+                    detectTapGestures(
+                        onDoubleTap = { offset ->
+                            Log.d(TAG, "onDoubleTap $offset")
+                            viewModel.flipCamera()
+                        },
+                        onTap = { offset ->
+                            // tap to focus
+                            try {
+                                viewModel.tapToFocus(
+                                    viewInfo.display,
+                                    viewInfo.width,
+                                    viewInfo.height,
+                                    offset.x, offset.y
+                                )
+                                Log.d(TAG, "onTap $offset")
+                            } catch (e: UninitializedPropertyAccessException) {
+                                Log.d(TAG, "onTap $offset")
+                                e.printStackTrace()
+                            }
                         }
-                    }
-                )
-            },
+                    )
+                },
 
             contentAlignment = Alignment.Center
         ) {
@@ -201,6 +206,16 @@ fun PreviewScreen(
                     modifier = Modifier.size(72.dp)
                 )
             }
+
+                SuggestionChip(
+                    onClick = { viewModel.toggleCaptureMode() },
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(12.dp),
+                    label = {
+                        Text(if(previewUiState.singleStreamCapture) "Single Stream" else "Regular")
+                    }
+                )
 
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -28,7 +28,8 @@ data class PreviewUiState(
     val currentCameraSettings: CameraAppSettings, // "quick" settings
     val lensFacing: Int = CameraSelector.LENS_FACING_BACK,
     val videoRecordingState: VideoRecordingState = VideoRecordingState.INACTIVE,
-    val quickSettingsIsOpen: Boolean = false
+    val quickSettingsIsOpen: Boolean = false,
+    val singleStreamCapture: Boolean = false,
 )
 
 /**

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -148,7 +148,7 @@ class PreviewViewModel @Inject constructor(
                     singleStreamCapture = !singleStreamCapture
                 )
             )
-            cameraUseCase.toggleCaptureMode()
+            cameraUseCase.setSingleStreamCapture(!singleStreamCapture)
         }
     }
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -140,6 +140,18 @@ class PreviewViewModel @Inject constructor(
         )
     }
 
+    fun toggleCaptureMode() {
+        val singleStreamCapture = previewUiState.value.singleStreamCapture
+        viewModelScope.launch {
+            _previewUiState.emit(
+                previewUiState.value.copy(
+                    singleStreamCapture = !singleStreamCapture
+                )
+            )
+            cameraUseCase.toggleCaptureMode()
+        }
+    }
+
     // sets the camera to a designated direction
     fun flipCamera(isFacingFront: Boolean) {
         // only flip if 2 directions are available

--- a/feature/preview/src/main/res/values/strings.xml
+++ b/feature/preview/src/main/res/values/strings.xml
@@ -17,4 +17,6 @@
 <resources>
     <string name="camera_not_ready">Camera Not Ready</string>
     <string name="settings_content_description">Settings</string>
+    <string name="capture_mode_single_stream">Single Stream</string>
+    <string name="capture_mode_multi_stream">Multi Stream</string>
 </resources>

--- a/feature/quicksettings/build.gradle
+++ b/feature/quicksettings/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.quicksettings'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/feature/settings/build.gradle
+++ b/feature/settings/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace 'com.google.jetpackcamera.settings'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        maven { url 'https://androidx.dev/snapshots/builds/10707469/artifacts/repository' }
         google()
         mavenCentral()
     }


### PR DESCRIPTION
- Update AGP version (we need a version that supports sdkTarget 34)
- Update sdkTarget and compileSdk to 34 (we need this in order to use CameraX 1.3.0)
- Use androidx.dev to get CameraX version 1.3.0-SNAPSHOT
- Implement Single stream capture by forcing stream sharing with an empty CameraEffect
- Some minor refactoring to CameraXCameraUseCase to simplify some functions
- Use double tap for switching CaptureMode instead of lens (temporary change)