### PR TITLE
small visual updates

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -169,7 +169,6 @@ private fun ContentScreen(
         TestableToast(
             modifier = Modifier.testTag(previewUiState.toastMessageToShow.testTag),
             toastMessage = previewUiState.toastMessageToShow,
-            shouldShowToast = false,
             onToastShown = onToastShown
         )
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -44,7 +44,7 @@ import androidx.lifecycle.compose.LifecycleStartEffect
 import com.google.jetpackcamera.feature.preview.ui.CameraControlsOverlay
 import com.google.jetpackcamera.feature.preview.ui.PreviewDisplay
 import com.google.jetpackcamera.feature.preview.ui.ScreenFlashScreen
-import com.google.jetpackcamera.feature.preview.ui.ShowTestableToast
+import com.google.jetpackcamera.feature.preview.ui.TestableToast
 import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreenOverlay
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
@@ -166,9 +166,10 @@ private fun ContentScreen(
 
     // displays toast when there is a message to show
     if (previewUiState.toastMessageToShow != null) {
-        ShowTestableToast(
+        TestableToast(
             modifier = Modifier.testTag(previewUiState.toastMessageToShow.testTag),
             toastMessage = previewUiState.toastMessageToShow,
+            shouldShowToast = false,
             onToastShown = onToastShown
         )
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -271,7 +271,6 @@ class PreviewViewModel @Inject constructor(
             _previewUiState.emit(
                 previewUiState.value.copy(
                     quickSettingsIsOpen = isOpen
-
                 )
             )
         }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -30,8 +30,6 @@ import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -41,6 +39,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "PreviewViewModel"
 private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
@@ -271,6 +271,7 @@ class PreviewViewModel @Inject constructor(
             _previewUiState.emit(
                 previewUiState.value.copy(
                     quickSettingsIsOpen = isOpen
+
                 )
             )
         }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -30,6 +30,8 @@ import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -39,8 +41,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "PreviewViewModel"
 private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -286,6 +286,9 @@ class PreviewViewModel @Inject constructor(
         )
     }
 
+    /**
+     * Sets current value of [PreviewUiState.toastMessageToShow] to null.
+     */
     fun onToastShown() {
         viewModelScope.launch {
             // keeps the composable up on screen longer to be detected by UiAutomator

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -185,7 +185,7 @@ private fun ControlsBottom(
     onStartVideoRecording: () -> Unit = {},
     onStopVideoRecording: () -> Unit = {}
 ) {
-    Column(modifier) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         if (showZoomLevel) {
             ZoomScaleText(zoomLevel)
         }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -69,7 +69,6 @@ private const val TAG = "PreviewScreen"
  * An invisible box that will display a [Toast] with specifications set by a [ToastMessage].
  *
  * @param toastMessage the specifications for the [Toast].
- * @param shouldShowToast  shows a visible system toast when true.
  * @param onToastShown called once the Toast has been displayed.
  *
  */
@@ -77,7 +76,6 @@ private const val TAG = "PreviewScreen"
 fun TestableToast(
     modifier: Modifier = Modifier,
     toastMessage: ToastMessage,
-    shouldShowToast: Boolean = true,
     onToastShown: () -> Unit
 ) {
     val toastShownStatus = remember { mutableStateOf(false) }
@@ -88,7 +86,7 @@ fun TestableToast(
             .testTag(toastMessage.testTag)
     ) {
         // checking toastShownStatus prevents toast visual from being spammed
-        if (!toastShownStatus.value && shouldShowToast) {
+        if (!toastShownStatus.value && toastMessage.shouldShowToast) {
             Toast.makeText(
                 LocalContext.current,
                 stringResource(id = toastMessage.stringResource),
@@ -256,6 +254,8 @@ fun CaptureButton(
                     onLongPress = {
                         onLongPress()
                     },
+                    //TODO: @kimblebee - stopVideoRecording is being called every time the capture
+                    // button is pressed -- regardless of tap or long press
                     onPress = {
                         awaitRelease()
                         onRelease()

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -44,8 +44,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -78,26 +77,29 @@ fun TestableToast(
     toastMessage: ToastMessage,
     onToastShown: () -> Unit
 ) {
-    val toastShownStatus = remember { mutableStateOf(false) }
     Box(
         // box seems to need to have some size to be detected by UiAutomator
         modifier = modifier
             .size(20.dp)
             .testTag(toastMessage.testTag)
     ) {
-        // checking toastShownStatus prevents toast visual from being spammed
-        if (!toastShownStatus.value && toastMessage.shouldShowToast) {
-            Toast.makeText(
-                LocalContext.current,
-                stringResource(id = toastMessage.stringResource),
-                toastMessage.toastLength
-            )
-                .show()
+        val context = LocalContext.current
+        LaunchedEffect(toastMessage) {
+            if (toastMessage.shouldShowToast) {
+                Toast.makeText(
+                    context,
+                    context.getText(toastMessage.stringResource),
+                    toastMessage.toastLength
+                ).show()
+            }
+
+            onToastShown()
         }
-        toastShownStatus.value = true
-        onToastShown()
+        Log.d(
+            TAG,
+            "Toast Displayed with message: ${stringResource(id = toastMessage.stringResource)}"
+        )
     }
-    Log.d(TAG, "Toast Displayed with message: ${stringResource(id = toastMessage.stringResource)}")
 }
 
 /**

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -254,7 +254,7 @@ fun CaptureButton(
                     onLongPress = {
                         onLongPress()
                     },
-                    //TODO: @kimblebee - stopVideoRecording is being called every time the capture
+                    // TODO: @kimblebee - stopVideoRecording is being called every time the capture
                     // button is pressed -- regardless of tap or long press
                     onPress = {
                         awaitRelease()

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -69,12 +69,15 @@ private const val TAG = "PreviewScreen"
  * An invisible box that will display a [Toast] with specifications set by a [ToastMessage].
  *
  * @param toastMessage the specifications for the [Toast].
+ * @param shouldShowToast  shows a visible system toast when true.
  * @param onToastShown called once the Toast has been displayed.
+ *
  */
 @Composable
-fun ShowTestableToast(
+fun TestableToast(
     modifier: Modifier = Modifier,
     toastMessage: ToastMessage,
+    shouldShowToast: Boolean = true,
     onToastShown: () -> Unit
 ) {
     val toastShownStatus = remember { mutableStateOf(false) }
@@ -84,17 +87,17 @@ fun ShowTestableToast(
             .size(20.dp)
             .testTag(toastMessage.testTag)
     ) {
-        // prevents toast from being spammed
-        if (!toastShownStatus.value) {
+        // checking toastShownStatus prevents toast visual from being spammed
+        if (!toastShownStatus.value && shouldShowToast) {
             Toast.makeText(
                 LocalContext.current,
                 stringResource(id = toastMessage.stringResource),
                 toastMessage.toastLength
             )
                 .show()
-            toastShownStatus.value = true
-            onToastShown()
         }
+        toastShownStatus.value = true
+        onToastShown()
     }
     Log.d(TAG, "Toast Displayed with message: ${stringResource(id = toastMessage.stringResource)}")
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
@@ -21,11 +21,13 @@ import android.widget.Toast
  * Helper class containing information used to create a [Toast].
  *
  * @param stringResource the resource ID of to be displayed.
- * @param isLongToast determines if the display time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT].
+ * @param shouldShowToast  shows a visible system toast when true.
+ * @param isLongToast determines if the visible toast's time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT].
  * @property testTag the identifiable resource ID of a [TestableToast] on screen.
  */
 class ToastMessage(
     val stringResource: Int,
+    val shouldShowToast: Boolean = true,
     isLongToast: Boolean = false,
     val testTag: String = ""
 ) {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ToastMessage.kt
@@ -22,7 +22,7 @@ import android.widget.Toast
  *
  * @param stringResource the resource ID of to be displayed.
  * @param isLongToast determines if the display time is [Toast.LENGTH_LONG] or [Toast.LENGTH_SHORT].
- * @property testTag the identifiable resource ID of a [ShowTestableToast] on screen.
+ * @property testTag the identifiable resource ID of a [TestableToast] on screen.
  */
 class ToastMessage(
     val stringResource: Int,

--- a/feature/preview/src/main/res/values/strings.xml
+++ b/feature/preview/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="flip_camera_content_description">Flip Camera</string>
 
     <string name="toast_image_capture_success">Image Capture Success</string>
+    <string name="toast_video_capture_success">Video Capture Success</string>
+
     <string name="toast_capture_failure">Image Capture Failure</string>
     <string name="stabilization_icon_description_preview_and_video">Preview is Stabilized</string>
     <string name="stabilization_icon_description_video_only">Only Video is Stabilized</string>


### PR DESCRIPTION
This change has two (mostly) cosmetic changes.
1.)  **zoom scale text** is now  centered on the screen instead of being shifted to the left
<img src="https://github.com/google/jetpack-camera-app/assets/20013168/5ab0ba3d-1189-4b6c-a530-861995deb382" height = 400/> --> <img src="https://github.com/google/jetpack-camera-app/assets/20013168/7a520b6e-2183-4d49-960c-35428de65c25" height = 400/>

2.) When using`TestableToast`, the display of a system toast is now optional. 
The composable responsible for triggering the Toast display will still be visible to UiAutomator (UI automator only checks for the presence of the composable, not the visibility). 
<img src="https://github.com/google/jetpack-camera-app/assets/20013168/1beb2313-9dc4-45ae-bc10-a0fecc38d587" height = 400/>

