### PR TITLE
Pop from back stack when Settings back arrow is pressed

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ComposeTestRuleExt.kt
@@ -17,10 +17,13 @@ package com.google.jetpackcamera
 
 import android.content.Context
 import androidx.annotation.StringRes
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.printToString
 import androidx.test.core.app.ApplicationProvider
+import org.junit.AssumptionViolatedException
 
 /**
  * Allows use of testRule.onNodeWithText that uses an integer string resource
@@ -31,3 +34,48 @@ fun SemanticsNodeInteractionsProvider.onNodeWithText(
 ): SemanticsNodeInteraction = onNodeWithText(
     text = ApplicationProvider.getApplicationContext<Context>().getString(strRes)
 )
+
+/**
+ * Assumes that the provided [matcher] is satisfied for this node.
+ *
+ * This is equivalent to [SemanticsNodeInteraction.assert()], but will skip the test rather than
+ * fail the test.
+ *
+ * @param matcher Matcher to verify.
+ * @param messagePrefixOnError Prefix to be put in front of an error that gets thrown in case this
+ * assert fails. This can be helpful in situations where this assert fails as part of a bigger
+ * operation that used this assert as a precondition check.
+ *
+ * @throws AssumptionViolatedException if the matcher does not match or the node can no
+ * longer be found
+ */
+fun SemanticsNodeInteraction.assume(
+    matcher: SemanticsMatcher,
+    messagePrefixOnError: (() -> String)? = null
+): SemanticsNodeInteraction {
+    var errorMessageOnFail = "Failed to assume the following: (${matcher.description})"
+    if (messagePrefixOnError != null) {
+        errorMessageOnFail = messagePrefixOnError() + "\n" + errorMessageOnFail
+    }
+    val node = fetchSemanticsNode(errorMessageOnFail)
+    if (!matcher.matches(node)) {
+        throw AssumptionViolatedException(
+            buildGeneralErrorMessage(errorMessageOnFail, this)
+        )
+    }
+    return this
+}
+
+internal fun buildGeneralErrorMessage(
+    errorMessage: String,
+    nodeInteraction: SemanticsNodeInteraction
+): String {
+    val sb = StringBuilder()
+
+    sb.appendLine(errorMessage)
+
+    sb.appendLine("Semantics of the node:")
+    sb.appendLine(nodeInteraction.printToString())
+
+    return sb.toString()
+}

--- a/app/src/androidTest/java/com/google/jetpackcamera/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ComposeTestRuleExt.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+
+/**
+ * Allows use of testRule.onNodeWithText that uses an integer string resource
+ * rather than a [String] directly.
+ */
+fun SemanticsNodeInteractionsProvider.onNodeWithText(
+    @StringRes strRes: Int
+): SemanticsNodeInteraction = onNodeWithText(
+    text = ApplicationProvider.getApplicationContext<Context>().getString(strRes)
+)

