### PR TITLE
Single source of truth for camera settings

### DIFF
--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -30,7 +30,8 @@ data class CameraAppSettings(
     val videoCaptureStabilization: Stabilization = Stabilization.UNDEFINED,
     val supportedStabilizationModes: List<SupportedStabilizationMode> = emptyList(),
     val dynamicRange: DynamicRange = DynamicRange.SDR,
-    val supportedDynamicRanges: List<DynamicRange> = listOf(DynamicRange.SDR)
+    val supportedDynamicRanges: List<DynamicRange> = listOf(DynamicRange.SDR),
+    val zoomScale: Float = 1f
 )
 
 val DEFAULT_CAMERA_APP_SETTINGS = CameraAppSettings()

--- a/domain/camera/build.gradle.kts
+++ b/domain/camera/build.gradle.kts
@@ -54,10 +54,11 @@ android {
 dependencies {
     // Testing
     testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
+    testImplementation(libs.truth)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("org.mockito:mockito-core:5.2.0")
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 
     // Futures
     implementation(libs.futures.ktx)

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -36,17 +36,17 @@ interface CameraUseCase {
      *
      * @return list of available lenses.
      */
-    suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int>
+    suspend fun initialize()
 
     /**
-     * Starts the camera with given [CameraAppSettings].
+     * Starts the camera.
      *
      * This will start to configure the camera, but frames won't stream until a [SurfaceRequest]
      * from [getSurfaceRequest] has been fulfilled.
      *
      * The camera will run until the calling coroutine is cancelled.
      */
-    suspend fun runCamera(currentCameraSettings: CameraAppSettings)
+    suspend fun runCamera()
 
     suspend fun takePicture()
 
@@ -64,13 +64,15 @@ interface CameraUseCase {
 
     fun getScreenFlashEvents(): SharedFlow<ScreenFlashEvent>
 
-    fun setFlashMode(flashMode: SettingsFlashMode, isFrontFacing: Boolean)
+    fun getCurrentSettings(): StateFlow<CameraAppSettings?>
+
+    fun setFlashMode(flashMode: SettingsFlashMode)
 
     fun isScreenFlashEnabled(): Boolean
 
-    suspend fun setAspectRatio(aspectRatio: SettingsAspectRatio, isFrontFacing: Boolean)
+    suspend fun setAspectRatio(aspectRatio: SettingsAspectRatio)
 
-    suspend fun flipCamera(isFrontFacing: Boolean, flashMode: SettingsFlashMode)
+    suspend fun flipCamera(isFrontFacing: Boolean)
 
     fun tapToFocus(display: Display, surfaceWidth: Int, surfaceHeight: Int, x: Float, y: Float)
 

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -134,7 +134,7 @@ constructor(
         val aspectRatio: AspectRatio,
         val captureMode: CaptureMode,
         val stabilizePreviewMode: Stabilization,
-        val stabilizeVideoMode: Stabilization,
+        val stabilizeVideoMode: Stabilization
     )
 
     /**
@@ -222,7 +222,7 @@ constructor(
                             setFlashModeInternal(
                                 flashMode = newTransientSettings.flashMode,
                                 isFrontFacing = sessionSettings.cameraSelector
-                                        == CameraSelector.DEFAULT_FRONT_CAMERA
+                                    == CameraSelector.DEFAULT_FRONT_CAMERA
                             )
                         }
 

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -17,7 +17,6 @@ package com.google.jetpackcamera.domain.camera.test
 
 import android.content.ContentResolver
 import android.net.Uri
-import android.util.Log
 import android.view.Display
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.SurfaceRequest
@@ -81,12 +80,10 @@ class FakeCameraUseCase(
 
         currentSettings
             .onCompletion {
-                Log.e("TDBGTAG", "Completed.")
                 useCasesBinded = false
                 previewStarted = false
                 recordingInProgress = false
             }.collectLatest {
-                Log.e("TDBGTAG", "Started.")
                 useCasesBinded = true
                 previewStarted = true
 
@@ -160,6 +157,8 @@ class FakeCameraUseCase(
     }
 
     override fun isScreenFlashEnabled() = isScreenFlash
+
+    fun isPreviewStarted() = previewStarted
 
     override suspend fun setAspectRatio(aspectRatio: AspectRatio) {
         currentSettings.update { old ->

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -36,7 +36,8 @@ import kotlinx.coroutines.launch
 
 class FakeCameraUseCase(
     private val coroutineScope: CoroutineScope =
-        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    private val currentCameraSettings: CameraAppSettings = CameraAppSettings()
 ) : CameraUseCase {
     private val availableLenses =
         listOf(CameraSelector.LENS_FACING_FRONT, CameraSelector.LENS_FACING_BACK)
@@ -56,15 +57,14 @@ class FakeCameraUseCase(
     private var isScreenFlash = true
     private var screenFlashEvents = MutableSharedFlow<CameraUseCase.ScreenFlashEvent>()
 
-    override suspend fun initialize(currentCameraSettings: CameraAppSettings): List<Int> {
+    override suspend fun initialize() {
         initialized = true
         flashMode = currentCameraSettings.flashMode
         isLensFacingFront = currentCameraSettings.isFrontCameraFacing
         aspectRatio = currentCameraSettings.aspectRatio
-        return availableLenses
     }
 
-    override suspend fun runCamera(currentCameraSettings: CameraAppSettings) {
+    override suspend fun runCamera() {
         val lensFacing =
             when (currentCameraSettings.isFrontCameraFacing) {
                 true -> CameraSelector.LENS_FACING_FRONT
@@ -128,10 +128,12 @@ class FakeCameraUseCase(
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
     override fun getScreenFlashEvents() = screenFlashEvents
+    override fun getCurrentSettings(): StateFlow<CameraAppSettings?> {
+        TODO("Not yet implemented")
+    }
 
-    override fun setFlashMode(flashMode: FlashMode, isFrontFacing: Boolean) {
+    override fun setFlashMode(flashMode: FlashMode) {
         this.flashMode = flashMode
-        isLensFacingFront = isFrontFacing
 
         isScreenFlash =
             isLensFacingFront && (flashMode == FlashMode.AUTO || flashMode == FlashMode.ON)
@@ -139,11 +141,11 @@ class FakeCameraUseCase(
 
     override fun isScreenFlashEnabled() = isScreenFlash
 
-    override suspend fun setAspectRatio(aspectRatio: AspectRatio, isFrontFacing: Boolean) {
+    override suspend fun setAspectRatio(aspectRatio: AspectRatio) {
         this.aspectRatio = aspectRatio
     }
 
-    override suspend fun flipCamera(isFrontFacing: Boolean, flashMode: FlashMode) {
+    override suspend fun flipCamera(isFrontFacing: Boolean) {
         isLensFacingFront = isFrontFacing
     }
 

--- a/domain/camera/src/test/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCaseTest.kt
+++ b/domain/camera/src/test/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCaseTest.kt
@@ -16,7 +16,6 @@
 package com.google.jetpackcamera.domain.camera.test
 
 import com.google.jetpackcamera.domain.camera.CameraUseCase
-import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,7 +52,7 @@ class FakeCameraUseCaseTest {
 
     @Test
     fun canInitialize() = runTest(testDispatcher) {
-        cameraUseCase.initialize(DEFAULT_CAMERA_APP_SETTINGS)
+        cameraUseCase.initialize()
     }
 
     @Test
@@ -65,7 +64,8 @@ class FakeCameraUseCaseTest {
     fun screenFlashDisabled_whenFlashModeOffAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON, isFrontFacing = false)
+        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setFlashMode(flashMode = FlashMode.OFF)
 
         assertEquals(false, cameraUseCase.isScreenFlashEnabled())
     }
@@ -74,7 +74,8 @@ class FakeCameraUseCaseTest {
     fun screenFlashDisabled_whenFlashModeOnAndNotFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON, isFrontFacing = false)
+        cameraUseCase.flipCamera(isFrontFacing = false)
+        cameraUseCase.setFlashMode(flashMode = FlashMode.ON)
 
         assertEquals(false, cameraUseCase.isScreenFlashEnabled())
     }
@@ -83,7 +84,8 @@ class FakeCameraUseCaseTest {
     fun screenFlashDisabled_whenFlashModeAutoAndNotFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON, isFrontFacing = false)
+        cameraUseCase.flipCamera(isFrontFacing = false)
+        cameraUseCase.setFlashMode(flashMode = FlashMode.AUTO)
 
         assertEquals(false, cameraUseCase.isScreenFlashEnabled())
     }
@@ -92,7 +94,8 @@ class FakeCameraUseCaseTest {
     fun screenFlashEnabled_whenFlashModeOnAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON, isFrontFacing = true)
+        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setFlashMode(flashMode = FlashMode.ON)
 
         assertEquals(true, cameraUseCase.isScreenFlashEnabled())
     }
@@ -101,7 +104,8 @@ class FakeCameraUseCaseTest {
     fun screenFlashEnabled_whenFlashModeAutoAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON, isFrontFacing = true)
+        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setFlashMode(flashMode = FlashMode.AUTO)
 
         assertEquals(true, cameraUseCase.isScreenFlashEnabled())
     }
@@ -117,7 +121,8 @@ class FakeCameraUseCaseTest {
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash
-        cameraUseCase.setFlashMode(FlashMode.ON, true)
+        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setFlashMode(FlashMode.ON)
         cameraUseCase.takePicture()
 
         advanceUntilIdle()
@@ -131,7 +136,7 @@ class FakeCameraUseCaseTest {
     }
 
     private suspend fun initAndRunCamera() {
-        cameraUseCase.initialize(DEFAULT_CAMERA_APP_SETTINGS)
-        cameraUseCase.runCamera(DEFAULT_CAMERA_APP_SETTINGS)
+        cameraUseCase.initialize()
+        cameraUseCase.runCamera()
     }
 }

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -61,6 +61,10 @@ android {
             isIncludeAndroidResources = true
         }
     }
+
+    kotlinOptions {
+        freeCompilerArgs += "-Xcontext-receivers"
+    }
 }
 
 dependencies {
@@ -92,13 +96,14 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
+    testImplementation(libs.truth)
     testImplementation(libs.mockito.core)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     debugImplementation(libs.androidx.test.monitor)
     implementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 
     // Futures
     implementation(libs.futures.ktx)

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -127,15 +127,13 @@ class PreviewViewModel @Inject constructor(
     }
 
     fun setAspectRatio(aspectRatio: AspectRatio) {
-        stopCamera()
-        runningCameraJob = viewModelScope.launch {
+        viewModelScope.launch {
             cameraUseCase.setAspectRatio(aspectRatio)
         }
     }
 
     fun toggleCaptureMode() {
-        stopCamera()
-        runningCameraJob = viewModelScope.launch {
+        viewModelScope.launch {
             val newCaptureMode = when (previewUiState.value.currentCameraSettings.captureMode) {
                 CaptureMode.MULTI_STREAM -> CaptureMode.SINGLE_STREAM
                 CaptureMode.SINGLE_STREAM -> CaptureMode.MULTI_STREAM
@@ -147,8 +145,7 @@ class PreviewViewModel @Inject constructor(
 
     // sets the camera to a designated direction
     fun flipCamera() {
-        stopCamera()
-        runningCameraJob = viewModelScope.launch {
+        viewModelScope.launch {
             // only flip if 2 directions are available
             if (previewUiState.value.currentCameraSettings.isBackCameraAvailable &&
                 previewUiState.value.currentCameraSettings.isFrontCameraAvailable

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -54,7 +54,7 @@ const val IMAGE_CAPTURE_FAIL_TOAST_TAG = "ImageCaptureFailureToast"
  */
 @HiltViewModel
 class PreviewViewModel @Inject constructor(
-    private val cameraUseCase: CameraUseCase,
+    private val cameraUseCase: CameraUseCase
 ) : ViewModel() {
     private val _previewUiState: MutableStateFlow<PreviewUiState> =
         MutableStateFlow(PreviewUiState(currentCameraSettings = DEFAULT_CAMERA_APP_SETTINGS))

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -16,13 +16,13 @@
 package com.google.jetpackcamera.feature.preview
 
 import android.content.ContentResolver
+import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.domain.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.settings.model.FlashMode
-import com.google.jetpackcamera.settings.test.FakeSettingsRepository
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -39,7 +39,7 @@ class PreviewViewModelTest {
     @Before
     fun setup() = runTest(StandardTestDispatcher()) {
         Dispatchers.setMain(StandardTestDispatcher())
-        previewViewModel = PreviewViewModel(cameraUseCase, FakeSettingsRepository)
+        previewViewModel = PreviewViewModel(cameraUseCase)
         advanceUntilIdle()
     }
 
@@ -47,49 +47,48 @@ class PreviewViewModelTest {
     fun getPreviewUiState() = runTest(StandardTestDispatcher()) {
         advanceUntilIdle()
         val uiState = previewViewModel.previewUiState.value
-        assertEquals(CameraState.READY, uiState.cameraState)
+        assertThat(uiState.cameraState).isEqualTo(CameraState.READY)
     }
 
     @Test
     fun runCamera() = runTest(StandardTestDispatcher()) {
-        previewViewModel.startCamera()
-        advanceUntilIdle()
+        previewViewModel.startCameraUntilRunning()
 
-        assertEquals(cameraUseCase.previewStarted, true)
+        assertThat(cameraUseCase.previewStarted).isTrue()
     }
 
     @Test
     fun captureImage() = runTest(StandardTestDispatcher()) {
-        previewViewModel.startCamera()
+        previewViewModel.startCameraUntilRunning()
         previewViewModel.captureImage()
         advanceUntilIdle()
-        assertEquals(cameraUseCase.numPicturesTaken, 1)
+        assertThat(cameraUseCase.numPicturesTaken).isEqualTo(1)
     }
 
     @Test
     fun captureImageWithUri() = runTest(StandardTestDispatcher()) {
         val contentResolver: ContentResolver = mock()
-        previewViewModel.startCamera()
+        previewViewModel.startCameraUntilRunning()
         previewViewModel.captureImageWithUri(contentResolver, null) {}
         advanceUntilIdle()
-        assertEquals(cameraUseCase.numPicturesTaken, 1)
+        assertThat(cameraUseCase.numPicturesTaken).isEqualTo(1)
     }
 
     @Test
     fun startVideoRecording() = runTest(StandardTestDispatcher()) {
-        previewViewModel.startCamera()
+        previewViewModel.startCameraUntilRunning()
         previewViewModel.startVideoRecording()
         advanceUntilIdle()
-        assertEquals(cameraUseCase.recordingInProgress, true)
+        assertThat(cameraUseCase.recordingInProgress).isTrue()
     }
 
     @Test
     fun stopVideoRecording() = runTest(StandardTestDispatcher()) {
-        previewViewModel.startCamera()
+        previewViewModel.startCameraUntilRunning()
         previewViewModel.startVideoRecording()
         advanceUntilIdle()
         previewViewModel.stopVideoRecording()
-        assertEquals(cameraUseCase.recordingInProgress, false)
+        assertThat(cameraUseCase.recordingInProgress).isFalse()
     }
 
     @Test
@@ -97,28 +96,28 @@ class PreviewViewModelTest {
         previewViewModel.startCamera()
         previewViewModel.setFlash(FlashMode.AUTO)
         advanceUntilIdle()
-        assertEquals(
-            previewViewModel.previewUiState.value.currentCameraSettings.flashMode,
-            FlashMode.AUTO
-        )
+        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.flashMode)
+            .isEqualTo(FlashMode.AUTO)
     }
 
     @Test
     fun flipCamera() = runTest(StandardTestDispatcher()) {
         // initial default value should be back
         previewViewModel.startCamera()
-        assertEquals(
-            previewViewModel.previewUiState.value.currentCameraSettings.isFrontCameraFacing,
-            false
-        )
+        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.isFrontCameraFacing)
+            .isFalse()
         previewViewModel.flipCamera()
 
         advanceUntilIdle()
         // ui state and camera should both be true now
-        assertEquals(
-            previewViewModel.previewUiState.value.currentCameraSettings.isFrontCameraFacing,
-            true
-        )
-        assertEquals(true, cameraUseCase.isLensFacingFront)
+        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.isFrontCameraFacing)
+            .isTrue()
+        assertThat(cameraUseCase.isLensFacingFront).isTrue()
+    }
+
+    context(TestScope)
+    private fun PreviewViewModel.startCameraUntilRunning() {
+        startCamera()
+        advanceUntilIdle()
     }
 }

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -70,14 +69,13 @@ class ScreenFlashTest {
         cameraUseCase.takePicture(contentResolver, null)
 
         advanceUntilIdle()
-        assertEquals(
+        assertThat(states.map { it.enabled }).containsExactlyElementsIn(
             listOf(
                 false,
                 true,
                 false
-            ),
-            states.map { it.enabled }
-        )
+            )
+        ).inOrder()
     }
 
     @Test
@@ -88,10 +86,9 @@ class ScreenFlashTest {
         )
 
         advanceUntilIdle()
-        assertEquals(
-            5.0f,
-            screenFlash.screenFlashUiState.value.screenBrightnessToRestore
-        )
+        assertThat(screenFlash.screenFlashUiState.value.screenBrightnessToRestore)
+            .isWithin(FLOAT_TOLERANCE)
+            .of(5.0f)
     }
 
     @Test
@@ -105,10 +102,8 @@ class ScreenFlashTest {
         screenFlash.screenFlashUiState.value.onChangeComplete()
 
         advanceUntilIdle()
-        assertEquals(
-            ScreenFlash.ScreenFlashUiState(),
-            screenFlash.screenFlashUiState.value
-        )
+        assertThat(ScreenFlash.ScreenFlashUiState())
+            .isEqualTo(screenFlash.screenFlashUiState.value)
     }
 
     private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
@@ -118,5 +113,9 @@ class ScreenFlashTest {
         }
 
         testBody()
+    }
+
+    companion object {
+        const val FLOAT_TOLERANCE = 0.001f
     }
 }

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -16,10 +16,10 @@
 package com.google.jetpackcamera.feature.preview
 
 import android.content.ContentResolver
