### PR TITLE
Apply all spotless fixes that required manual intervention

### DIFF
--- a/app/src/main/java/com/google/jetpackcamera/JetpackCameraApplication.kt
+++ b/app/src/main/java/com/google/jetpackcamera/JetpackCameraApplication.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera
 
 import android.app.Application

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -29,8 +29,8 @@ import com.google.accompanist.permissions.rememberPermissionState
 import com.google.jetpackcamera.feature.preview.PreviewScreen
 import com.google.jetpackcamera.feature.preview.PreviewViewModel
 import com.google.jetpackcamera.settings.SettingsScreen
-import com.google.jetpackcamera.ui.Routes.PreviewRoute
-import com.google.jetpackcamera.ui.Routes.SettingsRoute
+import com.google.jetpackcamera.ui.Routes.PREVIEW_ROUTE
+import com.google.jetpackcamera.ui.Routes.SETTINGS_ROUTE
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -56,16 +56,16 @@ private fun JetpackCameraNavHost(
     onPreviewViewModel: (PreviewViewModel) -> Unit,
     navController: NavHostController = rememberNavController()
 ) {
-    NavHost(navController = navController, startDestination = PreviewRoute) {
-        composable(PreviewRoute) {
+    NavHost(navController = navController, startDestination = PREVIEW_ROUTE) {
+        composable(PREVIEW_ROUTE) {
             PreviewScreen(
                 onPreviewViewModel = onPreviewViewModel,
-                onNavigateToSettings = { navController.navigate(SettingsRoute) }
+                onNavigateToSettings = { navController.navigate(SETTINGS_ROUTE) }
             )
         }
-        composable(SettingsRoute) {
+        composable(SETTINGS_ROUTE) {
             SettingsScreen(
-                onNavigateToPreview = { navController.navigate(PreviewRoute) }
+                onNavigateToPreview = { navController.navigate(PREVIEW_ROUTE) }
             )
         }
     }

--- a/app/src/main/java/com/google/jetpackcamera/ui/Routes.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/Routes.kt
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.ui
 
 object Routes {
-    const val PreviewRoute = "preview"
-    const val SettingsRoute = "settings"
+    const val PREVIEW_ROUTE = "preview"
+    const val SETTINGS_ROUTE = "settings"
 }

--- a/app/src/main/java/com/google/jetpackcamera/ui/theme/Color.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/theme/Color.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/google/jetpackcamera/ui/theme/Theme.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/theme/Theme.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.ui.theme
 
 import android.app.Activity
@@ -31,17 +30,19 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
+private val DarkColorScheme =
+    darkColorScheme(
+        primary = Purple80,
+        secondary = PurpleGrey80,
+        tertiary = Pink80
+    )
 
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-)
+private val LightColorScheme =
+    lightColorScheme(
+        primary = Purple40,
+        secondary = PurpleGrey40,
+        tertiary = Pink40
+    )
 
 @Composable
 fun JetpackCameraTheme(
@@ -50,15 +51,16 @@ fun JetpackCameraTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+    val colorScheme =
+        when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
 
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
+            darkTheme -> DarkColorScheme
+            else -> LightColorScheme
+        }
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {

--- a/app/src/main/java/com/google/jetpackcamera/ui/theme/Type.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/theme/Type.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.ui.theme
 
 import androidx.compose.material3.Typography
@@ -23,14 +22,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 // Set of Material typography styles to start with
-val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
+val Typography =
+    Typography(
+        bodyLarge =
+        TextStyle(
+            fontFamily = FontFamily.Default,
+            fontWeight = FontWeight.Normal,
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            letterSpacing = 0.5.sp
+        )
     /* Other default text styles to override
     titleLarge = TextStyle(
         fontFamily = FontFamily.Default,
@@ -46,5 +47,5 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
-)
+     */
+    )

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/CameraPreview.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/CameraPreview.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.viewfinder
 
 import android.graphics.Bitmap
@@ -51,10 +50,12 @@ fun CameraPreview(
     Log.d(TAG, "CameraPreview")
 
     val surfaceRequest by produceState<SurfaceRequest?>(initialValue = null) {
-        onSurfaceProviderReady(SurfaceProvider { request ->
-            value?.willNotProvideSurface()
-            value = request
-        })
+        onSurfaceProviderReady(
+            SurfaceProvider { request ->
+                value?.willNotProvideSurface()
+                value = request
+            }
+        )
     }
 
     PreviewSurface(
@@ -64,7 +65,6 @@ fun CameraPreview(
         onRequestBitmapReady = onRequestBitmapReady,
         implementationMode = implementationMode
     )
-
 }
 
 @Composable
@@ -82,8 +82,11 @@ fun PreviewSurface(
     LaunchedEffect(surfaceRequest, surface) {
         Log.d(TAG, "LaunchedEffect")
         snapshotFlow {
-            if (surfaceRequest == null || surface == null) null
-            else Pair(surfaceRequest, surface)
+            if (surfaceRequest == null || surface == null) {
+                null
+            } else {
+                Pair(surfaceRequest, surface)
+            }
         }.mapNotNull { it }
             .collect { (request, surface) ->
                 Log.d(TAG, "Collect: Providing surface")
@@ -94,22 +97,24 @@ fun PreviewSurface(
 
     when (implementationMode) {
         ImplementationMode.PERFORMANCE -> TODO()
-        ImplementationMode.COMPATIBLE -> CombinedSurface(
-            modifier = modifier,
-            setView = setView,
-            onSurfaceEvent = { event ->
-                surface = when (event) {
-                    is CombinedSurfaceEvent.SurfaceAvailable -> {
-                        event.surface
-                    }
+        ImplementationMode.COMPATIBLE ->
+            CombinedSurface(
+                modifier = modifier,
+                setView = setView,
+                onSurfaceEvent = { event ->
+                    surface =
+                        when (event) {
+                            is CombinedSurfaceEvent.SurfaceAvailable -> {
+                                event.surface
+                            }
 
-                    is CombinedSurfaceEvent.SurfaceDestroyed -> {
-                        null
-                    }
-                }
-            },
-            surfaceRequest = surfaceRequest,
-            onRequestBitmapReady = onRequestBitmapReady
-        )
+                            is CombinedSurfaceEvent.SurfaceDestroyed -> {
+                                null
+                            }
+                        }
+                },
+                surfaceRequest = surfaceRequest,
+                onRequestBitmapReady = onRequestBitmapReady
+            )
     }
 }

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/CombinedSurface.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/CombinedSurface.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.viewfinder.surface
 
 import android.graphics.Bitmap
@@ -23,7 +22,6 @@ import android.view.View
 import androidx.camera.core.SurfaceRequest
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.google.jetpackcamera.viewfinder.surface.SurfaceType.*
 
 private const val TAG = "CombinedSurface"
 
@@ -32,56 +30,59 @@ fun CombinedSurface(
     modifier: Modifier,
     onSurfaceEvent: (CombinedSurfaceEvent) -> Unit,
     onRequestBitmapReady: (() -> Bitmap?) -> Unit = {},
-    type: SurfaceType = TEXTURE_VIEW,
+    type: SurfaceType = SurfaceType.TEXTURE_VIEW,
     setView: (View) -> Unit,
     surfaceRequest: SurfaceRequest?
 ) {
     Log.d(TAG, "PreviewTexture")
 
     when (type) {
-        SURFACE_VIEW -> Surface {
-            when (it) {
-                is SurfaceHolderEvent.SurfaceCreated -> {
-                    onSurfaceEvent(CombinedSurfaceEvent.SurfaceAvailable(it.holder.surface))
-                }
-
-                is SurfaceHolderEvent.SurfaceDestroyed -> {
-                    onSurfaceEvent(CombinedSurfaceEvent.SurfaceDestroyed)
-                }
-
-                is SurfaceHolderEvent.SurfaceChanged -> {
-                    // TODO(yasith@)
-                }
-
-            }
-        }
-
-        TEXTURE_VIEW -> Texture(
-            modifier = modifier,
-            onSurfaceTextureEvent = {
+        SurfaceType.SURFACE_VIEW ->
+            Surface {
                 when (it) {
-                    is SurfaceTextureEvent.SurfaceTextureAvailable -> {
-                        onSurfaceEvent(CombinedSurfaceEvent.SurfaceAvailable(Surface(it.surface)))
+                    is SurfaceHolderEvent.SurfaceCreated -> {
+                        onSurfaceEvent(CombinedSurfaceEvent.SurfaceAvailable(it.holder.surface))
                     }
 
-                    is SurfaceTextureEvent.SurfaceTextureDestroyed -> {
+                    is SurfaceHolderEvent.SurfaceDestroyed -> {
                         onSurfaceEvent(CombinedSurfaceEvent.SurfaceDestroyed)
                     }
 
-                    is SurfaceTextureEvent.SurfaceTextureSizeChanged -> {
-                        // TODO(yasith@)
-                    }
-
-                    is SurfaceTextureEvent.SurfaceTextureUpdated -> {
+                    is SurfaceHolderEvent.SurfaceChanged -> {
                         // TODO(yasith@)
                     }
                 }
-                true
-            },
-            onRequestBitmapReady,
-            setView = setView,
-            surfaceRequest = surfaceRequest
-        )
+            }
+
+        SurfaceType.TEXTURE_VIEW ->
+            Texture(
+                modifier = modifier,
+                onSurfaceTextureEvent = {
+                    when (it) {
+                        is SurfaceTextureEvent.SurfaceTextureAvailable -> {
+                            onSurfaceEvent(
+                                CombinedSurfaceEvent.SurfaceAvailable(Surface(it.surface))
+                            )
+                        }
+
+                        is SurfaceTextureEvent.SurfaceTextureDestroyed -> {
+                            onSurfaceEvent(CombinedSurfaceEvent.SurfaceDestroyed)
+                        }
+
+                        is SurfaceTextureEvent.SurfaceTextureSizeChanged -> {
+                            // TODO(yasith@)
+                        }
+
+                        is SurfaceTextureEvent.SurfaceTextureUpdated -> {
+                            // TODO(yasith@)
+                        }
+                    }
+                    true
+                },
+                onRequestBitmapReady,
+                setView = setView,
+                surfaceRequest = surfaceRequest
+            )
     }
 }
 
@@ -94,6 +95,6 @@ sealed interface CombinedSurfaceEvent {
 }
 
 enum class SurfaceType {
-    SURFACE_VIEW, TEXTURE_VIEW
+    SURFACE_VIEW,
+    TEXTURE_VIEW
 }
-

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Surface.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Surface.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.viewfinder.surface
 
 import android.util.Log
@@ -23,26 +22,24 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.jetpackcamera.viewfinder.surface.SurfaceHolderEvent.*
 
 private const val TAG = "Surface"
 
 @Composable
-fun Surface(
-    onSurfaceHolderEvent: (SurfaceHolderEvent) -> Unit = { _ -> }
-) {
+fun Surface(onSurfaceHolderEvent: (SurfaceHolderEvent) -> Unit = { _ -> }) {
     Log.d(TAG, "Surface")
 
     AndroidView(factory = { context ->
         SurfaceView(context).apply {
-            layoutParams = LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
+            layoutParams =
+                LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
             holder.addCallback(
                 object : SurfaceHolder.Callback {
                     override fun surfaceCreated(holder: SurfaceHolder) {
-                        onSurfaceHolderEvent(SurfaceCreated(holder))
+                        onSurfaceHolderEvent(SurfaceHolderEvent.SurfaceCreated(holder))
                     }
 
                     override fun surfaceChanged(
@@ -51,18 +48,23 @@ fun Surface(
                         width: Int,
                         height: Int
                     ) {
-                        onSurfaceHolderEvent(SurfaceChanged(holder, width, height))
+                        onSurfaceHolderEvent(
+                            SurfaceHolderEvent.SurfaceChanged(
+                                holder,
+                                width,
+                                height
+                            )
+                        )
                     }
 
                     override fun surfaceDestroyed(holder: SurfaceHolder) {
-                        onSurfaceHolderEvent(SurfaceDestroyed(holder))
+                        onSurfaceHolderEvent(SurfaceHolderEvent.SurfaceDestroyed(holder))
                     }
                 }
             )
         }
     })
 }
-
 
 sealed interface SurfaceHolderEvent {
     data class SurfaceCreated(

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/SurfaceTransformationUtil.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/SurfaceTransformationUtil.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.viewfinder.surface
 
 import android.annotation.SuppressLint
@@ -37,7 +36,9 @@ import androidx.camera.core.impl.utils.TransformUtils
  */
 object SurfaceTransformationUtil {
     @SuppressLint("RestrictedApi", "WrongConstant")
-    private fun getRemainingRotationDegrees(transformationInfo: SurfaceRequest.TransformationInfo): Int {
+    private fun getRemainingRotationDegrees(
+        transformationInfo: SurfaceRequest.TransformationInfo
+    ): Int {
         return if (!transformationInfo.hasCameraTransform()) {
             // If the Surface is not connected to the camera, then the SurfaceView/TextureView will
             // not apply any transformation. In that case, we need to apply the rotation
@@ -65,10 +66,14 @@ object SurfaceTransformationUtil {
     }
 
     @SuppressLint("RestrictedApi")
-    private fun getRotatedViewportSize(transformationInfo: SurfaceRequest.TransformationInfo): Size {
+    private fun getRotatedViewportSize(
+        transformationInfo: SurfaceRequest.TransformationInfo
+    ): Size {
         return if (TransformUtils.is90or270(transformationInfo.rotationDegrees)) {
             Size(transformationInfo.cropRect.height(), transformationInfo.cropRect.width())
-        } else Size(transformationInfo.cropRect.width(), transformationInfo.cropRect.height())
+        } else {
+            Size(transformationInfo.cropRect.width(), transformationInfo.cropRect.height())
+        }
     }
 
     @SuppressLint("RestrictedApi")
@@ -79,14 +84,14 @@ object SurfaceTransformationUtil {
         // Using viewport rect to check if the viewport is based on the view finder.
         val rotatedViewportSize: Size = getRotatedViewportSize(transformationInfo)
         return TransformUtils.isAspectRatioMatchingWithRoundingError(
-            viewFinderSize,  /* isAccurate1= */true,
-            rotatedViewportSize,  /* isAccurate2= */false
+            viewFinderSize,
+            true,
+            rotatedViewportSize,
+            false
         )
     }
 
-    private fun setMatrixRectToRect(
-        matrix: Matrix, source: RectF, destination: RectF,
-    ) {
+    private fun setMatrixRectToRect(matrix: Matrix, source: RectF, destination: RectF) {
         val matrixScaleType = Matrix.ScaleToFit.CENTER
         // android.graphics.Matrix doesn't support fill scale types. The workaround is
         // mapping inversely from destination to source, then invert the matrix.
@@ -96,22 +101,28 @@ object SurfaceTransformationUtil {
 
     private fun getViewFinderViewportRectForMismatchedAspectRatios(
         transformationInfo: SurfaceRequest.TransformationInfo,
-        viewFinderSize: Size,
+        viewFinderSize: Size
     ): RectF {
-        val viewFinderRect = RectF(
-            0f, 0f, viewFinderSize.width.toFloat(),
-            viewFinderSize.height.toFloat()
-        )
+        val viewFinderRect =
+            RectF(
+                0f,
+                0f,
+                viewFinderSize.width.toFloat(),
+                viewFinderSize.height.toFloat()
+            )
         val rotatedViewportSize = getRotatedViewportSize(transformationInfo)
-        val rotatedViewportRect = RectF(
-            0f, 0f, rotatedViewportSize.width.toFloat(),
-            rotatedViewportSize.height.toFloat()
-        )
+        val rotatedViewportRect =
+            RectF(
+                0f,
+                0f,
+                rotatedViewportSize.width.toFloat(),
+                rotatedViewportSize.height.toFloat()
+            )
         val matrix = Matrix()
         setMatrixRectToRect(
             matrix,
             rotatedViewportRect,
-            viewFinderRect,
+            viewFinderRect
         )
         matrix.mapRect(rotatedViewportRect)
         return rotatedViewportRect
@@ -130,20 +141,25 @@ object SurfaceTransformationUtil {
                 // fill the entire view finder. This happens if the scale type is FILL_* AND a
                 // view-finder-based viewport is used.
                 RectF(
-                    0f, 0f, viewFinderSize.width.toFloat(),
+                    0f,
+                    0f,
+                    viewFinderSize.width.toFloat(),
                     viewFinderSize.height.toFloat()
                 )
             } else {
                 // If the aspect ratios don't match, it could be 1) scale type is FIT_*, 2) the
                 // Viewport is not based on the view finder or 3) both.
                 getViewFinderViewportRectForMismatchedAspectRatios(
-                    transformationInfo, viewFinderSize
+                    transformationInfo,
+                    viewFinderSize
                 )
             }
-        val matrix = TransformUtils.getRectToRect(
-            RectF(transformationInfo.cropRect), viewFinderCropRect,
-            transformationInfo.rotationDegrees
-        )
+        val matrix =
+            TransformUtils.getRectToRect(
+                RectF(transformationInfo.cropRect),
+                viewFinderCropRect,
+                transformationInfo.rotationDegrees
+            )
         if (isFrontCamera && transformationInfo.hasCameraTransform()) {
             // SurfaceView/TextureView automatically mirrors the Surface for front camera, which
             // needs to be compensated by mirroring the Surface around the upright direction of the

--- a/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Texture.kt
+++ b/camera-viewfinder-compose/src/main/java/com/google/jetpackcamera/viewfinder/surface/Texture.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.viewfinder.surface
 
 import android.annotation.SuppressLint
@@ -28,7 +27,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.camera.core.SurfaceRequest
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,16 +47,17 @@ fun Texture(
     onSurfaceTextureEvent: (SurfaceTextureEvent) -> Boolean = { _ -> true },
     onRequestBitmapReady: (() -> Bitmap?) -> Unit,
     setView: (View) -> Unit,
-    surfaceRequest: SurfaceRequest?,
-    ) {
+    surfaceRequest: SurfaceRequest?
+) {
     Log.d(TAG, "Texture")
 
     val resolution = surfaceRequest?.resolution
     var textureView: TextureView? by remember { mutableStateOf(null) }
     var parentView: FrameLayout? by remember { mutableStateOf(null) }
     if (parentView != null && surfaceRequest != null && resolution != null) {
-        surfaceRequest.setTransformationInfoListener(Dispatchers.Main.asExecutor())
-        { transformationInfo ->
+        surfaceRequest.setTransformationInfoListener(
+            Dispatchers.Main.asExecutor()
+        ) { transformationInfo ->
             val parentViewSize = Size(parentView!!.width, parentView!!.height)
             if (parentViewSize.height == 0 || parentViewSize.width == 0) {
                 return@setTransformationInfoListener
@@ -72,21 +71,24 @@ fun Texture(
                     surfaceRequest.camera.isFrontFacing
                 )
             if (!transformationInfo.hasCameraTransform()) {
-                viewFinder.layoutParams = FrameLayout.LayoutParams(
-                    surfaceRectInViewFinder.width().toInt(),
-                    surfaceRectInViewFinder.height().toInt()
-                )
+                viewFinder.layoutParams =
+                    FrameLayout.LayoutParams(
+                        surfaceRectInViewFinder.width().toInt(),
+                        surfaceRectInViewFinder.height().toInt()
+                    )
             } else {
-                viewFinder.layoutParams = FrameLayout.LayoutParams(
-                    resolution.width,
-                    resolution.height
-                )
+                viewFinder.layoutParams =
+                    FrameLayout.LayoutParams(
+                        resolution.width,
+                        resolution.height
+                    )
             }
             // For TextureView, correct the orientation to match the target rotation.
-            val correctionMatrix = SurfaceTransformationUtil.getTextureViewCorrectionMatrix(
-                transformationInfo,
-                resolution
-            )
+            val correctionMatrix =
+                SurfaceTransformationUtil.getTextureViewCorrectionMatrix(
+                    transformationInfo,
+                    resolution
+                )
             viewFinder.setTransform(correctionMatrix)
 
             viewFinder.pivotX = 0f
@@ -103,63 +105,71 @@ fun Texture(
             modifier = modifier.clipToBounds(),
             factory = { context ->
                 FrameLayout(context).apply {
-                    layoutParams = LinearLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT
-                    )
-                    addView(TextureView(context).apply {
-                        layoutParams = FrameLayout.LayoutParams(
-                            resolution.width,
-                            resolution.height
+                    layoutParams =
+                        LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT
                         )
-                        surfaceTextureListener = object : TextureView.SurfaceTextureListener {
-                            override fun onSurfaceTextureAvailable(
-                                surface: SurfaceTexture,
-                                width: Int,
-                                height: Int
-                            ) {
-                                onSurfaceTextureEvent(
-                                    SurfaceTextureEvent.SurfaceTextureAvailable(
-                                        surface,
-                                        width,
-                                        height
-                                    )
+                    addView(
+                        TextureView(context).apply {
+                            layoutParams =
+                                FrameLayout.LayoutParams(
+                                    resolution.width,
+                                    resolution.height
                                 )
-                            }
+                            surfaceTextureListener =
+                                object : TextureView.SurfaceTextureListener {
+                                    override fun onSurfaceTextureAvailable(
+                                        surface: SurfaceTexture,
+                                        width: Int,
+                                        height: Int
+                                    ) {
+                                        onSurfaceTextureEvent(
+                                            SurfaceTextureEvent.SurfaceTextureAvailable(
+                                                surface,
+                                                width,
+                                                height
+                                            )
+                                        )
+                                    }
 
-                            override fun onSurfaceTextureSizeChanged(
-                                surface: SurfaceTexture,
-                                width: Int,
-                                height: Int
-                            ) {
-                                onSurfaceTextureEvent(
-                                    SurfaceTextureEvent.SurfaceTextureSizeChanged(
-                                        surface,
-                                        width,
-                                        height
-                                    )
-                                )
-                            }
+                                    override fun onSurfaceTextureSizeChanged(
+                                        surface: SurfaceTexture,
+                                        width: Int,
+                                        height: Int
+                                    ) {
+                                        onSurfaceTextureEvent(
+                                            SurfaceTextureEvent.SurfaceTextureSizeChanged(
+                                                surface,
+                                                width,
+                                                height
+                                            )
+                                        )
+                                    }
 
-                            override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
-                                return onSurfaceTextureEvent(
-                                    SurfaceTextureEvent.SurfaceTextureDestroyed(
-                                        surface
-                                    )
-                                )
-                            }
+                                    override fun onSurfaceTextureDestroyed(
+                                        surface: SurfaceTexture
+                                    ): Boolean {
+                                        return onSurfaceTextureEvent(
+                                            SurfaceTextureEvent.SurfaceTextureDestroyed(
+                                                surface
+                                            )
+                                        )
+                                    }
 
-                            override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
-                                onSurfaceTextureEvent(
-                                    SurfaceTextureEvent.SurfaceTextureUpdated(
-                                        surface
-                                    )
-                                )
-                            }
+                                    override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
+                                        onSurfaceTextureEvent(
+                                            SurfaceTextureEvent.SurfaceTextureUpdated(
+                                                surface
+                                            )
+                                        )
+                                    }
+                                }
                         }
-                    })
+                    )
                 }
-            }, update = {
+            },
+            update = {
                 parentView = it
                 textureView = it.getChildAt(0) as TextureView?
                 setView(it)
@@ -167,7 +177,6 @@ fun Texture(
             }
         )
     }
-
 }
 
 sealed interface SurfaceTextureEvent {

--- a/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/DataStoreModuleTest.kt
+++ b/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/DataStoreModuleTest.kt
@@ -13,35 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings
 
 import androidx.datastore.core.DataStore
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
-
-import org.junit.Before
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 import com.google.jetpackcamera.settings.test.FakeDataStoreModule
 import com.google.jetpackcamera.settings.test.FakeJcaSettingsSerializer
 import java.io.File
-import org.junit.Assert.*
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class DataStoreModuleTest {
     @get:Rule
-     val tempFolder = TemporaryFolder()
+    val tempFolder = TemporaryFolder()
     private lateinit var testFile: File
 
     @Before
     fun setUp() {
-       testFile = tempFolder.newFile()
+        testFile = tempFolder.newFile()
     }
 
     @Test

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/DataStoreModule.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/DataStoreModule.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings
 
 import android.content.Context
@@ -26,10 +25,10 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import javax.inject.Singleton
 
 // with hilt will ensure datastore instance access is unique per file
 @Module
@@ -42,12 +41,11 @@ object DataStoreModule {
     fun provideDataStore(@ApplicationContext context: Context): DataStore<JcaSettings> =
         DataStoreFactory.create(
             corruptionHandler = ReplaceFileCorruptionHandler { JcaSettings.getDefaultInstance() },
-            //TODO(b/286245619, kimblebee@): Inject coroutine scope once module providing default IO dispatcher scope is implemented
+            // TODO(b/286245619, kimblebee@): Inject coroutine scope once module providing default IO dispatcher scope is implemented
             scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
             serializer = JcaSettingsSerializer,
             produceFile = {
                 context.dataStoreFile(FILE_LOCATION)
-            })
-
-    }
-
+            }
+        )
+}

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsModule.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsModule.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings
 
 import dagger.Binds
@@ -31,5 +30,5 @@ interface SettingsModule {
     @Binds
     fun bindsSettingsRepository(
         localSettingsRepository: LocalSettingsRepository
-    ) : SettingsRepository
+    ): SettingsRepository
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/AspectRatio.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/AspectRatio.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings.model
 
 import android.util.Rational
@@ -35,7 +34,7 @@ enum class AspectRatio(val ratio: Rational) {
                 // defaults to 3:4 aspect ratio
                 AspectRatioProto.ASPECT_RATIO_THREE_FOUR,
                 AspectRatioProto.ASPECT_RATIO_UNDEFINED,
-                AspectRatioProto.UNRECOGNIZED,
+                AspectRatioProto.UNRECOGNIZED
                 -> AspectRatio.THREE_FOUR
             }
         }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings.model
 
 enum class CaptureMode {
-    MULTI_STREAM, SINGLE_STREAM
+    MULTI_STREAM,
+    SINGLE_STREAM
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeDataStoreModule.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeDataStoreModule.kt
@@ -13,23 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings.test
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import com.google.jetpackcamera.settings.JcaSettings
-import kotlinx.coroutines.CoroutineScope
 import java.io.File
+import kotlinx.coroutines.CoroutineScope
 
 /** test implementation of DataStoreModule */
 object FakeDataStoreModule {
-    
-    fun provideDataStore(scope: CoroutineScope, serializer: FakeJcaSettingsSerializer, file: File): DataStore<JcaSettings> =
-        DataStoreFactory.create(
-            corruptionHandler = ReplaceFileCorruptionHandler { JcaSettings.getDefaultInstance() },
-            scope = scope,
-            serializer = serializer,
-            produceFile = { file })
+
+    fun provideDataStore(
+        scope: CoroutineScope,
+        serializer: FakeJcaSettingsSerializer,
+        file: File
+    ): DataStore<JcaSettings> = DataStoreFactory.create(
+        corruptionHandler = ReplaceFileCorruptionHandler { JcaSettings.getDefaultInstance() },
+        scope = scope,
+        serializer = serializer,
+        produceFile = { file }
+    )
 }

--- a/data/settings/src/test/java/com/google/jetpackcamera/settings/ExampleUnitTest.kt
+++ b/data/settings/src/test/java/com/google/jetpackcamera/settings/ExampleUnitTest.kt
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -13,19 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.feature.preview
 
 import androidx.camera.core.CameraSelector
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-
 
 /**
  * Defines the current state of the [PreviewScreen].
  */
 data class PreviewUiState(
     val cameraState: CameraState = CameraState.NOT_READY,
-    val currentCameraSettings: CameraAppSettings, // "quick" settings
+    // "quick" settings
+    val currentCameraSettings: CameraAppSettings,
     val lensFacing: Int = CameraSelector.LENS_FACING_BACK,
     val videoRecordingState: VideoRecordingState = VideoRecordingState.INACTIVE,
     val quickSettingsIsOpen: Boolean = false
@@ -39,6 +38,7 @@ enum class VideoRecordingState {
      * Camera is not currently recording a video
      */
     INACTIVE,
+
     /**
      * Camera is currently recording a video
      */
@@ -58,5 +58,4 @@ enum class CameraState {
      * Camera is open and presenting a preview stream.
      */
     READY
-
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings
 
 import com.google.jetpackcamera.settings.model.CameraAppSettings


### PR DESCRIPTION
 Ran `spotlessApply` and fixed all issues that caused errors. Some
 automatic fixes were applied after fixing manual issues.

 This required temporarily turning off
 `ratchetFrom("origin/main")`
