### PR TITLE
Update copyright header year in spotless

### DIFF
--- a/spotless/copyright.kt
+++ b/spotless/copyright.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) $YEAR The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spotless/copyright.kts
+++ b/spotless/copyright.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) $YEAR The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spotless/copyright.xml
+++ b/spotless/copyright.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (C) 2023 The Android Open Source Project
+  ~ Copyright (C) $YEAR The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
 The year will now be updated to the current year rather than
 being changed back to 2023 by spotlessApply
![robin-williams](https://github.com/google/jetpack-camera-app/assets/1455403/3d93d4d5-0ea4-4ceb-9d65-0ba822b75fc9)


