### PR TITLE
Stop RuningCameraJob on all rebindUseCase() instances

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera
+
+import android.content.Context
+import android.view.KeyEvent
+import androidx.test.InstrumentationRegistry.getTargetContext
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BackgroundDeviceTest {
+    @get:Rule
+    val cameraPermissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val uiDevice = UiDevice.getInstance(instrumentation)
+
+    private fun backgroundThenForegroundApp() {
+        uiDevice.pressHome()
+        Thread.sleep(1500)
+        uiDevice.pressRecentApps()
+        Thread.sleep(1500)
+        uiDevice.click(uiDevice.displayWidth / 2, uiDevice.displayHeight / 2)
+        Thread.sleep(2000)
+
+    }
+
+    @Before
+    fun setUp() {
+        ActivityScenario.launch(MainActivity::class.java)
+        Thread.sleep(2000)
+    }
+
+    @Test
+    fun background_foreground() {
+        backgroundThenForegroundApp()
+    }
+
+    @Test
+    fun flipCamera_then_background_foreground() {
+        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
+        uiDevice.findObject(By.res("QuickSetFlipCamera")).click()
+        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        backgroundThenForegroundApp()
+    }
+
+    @Test
+    fun setAspectRatio_then_background_foreground() {
+        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
+        uiDevice.findObject(By.res("QuickSetAspectRatio")).click()
+        uiDevice.findObject(By.res("QuickSetAspectRatio1:1")).click()
+        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        backgroundThenForegroundApp()
+    }
+
+    @Test
+    fun toggleCaptureMode_then_background_foreground() {
+        uiDevice.findObject(By.res("ToggleCaptureMode")).click()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        backgroundThenForegroundApp()
+    }
+}

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -164,6 +165,7 @@ fun PreviewScreen(
 
                     TestingButton(
                         modifier = Modifier
+                            .testTag("ToggleCaptureMode")
                             .align(Alignment.TopEnd)
                             .padding(12.dp),
                         onClick = { viewModel.toggleCaptureMode() },

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -117,7 +117,8 @@ class PreviewViewModel @Inject constructor(
     }
 
     fun setAspectRatio(aspectRatio: AspectRatio) {
-        viewModelScope.launch {
+        stopCamera()
+        runningCameraJob = viewModelScope.launch {
             _previewUiState.emit(
                 previewUiState.value.copy(
                     currentCameraSettings =
@@ -148,7 +149,8 @@ class PreviewViewModel @Inject constructor(
             CaptureMode.SINGLE_STREAM -> CaptureMode.MULTI_STREAM
         }
 
-        viewModelScope.launch {
+        stopCamera()
+        runningCameraJob = viewModelScope.launch {
             _previewUiState.emit(
                 previewUiState.value.copy(
                     currentCameraSettings =

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -157,12 +157,14 @@ private fun ExpandedQuickSettingsUi(
                         },
                         {
                             QuickFlipCamera(
+                                modifier = Modifier.testTag("QuickSetFlipCamera"),
                                 flipCamera = { b: Boolean -> onLensFaceClick(b) },
                                 currentFacingFront = currentCameraSettings.isFrontCameraFacing
                             )
                         },
                         {
                             QuickSetRatio(
+                                modifier = Modifier.testTag("QuickSetAspectRatio"),
                                 onClick = {
                                     setVisibleQuickSetting(
                                         IsExpandedQuickSetting.ASPECT_RATIO
@@ -178,6 +180,7 @@ private fun ExpandedQuickSettingsUi(
             // if a setting that can be expanded is selected, show it
             IsExpandedQuickSetting.ASPECT_RATIO -> {
                 ExpandedQuickSetRatio(
+
                     setRatio = onAspectRatioClick,
                     currentRatio = currentCameraSettings.aspectRatio
                 )

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -72,6 +72,7 @@ fun ExpandedQuickSetRatio(setRatio: (aspectRatio: AspectRatio) -> Unit, currentR
             },
             {
                 QuickSetRatio(
+                    modifier = Modifier.testTag("QuickSetAspectRatio1:1"),
                     onClick = { setRatio(AspectRatio.ONE_ONE) },
                     ratio = AspectRatio.ONE_ONE,
                     currentRatio = currentRatio,


### PR DESCRIPTION
setCaptureMode() and setAspectRatio() also invokes rebindUseCase(), before which the old runningCameraJob needs to be stopped and updated