### PR TITLE
Update CI to run on pull requests instead of push

### DIFF
--- a/.github/workflows/PullRequestWorkflow.yaml
+++ b/.github/workflows/PullRequestWorkflow.yaml
@@ -1,6 +1,6 @@
 name: Presubmit
 
-on: [push]
+on: [pull_request]
 
 concurrency:
   group: build-${{ github.ref }}


### PR DESCRIPTION
Some of our CI tests are not triggering when there's a new pull request from outside of the repository.

This should be fixed by changing the event it's triggered on to `pull_request` instead of `push`