+import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.domain.camera.CameraUseCase
 import com.google.jetpackcamera.domain.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.feature.preview.rules.MainDispatcherRule
-import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -49,70 +49,74 @@ class ScreenFlashTest {
     @Before
     fun setup() = runTest(testDispatcher) {
         screenFlash = ScreenFlash(cameraUseCase, testScope)
-
-        cameraUseCase.initialize(DEFAULT_CAMERA_APP_SETTINGS)
-        cameraUseCase.runCamera(DEFAULT_CAMERA_APP_SETTINGS)
     }
 
     @Test
     fun initialScreenFlashUiState_disabledByDefault() {
-        assertEquals(false, screenFlash.screenFlashUiState.value.enabled)
+        assertThat(screenFlash.screenFlashUiState.value.enabled).isFalse()
     }
 
     @Test
-    fun captureScreenFlashImage_screenFlashUiStateChangedInCorrectSequence() =
-        runTest(testDispatcher) {
-            val states = mutableListOf<ScreenFlash.ScreenFlashUiState>()
-            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-                screenFlash.screenFlashUiState.toList(states)
-            }
-
-            // FlashMode.ON in front facing camera automatically enables screen flash
-            cameraUseCase.setFlashMode(FlashMode.ON, true)
-            val contentResolver: ContentResolver = Mockito.mock()
-            cameraUseCase.takePicture(contentResolver, null)
-
-            advanceUntilIdle()
-            assertEquals(
-                listOf(
-                    false,
-                    true,
-                    false
-                ),
-                states.map { it.enabled }
-            )
+    fun captureScreenFlashImage_screenFlashUiStateChangedInCorrectSequence() = runCameraTest {
+        val states = mutableListOf<ScreenFlash.ScreenFlashUiState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            screenFlash.screenFlashUiState.toList(states)
         }
+
+        // FlashMode.ON in front facing camera automatically enables screen flash
+        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setFlashMode(FlashMode.ON)
+        val contentResolver: ContentResolver = Mockito.mock()
+        cameraUseCase.takePicture(contentResolver, null)
+
+        advanceUntilIdle()
+        assertEquals(
+            listOf(
+                false,
+                true,
+                false
+            ),
+            states.map { it.enabled }
+        )
+    }
 
     @Test
