### PR TITLE
Fix quick settings back press

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
@@ -28,6 +28,9 @@ import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import com.google.jetpackcamera.feature.preview.ui.CAPTURE_BUTTON
 import com.google.jetpackcamera.feature.preview.ui.FLIP_CAMERA_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_RATIO_1_1_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_RATIO_BUTTON
 import com.google.jetpackcamera.feature.preview.ui.SETTINGS_BUTTON
 import com.google.jetpackcamera.settings.ui.BACK_BUTTON
 import org.junit.Rule
@@ -102,6 +105,59 @@ class NavigationTest {
 
         // Assert we're on PreviewScreen by finding the capture button
         composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists()
+    }
+
+    @Test
+    fun backFromQuickSettings_returnToPreview() = runScenarioTest<MainActivity> {
+        // Wait for the capture button to be displayed
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).isDisplayed()
+        }
+
+        // Navigate to the quick settings screen
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_BUTTON)
+            .assertExists()
+            .performClick()
+
+        // Wait for the quick settings to be displayed
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithTag(QUICK_SETTINGS_RATIO_BUTTON).isDisplayed()
+        }
+
+        // Press the device's back button
+        uiDevice.pressBack()
+
+        // Assert we're on PreviewScreen by finding the capture button
+        composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists()
+    }
+
+    @Test
+    fun backFromQuickSettingsExpended_returnToQuickSettings() = runScenarioTest<MainActivity> {
+        // Wait for the capture button to be displayed
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).isDisplayed()
+        }
+
+        // Navigate to the quick settings screen
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_BUTTON)
+            .assertExists()
+            .performClick()
+
+        // Navigate to the expanded quick settings ratio screen
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_RATIO_BUTTON)
+            .assertExists()
+            .performClick()
+
+        // Wait for the 1:1 ratio button to be displayed
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithTag(QUICK_SETTINGS_RATIO_1_1_BUTTON).isDisplayed()
+        }
+
+        // Press the device's back button
+        uiDevice.pressBack()
+
+        // Assert we're on quick settings by finding the ratio button
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_RATIO_BUTTON).assertExists()
     }
 
     private inline fun <reified T : Activity> runScenarioTest(

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/TestTags.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/TestTags.kt
@@ -18,3 +18,6 @@ package com.google.jetpackcamera.feature.preview.ui
 const val CAPTURE_BUTTON = "CaptureButton"
 const val SETTINGS_BUTTON = "SettingsButton"
 const val FLIP_CAMERA_BUTTON = "FlipCameraButton"
+const val QUICK_SETTINGS_BUTTON = "QuickSettingDropDown"
+const val QUICK_SETTINGS_RATIO_BUTTON = "QuickSetAspectRatio"
+const val QUICK_SETTINGS_RATIO_1_1_BUTTON = "QuickSetAspectRatio1:1"

--- a/feature/quicksettings/build.gradle.kts
+++ b/feature/quicksettings/build.gradle.kts
@@ -69,6 +69,9 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)
 
+    // Compose - Activity
+    implementation(libs.androidx.activity.compose)
+
     // Compose - Testing
     androidTestImplementation(libs.compose.junit)
 

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.feature.quicksettings
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -81,6 +82,13 @@ fun QuickSettingsScreenOverlay(
         )
 
     if (isOpen) {
+        val onBack = {
+            when (shouldShowQuickSetting) {
+                IsExpandedQuickSetting.NONE -> toggleIsOpen()
+                else -> shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+            }
+        }
+        BackHandler(onBack = onBack)
         Column(
             modifier =
             modifier


### PR DESCRIPTION
Make it so pressing back button in quick settings screen would navigate back instead of closing the app.

Added two more tests in NavigationTest