### PR TITLE
Create a Toast message with compose

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -59,6 +59,7 @@ import com.google.jetpackcamera.feature.preview.ui.CaptureButton
 import com.google.jetpackcamera.feature.preview.ui.FlipCameraButton
 import com.google.jetpackcamera.feature.preview.ui.PreviewDisplay
 import com.google.jetpackcamera.feature.preview.ui.SettingsNavButton
+import com.google.jetpackcamera.feature.preview.ui.ShowToast
 import com.google.jetpackcamera.feature.preview.ui.TestingButton
 import com.google.jetpackcamera.feature.preview.ui.ZoomScaleText
 import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreen
@@ -235,6 +236,10 @@ fun PreviewScreen(
                     )
                 }
             }
+        }
+        // displays toast when there is a message to show
+        if (previewUiState.toastMessageToShow != null){
+            ShowToast(toastMessage = previewUiState.toastMessageToShow!!, onToastShown = viewModel::onToastShown)
         }
     }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.feature.preview
 
+import android.widget.Toast
 import androidx.camera.core.CameraSelector
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 
@@ -27,8 +28,32 @@ data class PreviewUiState(
     val currentCameraSettings: CameraAppSettings,
     val lensFacing: Int = CameraSelector.LENS_FACING_BACK,
     val videoRecordingState: VideoRecordingState = VideoRecordingState.INACTIVE,
-    val quickSettingsIsOpen: Boolean = false
+    val quickSettingsIsOpen: Boolean = false,
+    //todo: remove after implementing post capture screen
+    val toastMessageToShow: ToastMessage? = null
 )
