### PR TITLE
Fix reset of front facing camera settings after leaving screen settings

### DIFF
--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -106,8 +106,13 @@ class LocalSettingsRepository @Inject constructor(
         // if a front or back lens is not present, the option to change
         // the direction of the camera should be disabled
         jcaSettings.updateData { currentSettings ->
+            val newLensFacing = if (currentSettings.defaultFrontCamera) {
+                frontLensAvailable
+            } else {
+                false
+            }
             currentSettings.toBuilder()
-                .setDefaultFrontCamera(frontLensAvailable)
+                .setDefaultFrontCamera(newLensFacing)
                 .setFrontCameraAvailable(frontLensAvailable)
                 .setBackCameraAvailable(backLensAvailable)
                 .build()


### PR DESCRIPTION
updateAvailableCameraLens function always set the settings of front facing camera to true if the front facing camera is available, by removing the call to setDefaultFrontCamera the front camera is not set to true as a default value and fix the issue.