### PR TITLE
Fix capture mode labels in filenames

### DIFF
--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -153,8 +153,8 @@ constructor(
         Log.d(TAG, "recordVideo")
         val captureTypeString =
             when (captureMode) {
-                CaptureMode.MULTI_STREAM -> "SingleStream"
-                CaptureMode.SINGLE_STREAM -> "MultiStream"
+                CaptureMode.MULTI_STREAM -> "MultiStream"
+                CaptureMode.SINGLE_STREAM -> "SingleStream"
             }
         val name = "JCA-recording-${Date()}-$captureTypeString.mp4"
         val contentValues =


### PR DESCRIPTION
 The capture mode labels were reversed. This change fixes that.
