### PR TITLE
Remove boolean from onLensFaceClick

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -134,8 +134,7 @@ fun PreviewScreen(onNavigateToSettings: () -> Unit, viewModel: PreviewViewModel 
                         isOpen = previewUiState.quickSettingsIsOpen,
                         toggleIsOpen = { viewModel.toggleQuickSettings() },
                         currentCameraSettings = previewUiState.currentCameraSettings,
-                        // TODO(yasith): Remove boolean from onLensFaceClick
-                        onLensFaceClick = { _ -> viewModel.flipCamera()},
+                        onLensFaceClick = viewModel::flipCamera,
                         onFlashModeClick = viewModel::setFlash,
                         onAspectRatioClick = {
                             viewModel.setAspectRatio(it)

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -54,7 +54,7 @@ fun QuickSettingsScreen(
     currentCameraSettings: CameraAppSettings,
     isOpen: Boolean = false,
     toggleIsOpen: () -> Unit,
-    onLensFaceClick: (lensFace: Boolean) -> Unit,
+    onLensFaceClick: () -> Unit,
     onFlashModeClick: (flashMode: FlashModeStatus) -> Unit,
     onAspectRatioClick: (aspectRation: AspectRatio) -> Unit
 ) {
@@ -126,7 +126,7 @@ private enum class IsExpandedQuickSetting {
 @Composable
 private fun ExpandedQuickSettingsUi(
     currentCameraSettings: CameraAppSettings,
-    onLensFaceClick: (lensFacingFront: Boolean) -> Unit,
+    onLensFaceClick: () -> Unit,
     onFlashModeClick: (flashMode: FlashModeStatus) -> Unit,
     shouldShowQuickSetting: IsExpandedQuickSetting,
     setVisibleQuickSetting: (IsExpandedQuickSetting) -> Unit,
@@ -155,7 +155,7 @@ private fun ExpandedQuickSettingsUi(
                         },
                         {
                             QuickFlipCamera(
-                                flipCamera = { b: Boolean -> onLensFaceClick(b) },
+                                flipCamera = onLensFaceClick,
                                 currentFacingFront = currentCameraSettings.isFrontCameraFacing
                             )
                         },

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -134,7 +134,7 @@ fun QuickSetFlash(
 @Composable
 fun QuickFlipCamera(
     modifier: Modifier = Modifier,
-    flipCamera: (Boolean) -> Unit,
+    flipCamera: () -> Unit,
     currentFacingFront: Boolean
 ) {
     val enum =
@@ -145,7 +145,7 @@ fun QuickFlipCamera(
     QuickSettingUiItem(
         modifier = modifier,
         enum = enum,
-        onClick = { flipCamera(!currentFacingFront) }
+        onClick = flipCamera
     )
 }
 


### PR DESCRIPTION
Decouple the settings display value from button click action for switching lenses.

