### PR TITLE
Make back press exit out of quick settings

### DIFF
--- a/feature/quicksettings/build.gradle.kts
+++ b/feature/quicksettings/build.gradle.kts
@@ -69,6 +69,9 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)
 
+    // Compose - Activity
+    implementation(libs.androidx.activity.compose)
+
     // Compose - Testing
     androidTestImplementation(libs.compose.junit)
 

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.feature.quicksettings
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -81,6 +82,9 @@ fun QuickSettingsScreenOverlay(
         )
 
     if (isOpen) {
+        BackHandler {
+            toggleIsOpen()
+        }
         Column(
             modifier =
             modifier


### PR DESCRIPTION
When quick settings screen is open, back press would toggle it to be closed