+
+/**
+ * Helper class containing information used to create a toast.
+ *
+ * @param message the text to be displayed.
+ * @param isLongToast determines if the display time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT]
+ * @param testDesc the *unique* description for toast message. i.e. *captureFailedToast* vs *captureSuccessToast*.
+ * @property testTag the identifiable resource ID of a Toast on screen.
+ */
+class ToastMessage(
+    val message: String,
+    isLongToast: Boolean = false,
+    val testDesc: String = "Toast Message"
+) {
+    val testTag: String = "Toast Message"
+    val toastLength: Int = when (isLongToast) {
+        true -> Toast.LENGTH_LONG
+        false -> Toast.LENGTH_SHORT
+    }
+}
+
+
 
 /**
  * Defines the current state of Video Recording

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera.feature.preview
 
 import android.widget.Toast
 import androidx.camera.core.CameraSelector
+import com.google.jetpackcamera.feature.preview.ui.ToastMessage
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 
 /**
@@ -32,28 +33,6 @@ data class PreviewUiState(
     //todo: remove after implementing post capture screen
     val toastMessageToShow: ToastMessage? = null
 )
-
-/**
- * Helper class containing information used to create a toast.
- *
- * @param message the text to be displayed.
- * @param isLongToast determines if the display time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT]
- * @param testDesc the *unique* description for toast message. i.e. *captureFailedToast* vs *captureSuccessToast*.
- * @property testTag the identifiable resource ID of a Toast on screen.
- */
-class ToastMessage(
-    val message: String,
-    isLongToast: Boolean = false,
-    val testDesc: String = "Toast Message"
-) {
-    val testTag: String = "Toast Message"
-    val toastLength: Int = when (isLongToast) {
-        true -> Toast.LENGTH_LONG
-        false -> Toast.LENGTH_SHORT
-    }
-}
-
-
 
 /**
  * Defines the current state of Video Recording

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -192,8 +192,18 @@ class PreviewViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 cameraUseCase.takePicture()
+                _previewUiState.emit(
+                    previewUiState.value.copy(
+                        toastMessageToShow = ToastMessage(message = "Image Capture Success", testDesc = "ImageCaptureSuccessToast")
+                    )
+                )
                 Log.d(TAG, "cameraUseCase.takePicture success")
             } catch (exception: ImageCaptureException) {
+                _previewUiState.emit(
+                    previewUiState.value.copy(
+                        toastMessageToShow = ToastMessage(message = "Image Capture Failure", testDesc = "ImageCaptureFailureToast")
+                    )
+                )
                 Log.d(TAG, "cameraUseCase.takePicture error")
                 Log.d(TAG, exception.toString())
             }
@@ -258,5 +268,15 @@ class PreviewViewModel @Inject constructor(
             x = x,
             y = y
         )
+    }
+
+    fun onToastShown() {
+        viewModelScope.launch {
+            _previewUiState.emit(
+                previewUiState.value.copy(
+                    toastMessageToShow = null
+                )
+            )
+        }
     }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -22,6 +22,7 @@ import androidx.camera.core.Preview.SurfaceProvider
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.jetpackcamera.domain.camera.CameraUseCase
+import com.google.jetpackcamera.feature.preview.ui.ToastMessage
 import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
@@ -192,6 +193,7 @@ class PreviewViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 cameraUseCase.takePicture()
+                //todo: remove toast after postcapture screen implemented
                 _previewUiState.emit(
                     previewUiState.value.copy(
                         toastMessageToShow = ToastMessage(message = "Image Capture Success", testDesc = "ImageCaptureSuccessToast")
@@ -199,6 +201,7 @@ class PreviewViewModel @Inject constructor(
                 )
                 Log.d(TAG, "cameraUseCase.takePicture success")
             } catch (exception: ImageCaptureException) {
+                //todo: remove toast after postcapture screen implemented
                 _previewUiState.emit(
                     previewUiState.value.copy(
                         toastMessageToShow = ToastMessage(message = "Image Capture Failure", testDesc = "ImageCaptureFailureToast")

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.feature.preview.R
-import com.google.jetpackcamera.feature.preview.ToastMessage
 import com.google.jetpackcamera.feature.preview.VideoRecordingState
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.viewfinder.CameraPreview
@@ -68,10 +67,10 @@ private const val TAG = "PreviewScreen"
 
 
 /**
- * Displays a [Toast] with specifications set by a [ToastMessage]
+ * Displays a [Toast] with specifications set by a [ToastMessage].
  *
- * @param toastMessage the specifications for the [Toast]
- * @param onToastShown called once the toast has been displayed
+ * @param toastMessage the specifications for the [Toast].
+ * @param onToastShown called once the Toast has been displayed.
  */
 @Composable
 fun ShowToast(modifier: Modifier = Modifier, toastMessage: ToastMessage, onToastShown : () -> Unit){

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera.feature.preview.ui
 import android.util.Log
 import android.view.Display
 import android.view.View
+import android.widget.Toast
 import androidx.camera.core.Preview
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -49,10 +50,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.feature.preview.R
+import com.google.jetpackcamera.feature.preview.ToastMessage
 import com.google.jetpackcamera.feature.preview.VideoRecordingState
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.viewfinder.CameraPreview
@@ -60,8 +66,27 @@ import kotlinx.coroutines.CompletableDeferred
 
 private const val TAG = "PreviewScreen"
 
-/** this is the preview surface display. This view implements gestures tap to focus, pinch to zoom,
- * and double tap to flip camera */
+
+/**
+ * Displays a [Toast] with specifications set by a [ToastMessage]
+ *
+ * @param toastMessage the specifications for the [Toast]
+ * @param onToastShown called once the toast has been displayed
+ */
+@Composable
+fun ShowToast(modifier: Modifier = Modifier, toastMessage: ToastMessage, onToastShown : () -> Unit){
+    Box(
+        modifier.testTag(toastMessage.testTag).semantics { contentDescription = toastMessage.testDesc }
+    ) {
+        Toast.makeText(LocalContext.current, toastMessage.message, toastMessage.toastLength).show()
+        onToastShown()
+    }
+}
+
+/**
+ * this is the preview surface display. This view implements gestures tap to focus, pinch to zoom,
+ * and double-tap to flip camera
+ */
 @Composable
 fun PreviewDisplay(
     onTapToFocus: (Display, Int, Int, Float, Float) -> Unit,

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera.feature.preview.ui
+
+import android.widget.Toast
+
+/**
+ * Helper class containing information used to create a [Toast].
+ *
+ * @param message the text to be displayed.
+ * @param isLongToast determines if the display time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT]
+ * @param testDesc the *unique* description for toast message. i.e. *captureFailedToast* vs *captureSuccessToast*.
+ * @property testTag the identifiable resource ID of a Toast on screen.
+ */
+class ToastMessage(
+    val message: String,
+    isLongToast: Boolean = false,
+    val testDesc: String = "Toast Message"
+) {
+    val testTag: String = "Toast Message"
+    val toastLength: Int = when (isLongToast) {
+        true -> Toast.LENGTH_LONG
+        false -> Toast.LENGTH_SHORT
+    }
+}


### PR DESCRIPTION
🍞 _it is time ⏰ for toast (yum)_ 🍞

Here are the notable things about the change:
Create the option to have toasts in the preview screen!
in this PR it displays a toast message when the image capture is successful or unsuccessful

New **PreviewUiState** property -`toastMessageToShow : ToastMessage`, which is default to null
New class - `ToastMessage.kt`, which holds the information necessary to create a toast 
New composable component - `ShowToast`, takes in a `ToastMessage` and `onToastShown()` (which resets toast ui state to null). Whats special about it is that it has a TestTag and a changeable description, so you can target the presence of a toast or a specific toast when testing.
 
Implementation in `PreviewScreen` -  if the toast property is not null for preview ui state, show composable and reset ui state.


![image](https://github.com/google/jetpack-camera-app/assets/20013168/539e8ce9-e426-418c-bc94-5528c16b82ec)

note:
* you can still click the capture button through the toast
* starting from android 12 the toast messages include the app icon