--- a/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera
+
+import android.app.Activity
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
+import com.google.jetpackcamera.feature.preview.ui.CAPTURE_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.SETTINGS_BUTTON
+import com.google.jetpackcamera.settings.ui.BACK_BUTTON
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NavigationTest {
+    @get:Rule
+    val cameraPermissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val uiDevice = UiDevice.getInstance(instrumentation)
+
+    @Test
+    fun backAfterReturnFromSettings_doesNotReturnToSettings() = runScenarioTest<MainActivity> {
+        // Wait for the capture button to be displayed
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).isDisplayed()
+        }
+
+        // Navigate to the settings screen
+        composeTestRule.onNodeWithTag(SETTINGS_BUTTON).apply {
+            assertExists()
+            performClick()
+        }
+
+        // Navigate back using the button
+        composeTestRule.onNodeWithTag(BACK_BUTTON).apply {
+            assertExists()
+            performClick()
+        }
+
+        // Assert we're on PreviewScreen by finding the capture button
+        composeTestRule.onNodeWithTag(CAPTURE_BUTTON).apply {
+            assertExists()
+        }
+
+        // Press the device's back button
+        uiDevice.pressBack()
+
+        // Assert we do not see the settings screen based on the title
+        composeTestRule.onNodeWithText(
+            com.google.jetpackcamera.settings.R.string.settings_title
+        ).assertDoesNotExist()
+    }
+
+    private inline fun <reified T : Activity> runScenarioTest(
+        crossinline block: ActivityScenario<T>.() -> Unit
+    ) {
+        ActivityScenario.launch(T::class.java).use { scenario ->
+            scenario.apply(block)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera
 
 import android.app.Activity
 import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -26,6 +27,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import com.google.jetpackcamera.feature.preview.ui.CAPTURE_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.FLIP_CAMERA_BUTTON
 import com.google.jetpackcamera.feature.preview.ui.SETTINGS_BUTTON
 import com.google.jetpackcamera.settings.ui.BACK_BUTTON
 import org.junit.Rule
@@ -52,21 +54,17 @@ class NavigationTest {
         }
 
         // Navigate to the settings screen
-        composeTestRule.onNodeWithTag(SETTINGS_BUTTON).apply {
-            assertExists()
-            performClick()
-        }
+        composeTestRule.onNodeWithTag(SETTINGS_BUTTON)
+            .assertExists()
+            .performClick()
 
         // Navigate back using the button
-        composeTestRule.onNodeWithTag(BACK_BUTTON).apply {
-            assertExists()
-            performClick()
-        }
+        composeTestRule.onNodeWithTag(BACK_BUTTON)
+            .assertExists()
+            .performClick()
 
         // Assert we're on PreviewScreen by finding the capture button
-        composeTestRule.onNodeWithTag(CAPTURE_BUTTON).apply {
-            assertExists()
-        }
+        composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists()
 
         // Press the device's back button
         uiDevice.pressBack()
@@ -75,6 +73,35 @@ class NavigationTest {
         composeTestRule.onNodeWithText(
             com.google.jetpackcamera.settings.R.string.settings_title
         ).assertDoesNotExist()
+    }
+
+    // Test to ensure we haven't regressed to the cause of
+    // https://github.com/google/jetpack-camera-app/pull/28
+    @Test
+    fun returnFromSettings_afterFlipCamera_returnsToPreview() = runScenarioTest<MainActivity> {
+        // Wait for the capture button to be displayed
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).isDisplayed()
+        }
+
+        // If flipping the camera is available, flip it. Otherwise skip test.
+        composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON)
+            .assume(isEnabled()) {
+                "Device does not have multiple cameras to flip between."
+            }.performClick()
+
+        // Navigate to the settings screen
+        composeTestRule.onNodeWithTag(SETTINGS_BUTTON)
+            .assertExists()
+            .performClick()
+
+        // Navigate back using the button
+        composeTestRule.onNodeWithTag(BACK_BUTTON)
+            .assertExists()
+            .performClick()
+
+        // Assert we're on PreviewScreen by finding the capture button
+        composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists()
     }
 
     private inline fun <reified T : Activity> runScenarioTest(

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -72,7 +72,7 @@ private fun JetpackCameraNavHost(
         }
         composable(SETTINGS_ROUTE) {
             SettingsScreen(
-                onNavigateToPreview = { navController.navigate(PREVIEW_ROUTE) }
+                onNavigateBack = { navController.popBackStack() }
             )
         }
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -145,7 +145,10 @@ private fun ControlsTop(
     Row(modifier, verticalAlignment = Alignment.CenterVertically) {
         Row(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
             // button to open default settings page
-            SettingsNavButton(Modifier.padding(12.dp), onNavigateToSettings)
+            SettingsNavButton(
+                Modifier.padding(12.dp).testTag(SETTINGS_BUTTON),
+                onNavigateToSettings
+            )
             if (!isQuickSettingsOpen) {
                 QuickSettingsIndicators(
                     currentFlashMode = currentCameraSettings.flashMode,

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/TestTags.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/TestTags.kt
@@ -17,4 +17,4 @@ package com.google.jetpackcamera.feature.preview.ui
 
 const val CAPTURE_BUTTON = "CaptureButton"
 const val SETTINGS_BUTTON = "SettingsButton"
-const val DEFAULT_CAMERA_FACING_SETTING = "SetDefaultCameraFacingSwitch"
+const val FLIP_CAMERA_BUTTON = "FlipCameraButton"

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -37,10 +37,7 @@ import com.google.jetpackcamera.settings.ui.StabilizationSetting
  * Screen used for the Settings feature.
  */
 @Composable
-fun SettingsScreen(
-    viewModel: SettingsViewModel = hiltViewModel(),
-    onNavigateToPreview: () -> Unit
-) {
+fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel(), onNavigateBack: () -> Unit) {
     val settingsUiState by viewModel.settingsUiState.collectAsState()
 
     Column(
@@ -49,7 +46,7 @@ fun SettingsScreen(
     ) {
         SettingsPageHeader(
             title = stringResource(id = R.string.settings_title),
-            navBack = onNavigateToPreview
+            navBack = onNavigateBack
         )
         SettingsList(uiState = settingsUiState, viewModel = viewModel)
     }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -70,7 +71,10 @@ fun SettingsPageHeader(modifier: Modifier = Modifier, title: String, navBack: ()
             Text(title)
         },
         navigationIcon = {
-            IconButton(onClick = { navBack() }) {
+            IconButton(
+                modifier = Modifier.testTag(BACK_BUTTON),
+                onClick = { navBack() }
+            ) {
                 Icon(
                     Icons.AutoMirrored.Filled.ArrowBack,
                     stringResource(id = R.string.nav_back_accessibility)

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/TestTags.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/TestTags.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.settings.ui
+
+const val BACK_BUTTON = "BackButton"


### PR DESCRIPTION
When the back arrow is pressed on `SettingsScreen`, `navController.navigate(PREVIEW_ROUTE)` was being called, which added `SettingsScreen` to the back stack. Instead, `navController.popBackStack()` can be used to return to the previous screen, mimicking the behavior of using the device's back button (or back gesture).