### PR TITLE
Preview screen layout refactor

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -63,7 +63,7 @@ import com.google.jetpackcamera.feature.preview.ui.SettingsNavButton
 import com.google.jetpackcamera.feature.preview.ui.ShowTestableToast
 import com.google.jetpackcamera.feature.preview.ui.TestingButton
 import com.google.jetpackcamera.feature.preview.ui.ZoomScaleText
-import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreen
+import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreenOverlay
 import com.google.jetpackcamera.feature.quicksettings.ui.QuickSettingsIndicators
 import com.google.jetpackcamera.feature.quicksettings.ui.ToggleQuickSettingsButton
 import com.google.jetpackcamera.settings.model.CaptureMode
@@ -137,8 +137,8 @@ fun PreviewScreen(
             aspectRatio = previewUiState.currentCameraSettings.aspectRatio,
             deferredSurfaceProvider = deferredSurfaceProvider
         )
-        // quick settings screen overlay
-        QuickSettingsScreen(
+
+        QuickSettingsScreenOverlay(
             modifier = Modifier,
             isOpen = previewUiState.quickSettingsIsOpen,
             toggleIsOpen = { viewModel.toggleQuickSettings() },

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -88,7 +88,7 @@ fun PreviewScreen(
     val previewUiState: PreviewUiState by viewModel.previewUiState.collectAsState()
 
     val screenFlashUiState: ScreenFlash.ScreenFlashUiState
-            by viewModel.screenFlash.screenFlashUiState.collectAsState()
+        by viewModel.screenFlash.screenFlashUiState.collectAsState()
 
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -137,7 +137,7 @@ fun PreviewScreen(
             aspectRatio = previewUiState.currentCameraSettings.aspectRatio,
             deferredSurfaceProvider = deferredSurfaceProvider
         )
-        //quick settings screen overlay
+        // quick settings screen overlay
         QuickSettingsScreen(
             modifier = Modifier,
             isOpen = previewUiState.quickSettingsIsOpen,
@@ -162,7 +162,6 @@ fun PreviewScreen(
             when (previewUiState.videoRecordingState) {
                 VideoRecordingState.ACTIVE -> {}
                 VideoRecordingState.INACTIVE -> {
-
                     // 3-segmented row to keep quick settings button centered
                     Row(
                         modifier = Modifier
@@ -182,11 +181,12 @@ fun PreviewScreen(
                                     .padding(12.dp),
                                 onNavigateToSettings = onNavigateToSettings
                             )
-                            if (!previewUiState.quickSettingsIsOpen)
+                            if (!previewUiState.quickSettingsIsOpen) {
                                 QuickSettingsIndicators(
                                     currentCameraSettings = previewUiState.currentCameraSettings,
                                     onFlashModeClick = viewModel::setFlash
                                 )
+                            }
                         }
                         // quick settings button
                         ToggleQuickSettingsButton(
@@ -208,8 +208,11 @@ fun PreviewScreen(
                                 onClick = { viewModel.toggleCaptureMode() },
                                 text = stringResource(
                                     when (previewUiState.currentCameraSettings.captureMode) {
-                                        CaptureMode.SINGLE_STREAM -> R.string.capture_mode_single_stream
-                                        CaptureMode.MULTI_STREAM -> R.string.capture_mode_multi_stream
+                                        CaptureMode.SINGLE_STREAM ->
+                                            R.string.capture_mode_single_stream
+
+                                        CaptureMode.MULTI_STREAM ->
+                                            R.string.capture_mode_multi_stream
                                     }
                                 )
                             )
@@ -218,12 +221,14 @@ fun PreviewScreen(
                 }
             }
 
-            // this component places a gap in the center of the column that will push out the top and
-            // bottom edges. This will also allow the addition of vertical button bars on the
+            // this component places a gap in the center of the column that will push out the top
+            // and bottom edges. This will also allow the addition of vertical button bars on the
             // sides of the screen
-            Row(modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()) {}
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {}
 
             if (zoomScaleShow) {
                 ZoomScaleText(zoomScale = zoomScale)
@@ -254,14 +259,16 @@ fun PreviewScreen(
                             horizontalArrangement = Arrangement.Center,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            if (!previewUiState.quickSettingsIsOpen)
+                            if (!previewUiState.quickSettingsIsOpen) {
                                 FlipCameraButton(
                                     onClick = { viewModel.flipCamera() },
                                     // enable only when phone has front and rear camera
                                     enabledCondition =
                                     previewUiState.currentCameraSettings.isBackCameraAvailable &&
-                                            previewUiState.currentCameraSettings.isFrontCameraAvailable
+                                        previewUiState.currentCameraSettings
+                                            .isFrontCameraAvailable
                                 )
+                            }
                         }
                     }
                 }
@@ -272,13 +279,15 @@ fun PreviewScreen(
                         .testTag(CAPTURE_BUTTON),
                     onClick = {
                         multipleEventsCutter.processEvent { viewModel.captureImage() }
-                        if (previewUiState.quickSettingsIsOpen)
+                        if (previewUiState.quickSettingsIsOpen) {
                             viewModel.toggleQuickSettings()
+                        }
                     },
                     onLongPress = {
                         viewModel.startVideoRecording()
-                        if (previewUiState.quickSettingsIsOpen)
+                        if (previewUiState.quickSettingsIsOpen) {
                             viewModel.toggleQuickSettings()
+                        }
                     },
                     onRelease = { viewModel.stopVideoRecording() },
                     videoRecordingState = previewUiState.videoRecordingState

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -30,8 +30,12 @@ import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -58,6 +62,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.jetpackcamera.feature.preview.MultipleEventsCutter
 import com.google.jetpackcamera.feature.preview.R
 import com.google.jetpackcamera.feature.preview.VideoRecordingState
 import com.google.jetpackcamera.settings.model.AspectRatio
@@ -202,10 +207,8 @@ fun FlipCameraButton(
     enabledCondition: Boolean,
     onClick: () -> Unit
 ) {
-    Box(modifier = modifier) {
         IconButton(
-            modifier = Modifier
-                .align(Alignment.Center)
+            modifier = modifier
                 .size(40.dp),
             onClick = onClick,
             enabled = enabledCondition
@@ -217,7 +220,6 @@ fun FlipCameraButton(
                 modifier = Modifier.size(72.dp)
             )
         }
-    }
 }
 
 @Composable

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -30,12 +30,8 @@ import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -62,7 +58,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.jetpackcamera.feature.preview.MultipleEventsCutter
 import com.google.jetpackcamera.feature.preview.R
 import com.google.jetpackcamera.feature.preview.VideoRecordingState
 import com.google.jetpackcamera.settings.model.AspectRatio
@@ -207,19 +202,19 @@ fun FlipCameraButton(
     enabledCondition: Boolean,
     onClick: () -> Unit
 ) {
-        IconButton(
-            modifier = modifier
-                .size(40.dp),
-            onClick = onClick,
-            enabled = enabledCondition
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Refresh,
-                tint = Color.White,
-                contentDescription = stringResource(id = R.string.flip_camera_content_description),
-                modifier = Modifier.size(72.dp)
-            )
-        }
+    IconButton(
+        modifier = modifier
+            .size(40.dp),
+        onClick = onClick,
+        enabled = enabledCondition
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Refresh,
+            tint = Color.White,
+            contentDescription = stringResource(id = R.string.flip_camera_content_description),
+            modifier = Modifier.size(72.dp)
+        )
+    }
 }
 
 @Composable

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import com.google.jetpackcamera.feature.quicksettings.ui.DropDownIcon
 import com.google.jetpackcamera.feature.quicksettings.ui.ExpandedQuickSetRatio
 import com.google.jetpackcamera.feature.quicksettings.ui.QuickFlipCamera
 import com.google.jetpackcamera.feature.quicksettings.ui.QuickSetFlash
@@ -115,11 +114,6 @@ fun QuickSettingsScreen(
     } else {
         shouldShowQuickSetting = IsExpandedQuickSetting.NONE
     }
-    DropDownIcon(
-        modifier = modifier,
-        toggleDropDown = toggleIsOpen,
-        isOpen = isOpen
-    )
 }
 
 // enum representing which individual quick setting is currently expanded

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -53,7 +53,7 @@ import com.google.jetpackcamera.settings.model.FlashMode
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun QuickSettingsScreen(
+fun QuickSettingsScreenOverlay(
     modifier: Modifier = Modifier,
     currentCameraSettings: CameraAppSettings,
     isOpen: Boolean = false,

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -164,8 +164,11 @@ fun QuickFlipCamera(
     )
 }
 
+/**
+ * Button to toggle quick settings
+ */
 @Composable
-fun DropDownIcon(modifier: Modifier = Modifier, toggleDropDown: () -> Unit, isOpen: Boolean) {
+fun ToggleQuickSettingsButton(modifier: Modifier = Modifier, toggleDropDown: () -> Unit, isOpen: Boolean) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.Center,

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -168,7 +168,11 @@ fun QuickFlipCamera(
  * Button to toggle quick settings
  */
 @Composable
-fun ToggleQuickSettingsButton(modifier: Modifier = Modifier, toggleDropDown: () -> Unit, isOpen: Boolean) {
+fun ToggleQuickSettingsButton(
+    modifier: Modifier = Modifier,
+    toggleDropDown: () -> Unit,
+    isOpen: Boolean
+) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.Center,


### PR DESCRIPTION
**Low priority**
when working on adding an icon in the preview screen for [pr #83](https://github.com/google/jetpack-camera-app/pull/83), I noticed it was a bit difficult to "neatly" insert new elements into the top bar; I made a small refactor to `previewScreen` to make it easier to do so. This will facilitate the addition of future potential elements to the preview screen such as a vertical side bar. 

Most important about the change:
* Preview screen buttons/icons overlay layer has more of a grid-relative layout -- no more free-floating elements in boxes 🎈 
* Top row of icons is a 3-segmented row similar to how the bottom row was implemented
* `QuickSettingsScreen` has been decoupled from its toggle button

Screenshots below use colors to show how the overlay is divided
Magenta = parent column
Green/Blue = rows within the column (the center "empty" space between them is currently a placeholder spacer element)
Grays = shows how the rows are divided
<img width="100" alt="Screenshot 2024-01-12 at 9 40 44 AM" src="https://github.com/google/jetpack-camera-app/assets/20013168/2b7534c6-62eb-4d0d-b654-cb6a213e44fd"> <img width="107" alt="Screenshot 2024-01-12 at 9 45 58 AM" src="https://github.com/google/jetpack-camera-app/assets/20013168/38df22a9-021b-46fb-8e87-5f05c323d6dc"> <img width="100" alt="Screenshot 2024-01-12 at 9 53 14 AM" src="https://github.com/google/jetpack-camera-app/assets/20013168/d7387eaa-7d45-4397-a4cb-cb1e44d033b7">

