### PR TITLE
ToastMessage adjustments

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -62,8 +62,8 @@ class PreviewViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             settingsRepository.cameraAppSettings.collect {
-                // TODO: only update settings that were actually changed
-                // currently resets all "quick" settings to stored settings
+                    // TODO: only update settings that were actually changed
+                    // currently resets all "quick" settings to stored settings
                     settings ->
                 _previewUiState
                     .emit(previewUiState.value.copy(currentCameraSettings = settings))

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -38,8 +38,8 @@ import kotlinx.coroutines.launch
 private const val TAG = "PreviewViewModel"
 
 // toast test descriptions
-const val IMAGE_CAPTURE_SUCCESS_TOAST_DESC = "ImageCaptureSuccessToast"
-const val IMAGE_CAPTURE_FAIL_TOAST_DESC = "ImageCaptureFailureToast"
+const val IMAGE_CAPTURE_SUCCESS_TOAST_TAG = "ImageCaptureSuccessToast"
+const val IMAGE_CAPTURE_FAIL_TOAST_TAG = "ImageCaptureFailureToast"
 
 /**
  * [ViewModel] for [PreviewScreen].
@@ -62,8 +62,8 @@ class PreviewViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             settingsRepository.cameraAppSettings.collect {
-                    // TODO: only update settings that were actually changed
-                    // currently resets all "quick" settings to stored settings
+                // TODO: only update settings that were actually changed
+                // currently resets all "quick" settings to stored settings
                     settings ->
                 _previewUiState
                     .emit(previewUiState.value.copy(currentCameraSettings = settings))
@@ -201,8 +201,8 @@ class PreviewViewModel @Inject constructor(
                 _previewUiState.emit(
                     previewUiState.value.copy(
                         toastMessageToShow = ToastMessage(
-                            message = R.string.toast_image_capture_success.toString(),
-                            testDesc = IMAGE_CAPTURE_SUCCESS_TOAST_DESC
+                            stringResource = R.string.toast_image_capture_success,
+                            testTag = IMAGE_CAPTURE_SUCCESS_TOAST_TAG
                         )
                     )
                 )
@@ -212,8 +212,8 @@ class PreviewViewModel @Inject constructor(
                 _previewUiState.emit(
                     previewUiState.value.copy(
                         toastMessageToShow = ToastMessage(
-                            message = R.string.toast_capture_failure.toString(),
-                            testDesc = IMAGE_CAPTURE_FAIL_TOAST_DESC
+                            stringResource = R.string.toast_capture_failure,
+                            testTag = IMAGE_CAPTURE_FAIL_TOAST_TAG
                         )
                     )
                 )

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -76,9 +76,12 @@ fun ShowToast(modifier: Modifier = Modifier, toastMessage: ToastMessage, onToast
     Box(
         modifier
             .testTag(toastMessage.testTag)
-            .semantics { contentDescription = toastMessage.testDesc }
     ) {
-        Toast.makeText(LocalContext.current, toastMessage.message, toastMessage.toastLength).show()
+        Toast.makeText(
+            LocalContext.current,
+            stringResource(id = toastMessage.stringResource),
+            toastMessage.toastLength
+        ).show()
         onToastShown()
     }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.feature.preview.R

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
@@ -20,17 +20,15 @@ import android.widget.Toast
 /**
  * Helper class containing information used to create a [Toast].
  *
- * @param message the text to be displayed.
+ * @param stringResource the resource ID of to be displayed.
  * @param isLongToast determines if the display time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT].
- * @param testDesc the *unique* description to identify a specific toast message.
- * @property testTag the identifiable resource ID of a Toast on screen.
+ * @property testTag the identifiable resource ID of a [ShowToast] on screen.
  */
 class ToastMessage(
-    val message: String,
+    val stringResource: Int,
     isLongToast: Boolean = false,
-    val testDesc: String = "Toast Message"
+    val testTag: String = ""
 ) {
-    val testTag: String = "Toast Message"
     val toastLength: Int = when (isLongToast) {
         true -> Toast.LENGTH_LONG
         false -> Toast.LENGTH_SHORT


### PR DESCRIPTION
ToastMessage takes a stringResource Int instead of a string.

remove toast test descriptions to avoid potential conflict with accessibility reader