### PR TITLE
fix stabilization issue

### DIFF
--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -524,11 +524,7 @@ constructor(
         val previewUseCaseBuilder = Preview.Builder()
         // set preview stabilization
         if (shouldPreviewBeStabilized(sessionSettings, supportedStabilizationModes)) {
-            val isStabilized = when (sessionSettings.stabilizePreviewMode) {
-                Stabilization.ON -> true
-                else -> false
-            }
-            previewUseCaseBuilder.setPreviewStabilizationEnabled(isStabilized)
+            previewUseCaseBuilder.setPreviewStabilizationEnabled(true)
         }
 
         return previewUseCaseBuilder.build().apply {

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -496,12 +496,9 @@ constructor(
 
         // set video stabilization
 
-        if (shouldVideoBeStabilized(sessionSettings, supportedStabilizationMode)) {
-            val isStabilized = when (sessionSettings.stabilizeVideoMode) {
-                Stabilization.ON -> true
-                Stabilization.OFF, Stabilization.UNDEFINED -> false
-            }
-            videoCaptureBuilder.setVideoStabilizationEnabled(isStabilized)
+        if (shouldVideoBeStabilized(sessionSettings, supportedStabilizationMode)
+        ) {
+            videoCaptureBuilder.setVideoStabilizationEnabled(true)
         }
         return videoCaptureBuilder.build()
     }
@@ -511,20 +508,14 @@ constructor(
         supportedStabilizationModes: List<SupportedStabilizationMode>
     ): Boolean {
         // video is supported by the device AND
-        // video is on OR preview is on
+        // video is on
         return (supportedStabilizationModes.contains(SupportedStabilizationMode.HIGH_QUALITY)) &&
-            (
                 // high quality (video only) selected
                 (
-                    sessionSettings.stabilizeVideoMode == Stabilization.ON &&
-                        sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
-                    ) ||
-                    // or on is selected
-                    (
-                        sessionSettings.stabilizePreviewMode == Stabilization.ON &&
-                            sessionSettings.stabilizeVideoMode != Stabilization.OFF
+                        sessionSettings.stabilizeVideoMode == Stabilization.ON &&
+                                sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
                         )
-                )
+
     }
 
     private fun createPreviewUseCase(

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -510,12 +510,11 @@ constructor(
         // video is supported by the device AND
         // video is on
         return (supportedStabilizationModes.contains(SupportedStabilizationMode.HIGH_QUALITY)) &&
-                // high quality (video only) selected
-                (
-                        sessionSettings.stabilizeVideoMode == Stabilization.ON &&
-                                sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
-                        )
-
+            // high quality (video only) selected
+            (
+                sessionSettings.stabilizeVideoMode == Stabilization.ON &&
+                    sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
+                )
     }
 
     private fun createPreviewUseCase(

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import com.google.jetpackcamera.settings.ui.DefaultCameraFacing
 import com.google.jetpackcamera.settings.ui.FlashModeSetting
 import com.google.jetpackcamera.settings.ui.SectionHeader
 import com.google.jetpackcamera.settings.ui.SettingsPageHeader
+import com.google.jetpackcamera.settings.ui.StabilizationSetting
 
 /**
  * Screen used for the Settings feature.
@@ -76,7 +77,7 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
     )
 
     // TODO: b/326140212 - stabilization setting not changing active stabilization mode
-   /*
+
     StabilizationSetting(
         currentVideoStabilization = uiState.cameraAppSettings.videoCaptureStabilization,
         currentPreviewStabilization = uiState.cameraAppSettings.previewStabilization,
@@ -84,7 +85,7 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
         setVideoStabilization = viewModel::setVideoStabilization,
         setPreviewStabilization = viewModel::setPreviewStabilization
     )
-    */
+
 
     SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
 

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -86,7 +86,6 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
         setPreviewStabilization = viewModel::setPreviewStabilization
     )
 
-
     SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
 
     DarkModeSetting(


### PR DESCRIPTION
fixes #118 
![image](https://github.com/google/jetpack-camera-app/assets/20013168/073987e7-abe0-4206-a1ed-056c22ad0cc2)


`adb shell cmd media.camera watch start -m android.control.videoStabilizationMode && adb shell cmd media.camera watch live`

note the changes when applied in default settings currently requires the app to be relaunched to take effect

