### PR TITLE
Backgrounding crash fix

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -168,8 +168,8 @@ class PreviewViewModel @Inject constructor(
         if (previewUiState.value.currentCameraSettings.isBackCameraAvailable
             && previewUiState.value.currentCameraSettings.isFrontCameraAvailable
         ) {
-
-            viewModelScope.launch {
+            stopCamera()
+            runningCameraJob = viewModelScope.launch {
                 _previewUiState.emit(
                     previewUiState.value.copy(
                         currentCameraSettings =


### PR DESCRIPTION
A better fix than https://github.com/google/jetpack-camera-app/pull/58

When camera is flipped, it is not assigned to a runningCameraJob, this caused the CorotineCameraProvider to not be able to unbind camera on job cancelled