-    fun emitClearUiEvent_screenFlashUiStateContainsClearUiScreenBrightness() =
-        runTest(testDispatcher) {
-            screenFlash.setClearUiScreenBrightness(5.0f)
-            cameraUseCase.emitScreenFlashEvent(
-                CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
-            )
+    fun emitClearUiEvent_screenFlashUiStateContainsClearUiScreenBrightness() = runCameraTest {
+        screenFlash.setClearUiScreenBrightness(5.0f)
+        cameraUseCase.emitScreenFlashEvent(
+            CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
+        )
 
-            advanceUntilIdle()
-            assertEquals(
-                5.0f,
-                screenFlash.screenFlashUiState.value.screenBrightnessToRestore
-            )
-        }
+        advanceUntilIdle()
+        assertEquals(
+            5.0f,
+            screenFlash.screenFlashUiState.value.screenBrightnessToRestore
+        )
+    }
 
     @Test
-    fun invokeOnChangeCompleteAfterClearUiEvent_screenFlashUiStateReset() =
-        runTest(testDispatcher) {
-            screenFlash.setClearUiScreenBrightness(5.0f)
-            cameraUseCase.emitScreenFlashEvent(
-                CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
-            )
+    fun invokeOnChangeCompleteAfterClearUiEvent_screenFlashUiStateReset() = runCameraTest {
+        screenFlash.setClearUiScreenBrightness(5.0f)
+        cameraUseCase.emitScreenFlashEvent(
+            CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
+        )
 
-            advanceUntilIdle()
-            screenFlash.screenFlashUiState.value.onChangeComplete()
+        advanceUntilIdle()
+        screenFlash.screenFlashUiState.value.onChangeComplete()
 
-            advanceUntilIdle()
-            assertEquals(
-                ScreenFlash.ScreenFlashUiState(),
-                screenFlash.screenFlashUiState.value
-            )
+        advanceUntilIdle()
+        assertEquals(
+            ScreenFlash.ScreenFlashUiState(),
+            screenFlash.screenFlashUiState.value
+        )
+    }
+
+    private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            cameraUseCase.initialize()
+            cameraUseCase.runCamera()
         }
+
+        testBody()
+    }
 }


### PR DESCRIPTION
- Update CameraUseCase to reactive model
- CameraUseCase is only place where default settings will be applied
- PreviewViewModel should not edit CameraAppState
- Setting aspect ratio and flipping camera no longer restarts camera job
