### PR TITLE
fix dependency issue causing test failures in :data:settings

### DIFF
--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -56,10 +56,9 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     implementation(libs.kotlinx.coroutines.core)
-    androidTestImplementation(libs.kotlinx.coroutines.core)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-
     // Hilt
     implementation(libs.dagger.hilt.android)
     kapt(libs.dagger.hilt.compiler)


### PR DESCRIPTION
there was a typo in `data/settings/build.gradle.kts` when migrating to version catalogs in #95 