### PR TITLE
Use LensFacing instead of flipCamera

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,9 +99,9 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-
     androidTestImplementation(libs.androidx.rules)
     androidTestImplementation(libs.androidx.uiautomator)
+    androidTestImplementation(libs.truth)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
@@ -121,6 +121,8 @@ dependencies {
 
     // Camera Preview
     implementation(project(":feature:preview"))
+    // Only needed as androidTestImplementation for now since we only need it for string resources
+    androidTestImplementation(project(":feature:quicksettings"))
 
     // Settings Screen
     implementation(project(":feature:settings"))

--- a/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
@@ -21,6 +21,10 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_RATIO_1_1_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_RATIO_BUTTON
+import com.google.jetpackcamera.feature.quicksettings.ui.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -57,19 +61,19 @@ class BackgroundDeviceTest {
 
     @Test
     fun flipCamera_then_background_foreground() {
-        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
-        uiDevice.findObject(By.res("QuickSetFlipCamera")).click()
-        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_BUTTON)).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_FLIP_CAMERA_BUTTON)).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_BUTTON)).click()
         uiDevice.waitForIdle(2000)
         backgroundThenForegroundApp()
     }
 
     @Test
     fun setAspectRatio_then_background_foreground() {
-        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
-        uiDevice.findObject(By.res("QuickSetAspectRatio")).click()
-        uiDevice.findObject(By.res("QuickSetAspectRatio1:1")).click()
-        uiDevice.findObject(By.res("QuickSettingDropDown")).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_BUTTON)).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_RATIO_BUTTON)).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_RATIO_1_1_BUTTON)).click()
+        uiDevice.findObject(By.res(QUICK_SETTINGS_BUTTON)).click()
         uiDevice.waitForIdle(2000)
         backgroundThenForegroundApp()
     }

--- a/app/src/androidTest/java/com/google/jetpackcamera/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ComposeTestRuleExt.kt
@@ -20,6 +20,7 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.printToString
 import androidx.test.core.app.ApplicationProvider
@@ -32,8 +33,25 @@ import org.junit.AssumptionViolatedException
 fun SemanticsNodeInteractionsProvider.onNodeWithText(
     @StringRes strRes: Int
 ): SemanticsNodeInteraction = onNodeWithText(
-    text = ApplicationProvider.getApplicationContext<Context>().getString(strRes)
+    text = getResString(strRes)
 )
+
+/**
+ * Allows use of testRule.onNodeWithContentDescription that uses an integer string resource
+ * rather than a [String] directly.
+ */
+fun SemanticsNodeInteractionsProvider.onNodeWithContentDescription(
+    @StringRes strRes: Int
+): SemanticsNodeInteraction = onNodeWithContentDescription(
+    label = getResString(strRes)
+)
+
+/**
+ * Fetch a string resources from a [SemanticsNodeInteractionsProvider] context.
+ */
+fun SemanticsNodeInteractionsProvider.getResString(@StringRes strRes: Int): String {
+    return ApplicationProvider.getApplicationContext<Context>().getString(strRes)
+}
 
 /**
  * Assumes that the provided [matcher] is satisfied for this node.

--- a/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/NavigationTest.kt
@@ -15,13 +15,11 @@
  */
 package com.google.jetpackcamera
 
-import android.app.Activity
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -158,13 +156,5 @@ class NavigationTest {
 
         // Assert we're on quick settings by finding the ratio button
         composeTestRule.onNodeWithTag(QUICK_SETTINGS_RATIO_BUTTON).assertExists()
-    }
-
-    private inline fun <reified T : Activity> runScenarioTest(
-        crossinline block: ActivityScenario<T>.() -> Unit
-    ) {
-        ActivityScenario.launch(T::class.java).use { scenario ->
-            scenario.apply(block)
-        }
     }
 }

--- a/app/src/androidTest/java/com/google/jetpackcamera/SwitchCameraTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/SwitchCameraTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.feature.preview.ui.FLIP_CAMERA_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.PREVIEW_DISPLAY
+import com.google.jetpackcamera.feature.preview.ui.QUICK_SETTINGS_BUTTON
+import com.google.jetpackcamera.feature.quicksettings.ui.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
+import com.google.jetpackcamera.quicksettings.R.string.quick_settings_back_camera_description
+import com.google.jetpackcamera.quicksettings.R.string.quick_settings_dropdown_closed_description
+import com.google.jetpackcamera.quicksettings.R.string.quick_settings_dropdown_open_description
+import com.google.jetpackcamera.quicksettings.R.string.quick_settings_front_camera_description
+import com.google.jetpackcamera.settings.model.LensFacing
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SwitchCameraTest {
+    @get:Rule
+    val cameraPermissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    @Test
+    fun canFlipCamera_fromPreviewScreenButton() = runFlipCameraTest(composeTestRule) {
+        val lensFacingStates = mutableListOf<LensFacing>()
+        // Get initial lens facing
+        val initialLensFacing = composeTestRule.getCurrentLensFacing()
+        lensFacingStates.add(initialLensFacing)
+
+        // Press the flip camera button
+        composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).performClick()
+
+        // Get lens facing after first flip
+        lensFacingStates.add(composeTestRule.getCurrentLensFacing())
+
+        // Press the flip camera button again
+        composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).performClick()
+
+        // Get lens facing after second flip
+        lensFacingStates.add(composeTestRule.getCurrentLensFacing())
+
+        assertThat(lensFacingStates).containsExactly(
+            initialLensFacing,
+            initialLensFacing.flip(),
+            initialLensFacing.flip().flip()
+        ).inOrder()
+    }
+
+    @Test
+    fun canFlipCamera_fromPreviewScreenDoubleTap() = runFlipCameraTest(composeTestRule) {
+        val lensFacingStates = mutableListOf<LensFacing>()
+        // Get initial lens facing
+        val initialLensFacing = composeTestRule.getCurrentLensFacing()
+        lensFacingStates.add(initialLensFacing)
+
+        // Double click display to flip camera
+        composeTestRule.onNodeWithTag(PREVIEW_DISPLAY)
+            .performTouchInput { doubleClick() }
+
+        // Get lens facing after first flip
+        lensFacingStates.add(composeTestRule.getCurrentLensFacing())
+
+        // Double click display to flip camera again
+        composeTestRule.onNodeWithTag(PREVIEW_DISPLAY)
+            .performTouchInput { doubleClick() }
+
+        // Get lens facing after second flip
+        lensFacingStates.add(composeTestRule.getCurrentLensFacing())
+
+        assertThat(lensFacingStates).containsExactly(
+            initialLensFacing,
+            initialLensFacing.flip(),
+            initialLensFacing.flip().flip()
+        ).inOrder()
+    }
+
+    @Test
+    fun canFlipCamera_fromQuickSettings() = runFlipCameraTest(composeTestRule) {
+        // Navigate to quick settings
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_BUTTON)
+            .assertExists()
+            .performClick()
+
+        val lensFacingStates = mutableListOf<LensFacing>()
+        // Get initial lens facing
+        val initialLensFacing = composeTestRule.getCurrentLensFacing()
+        lensFacingStates.add(initialLensFacing)
+
+        // Double click quick settings button to flip camera
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON).performClick()
+
+        // Get lens facing after first flip
+        lensFacingStates.add(composeTestRule.getCurrentLensFacing())
+
+        // Double click quick settings button to flip camera again
+        composeTestRule.onNodeWithTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON).performClick()
+
+        // Get lens facing after second flip
+        lensFacingStates.add(composeTestRule.getCurrentLensFacing())
+
+        assertThat(lensFacingStates).containsExactly(
+            initialLensFacing,
+            initialLensFacing.flip(),
+            initialLensFacing.flip().flip()
+        ).inOrder()
+    }
+}
+
+inline fun runFlipCameraTest(
+    composeTestRule: ComposeTestRule,
+    crossinline block: ActivityScenario<MainActivity>.() -> Unit
+) = runScenarioTest {
+    // Wait for the preview display to be visible
+    composeTestRule.waitUntil {
+        composeTestRule.onNodeWithTag(PREVIEW_DISPLAY).isDisplayed()
+    }
+
+    // If flipping the camera is available, flip it. Otherwise skip test.
+    composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).assume(isEnabled()) {
+        "Device does not have multiple cameras to flip between."
+    }
+
+    block()
+}
+
+private fun ComposeTestRule.getCurrentLensFacing(): LensFacing {
+    var needReturnFromQuickSettings = false
+    onNodeWithContentDescription(quick_settings_dropdown_closed_description).apply {
+        if (isDisplayed()) {
+            performClick()
+            needReturnFromQuickSettings = true
+        }
+    }
+
+    onNodeWithContentDescription(quick_settings_dropdown_open_description).assertExists(
+        "LensFacing can only be retrieved from PreviewScreen or QuickSettings screen"
+    )
+
+    try {
+        return onNodeWithTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON).fetchSemanticsNode(
+            "Flip camera button is not visible when expected."
+        ).let { node ->
+            node.config[SemanticsProperties.ContentDescription].any { description ->
+                when (description) {
+                    getResString(quick_settings_front_camera_description) ->
+                        return@let LensFacing.FRONT
+
+                    getResString(quick_settings_back_camera_description) ->
+                        return@let LensFacing.BACK
+
+                    else -> false
+                }
+            }
+            throw AssertionError("Unable to determine lens facing from quick settings")
+        }
+    } finally {
+        if (needReturnFromQuickSettings) {
+            onNodeWithContentDescription(quick_settings_dropdown_open_description)
+                .assertExists()
+                .performClick()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/google/jetpackcamera/UiTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/UiTestUtil.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera
 
+import android.app.Activity
 import androidx.test.core.app.ActivityScenario
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import java.util.concurrent.atomic.AtomicReference
@@ -32,5 +33,13 @@ object UiTestUtil {
         return getActivity(
             activityScenario
         ).previewViewModel!!.previewUiState.value.currentCameraSettings
+    }
+}
+
+inline fun <reified T : Activity> runScenarioTest(
+    crossinline block: ActivityScenario<T>.() -> Unit
+) {
+    ActivityScenario.launch(T::class.java).use { scenario ->
+        scenario.apply(block)
     }
 }

--- a/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalSettingsRepositoryInstrumentedTest.kt
+++ b/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalSettingsRepositoryInstrumentedTest.kt
@@ -28,6 +28,7 @@ import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkMode
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -108,15 +109,15 @@ class LocalSettingsRepositoryInstrumentedTest {
 
     @Test
     fun can_update_default_to_front_camera() = runTest {
-        // default to front camera starts false
-        val initialFrontCameraDefault = repository.getCameraAppSettings().isFrontCameraFacing
-        repository.updateDefaultToFrontCamera()
+        // default to front camera starts as back
+        val initialDefaultLensFacing = repository.getCameraAppSettings().cameraLensFacing
+        repository.updateDefaultLensFacing(LensFacing.FRONT)
         // default to front camera is now true
-        val frontCameraDefault = repository.getCameraAppSettings().isFrontCameraFacing
+        val newDefaultLensFacing = repository.getCameraAppSettings().cameraLensFacing
         advanceUntilIdle()
 
-        assertThat(initialFrontCameraDefault).isFalse()
-        assertThat(frontCameraDefault).isTrue()
+        assertThat(initialDefaultLensFacing).isEqualTo(LensFacing.BACK)
+        assertThat(newDefaultLensFacing).isEqualTo(LensFacing.FRONT)
     }
 
     @Test

--- a/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalSettingsRepositoryInstrumentedTest.kt
+++ b/data/settings/src/androidTest/java/com/google/jetpackcamera/settings/LocalSettingsRepositoryInstrumentedTest.kt
@@ -109,10 +109,10 @@ class LocalSettingsRepositoryInstrumentedTest {
 
     @Test
     fun can_update_default_to_front_camera() = runTest {
-        // default to front camera starts as back
+        // default lens facing starts as BACK
         val initialDefaultLensFacing = repository.getCameraAppSettings().cameraLensFacing
         repository.updateDefaultLensFacing(LensFacing.FRONT)
-        // default to front camera is now true
+        // default lens facing is now FRONT
         val newDefaultLensFacing = repository.getCameraAppSettings().cameraLensFacing
         advanceUntilIdle()
 
@@ -122,10 +122,10 @@ class LocalSettingsRepositoryInstrumentedTest {
 
     @Test
     fun can_update_flash_mode() = runTest {
-        // default to front camera starts false
+        // default flash mode starts as OFF
         val initialFlashModeStatus = repository.getCameraAppSettings().flashMode
         repository.updateFlashModeStatus(FlashMode.ON)
-        // default to front camera is now true
+        // default flash mode is now ON
         val newFlashModeStatus = repository.getCameraAppSettings().flashMode
         advanceUntilIdle()
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -29,6 +29,8 @@ import com.google.jetpackcamera.settings.model.DarkMode
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.DynamicRange.Companion.toProto
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
+import com.google.jetpackcamera.settings.model.LensFacing.Companion.toProto
 import com.google.jetpackcamera.settings.model.Stabilization
 import com.google.jetpackcamera.settings.model.SupportedStabilizationMode
 import javax.inject.Inject
@@ -45,7 +47,7 @@ class LocalSettingsRepository @Inject constructor(
     override val cameraAppSettings = jcaSettings.data
         .map {
             CameraAppSettings(
-                isFrontCameraFacing = it.defaultFrontCamera,
+                cameraLensFacing = LensFacing.fromProto(it.defaultLensFacing),
                 darkMode = when (it.darkModeStatus) {
                     DarkModeProto.DARK_MODE_DARK -> DarkMode.DARK
                     DarkModeProto.DARK_MODE_LIGHT -> DarkMode.LIGHT
@@ -82,10 +84,10 @@ class LocalSettingsRepository @Inject constructor(
 
     override suspend fun getCameraAppSettings(): CameraAppSettings = cameraAppSettings.first()
 
-    override suspend fun updateDefaultToFrontCamera() {
+    override suspend fun updateDefaultLensFacing(lensFacing: LensFacing) {
         jcaSettings.updateData { currentSettings ->
             currentSettings.toBuilder()
-                .setDefaultFrontCamera(!currentSettings.defaultFrontCamera)
+                .setDefaultLensFacing(lensFacing.toProto())
                 .build()
         }
     }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/SettingsRepository.kt
@@ -21,6 +21,7 @@ import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DarkMode
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.Stabilization
 import kotlinx.coroutines.flow.Flow
 
@@ -31,7 +32,7 @@ interface SettingsRepository {
 
     val cameraAppSettings: Flow<CameraAppSettings>
 
-    suspend fun updateDefaultToFrontCamera()
+    suspend fun updateDefaultLensFacing(lensFacing: LensFacing)
 
     suspend fun updateDarkModeStatus(darkMode: DarkMode)
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -19,7 +19,7 @@ package com.google.jetpackcamera.settings.model
  * Data layer representation for settings.
  */
 data class CameraAppSettings(
-    val cameraLensFacing: LensFacing = LensFacing.FRONT,
+    val cameraLensFacing: LensFacing = LensFacing.BACK,
     val isFrontCameraAvailable: Boolean = true,
     val isBackCameraAvailable: Boolean = true,
     val darkMode: DarkMode = DarkMode.SYSTEM,

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -19,7 +19,7 @@ package com.google.jetpackcamera.settings.model
  * Data layer representation for settings.
  */
 data class CameraAppSettings(
-    val isFrontCameraFacing: Boolean = false,
+    val cameraLensFacing: LensFacing = LensFacing.FRONT,
     val isFrontCameraAvailable: Boolean = true,
     val isBackCameraAvailable: Boolean = true,
     val darkMode: DarkMode = DarkMode.SYSTEM,

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LensFacing.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LensFacing.kt
@@ -21,6 +21,13 @@ enum class LensFacing {
     BACK,
     FRONT;
 
+    fun flip(): LensFacing {
+        return when (this) {
+            FRONT -> BACK
+            BACK -> FRONT
+        }
+    }
+
     companion object {
 
         /** returns the LensFacing enum equivalent of a provided LensFacingProto */

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LensFacing.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LensFacing.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.settings.model
+
+import com.google.jetpackcamera.settings.LensFacing as LensFacingProto
+
+enum class LensFacing {
+    BACK,
+    FRONT;
+
+    companion object {
+
+        /** returns the LensFacing enum equivalent of a provided LensFacingProto */
+        fun fromProto(lensFacingProto: LensFacingProto): LensFacing {
+            return when (lensFacingProto) {
+                LensFacingProto.LENS_FACING_BACK -> BACK
+
+                // Treat unrecognized as front as a fallback
+                LensFacingProto.LENS_FACING_FRONT,
+                LensFacingProto.UNRECOGNIZED -> FRONT
+            }
+        }
+
+        fun LensFacing.toProto(): LensFacingProto {
+            return when (this) {
+                BACK -> LensFacingProto.LENS_FACING_BACK
+                FRONT -> LensFacingProto.LENS_FACING_FRONT
+            }
+        }
+    }
+}

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeSettingsRepository.kt
@@ -23,21 +23,21 @@ import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkMode
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.Stabilization
 import com.google.jetpackcamera.settings.model.SupportedStabilizationMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 object FakeSettingsRepository : SettingsRepository {
-    var currentCameraSettings: CameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
+    private var currentCameraSettings: CameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
     private var isPreviewStabilizationSupported: Boolean = false
     private var isVideoStabilizationSupported: Boolean = false
 
     override val cameraAppSettings: Flow<CameraAppSettings> = flow { emit(currentCameraSettings) }
 
-    override suspend fun updateDefaultToFrontCamera() {
-        val newLensFacing = !currentCameraSettings.isFrontCameraFacing
-        currentCameraSettings = currentCameraSettings.copy(isFrontCameraFacing = newLensFacing)
+    override suspend fun updateDefaultLensFacing(lensFacing: LensFacing) {
+        currentCameraSettings = currentCameraSettings.copy(cameraLensFacing = lensFacing)
     }
 
     override suspend fun updateDarkModeStatus(darkMode: DarkMode) {

--- a/data/settings/src/main/proto/com/google/jetpackcamera/settings/jca_settings.proto
+++ b/data/settings/src/main/proto/com/google/jetpackcamera/settings/jca_settings.proto
@@ -19,17 +19,18 @@ syntax = "proto3";
 import "com/google/jetpackcamera/settings/aspect_ratio.proto";
 import "com/google/jetpackcamera/settings/capture_mode.proto";
 import "com/google/jetpackcamera/settings/dark_mode.proto";
+import "com/google/jetpackcamera/settings/dynamic_range.proto";
 import "com/google/jetpackcamera/settings/flash_mode.proto";
+import "com/google/jetpackcamera/settings/lens_facing.proto";
 import "com/google/jetpackcamera/settings/preview_stabilization.proto";
 import "com/google/jetpackcamera/settings/video_stabilization.proto";
-import "com/google/jetpackcamera/settings/dynamic_range.proto";
 
 
 option java_package = "com.google.jetpackcamera.settings";
 option java_multiple_files = true;
 
 message JcaSettings {
-  bool default_front_camera = 2;
+  bool default_front_camera = 2 [deprecated = true];
   bool front_camera_available = 3;
   bool back_camera_available = 4;
   DarkMode dark_mode_status = 5;
@@ -42,4 +43,5 @@ message JcaSettings {
   bool stabilize_preview_supported = 12;
   DynamicRange dynamic_range_status = 13;
   repeated DynamicRange supported_dynamic_ranges = 14;
+  LensFacing default_lens_facing = 15;
 }

--- a/data/settings/src/main/proto/com/google/jetpackcamera/settings/lens_facing.proto
+++ b/data/settings/src/main/proto/com/google/jetpackcamera/settings/lens_facing.proto
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "com.google.jetpackcamera.settings";
+option java_multiple_files = true;
+
+enum LensFacing {
+  LENS_FACING_BACK = 0;
+  LENS_FACING_FRONT = 1;
+}

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -23,6 +23,7 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -71,7 +72,7 @@ interface CameraUseCase {
 
     suspend fun setAspectRatio(aspectRatio: AspectRatio)
 
-    suspend fun flipCamera(isFrontFacing: Boolean)
+    suspend fun setLensFacing(lensFacing: LensFacing)
 
     fun tapToFocus(display: Display, surfaceWidth: Int, surfaceHeight: Int, x: Float, y: Float)
 

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -17,13 +17,12 @@ package com.google.jetpackcamera.domain.camera
 
 import android.content.ContentResolver
 import android.net.Uri
-import android.util.Rational
 import android.view.Display
 import androidx.camera.core.SurfaceRequest
-import com.google.jetpackcamera.settings.model.AspectRatio as SettingsAspectRatio
+import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.CaptureMode as SettingsCaptureMode
-import com.google.jetpackcamera.settings.model.FlashMode as SettingsFlashMode
+import com.google.jetpackcamera.settings.model.CaptureMode
+import com.google.jetpackcamera.settings.model.FlashMode
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -66,65 +65,17 @@ interface CameraUseCase {
 
     fun getCurrentSettings(): StateFlow<CameraAppSettings?>
 
-    fun setFlashMode(flashMode: SettingsFlashMode)
+    fun setFlashMode(flashMode: FlashMode)
 
     fun isScreenFlashEnabled(): Boolean
 
-    suspend fun setAspectRatio(aspectRatio: SettingsAspectRatio)
+    suspend fun setAspectRatio(aspectRatio: AspectRatio)
 
     suspend fun flipCamera(isFrontFacing: Boolean)
 
     fun tapToFocus(display: Display, surfaceWidth: Int, surfaceHeight: Int, x: Float, y: Float)
 
-    suspend fun setCaptureMode(captureMode: SettingsCaptureMode)
-
-    companion object {
-        const val INVALID_ZOOM_SCALE = -1f
-    }
-
-    /**
-     * Data class holding information used for configuring [CameraUseCase].
-     */
-    data class Config(
-        val lensFacing: LensFacing = LensFacing.FRONT,
-        val captureMode: CaptureMode = CaptureMode.SINGLE_STREAM,
-        val aspectRatio: AspectRatio = AspectRatio.ASPECT_RATIO_4_3,
-        val flashMode: FlashMode = FlashMode.OFF
-    )
-
-    /**
-     * Represents the lens used by [CameraUseCase].
-     */
-    enum class LensFacing {
-        FRONT,
-        BACK
-    }
-
-    /**
-     * Represents the capture mode used by [CameraUseCase].
-     */
-    enum class CaptureMode {
-        MULTI_STREAM,
-        SINGLE_STREAM
-    }
-
-    /**
-     * Represents the aspect ratio used by [CameraUseCase].
-     */
-    enum class AspectRatio(val rational: Rational) {
-        ASPECT_RATIO_4_3(Rational(4, 3)),
-        ASPECT_RATIO_16_9(Rational(16, 9)),
-        ASPECT_RATIO_1_1(Rational(1, 1))
-    }
-
-    /**
-     * Represents the flash mode used by [CameraUseCase].
-     */
-    enum class FlashMode {
-        OFF,
-        ON,
-        AUTO
-    }
+    suspend fun setCaptureMode(captureMode: CaptureMode)
 
     /**
      * Represents the events required for screen flash.

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -25,7 +25,6 @@ import android.util.Log
 import android.view.Display
 import androidx.camera.core.CameraInfo
 import androidx.camera.core.CameraSelector
-import androidx.camera.core.CameraSelector.LensFacing
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCapture.OutputFileOptions
 import androidx.camera.core.ImageCapture.ScreenFlash
@@ -48,6 +47,7 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.Stabilization
 import com.google.jetpackcamera.settings.model.SupportedStabilizationMode
 import dagger.hilt.android.scopes.ViewModelScoped
@@ -365,10 +365,10 @@ constructor(
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
-    // flips the camera to the designated lensFacing direction
-    override suspend fun flipCamera(isFrontFacing: Boolean) {
+    // Sets the camera to the designated lensFacing direction
+    override suspend fun setLensFacing(lensFacing: LensFacing) {
         currentSettings.update { old ->
-            old?.copy(isFrontCameraFacing = isFrontFacing)
+            old?.copy(isFrontCameraFacing = lensFacing == LensFacing.FRONT)
         }
     }
 
@@ -544,13 +544,7 @@ constructor(
             )
     }
 
-    // converts LensFacing from datastore to @LensFacing Int value
-    private fun getLensFacing(isFrontFacing: Boolean): Int = when (isFrontFacing) {
-        true -> CameraSelector.LENS_FACING_FRONT
-        false -> CameraSelector.LENS_FACING_BACK
-    }
-
-    private fun cameraLensToSelector(@LensFacing lensFacing: Int): CameraSelector =
+    private fun cameraLensToSelector(@CameraSelector.LensFacing lensFacing: Int): CameraSelector =
         when (lensFacing) {
             CameraSelector.LENS_FACING_FRONT -> CameraSelector.DEFAULT_FRONT_CAMERA
             CameraSelector.LENS_FACING_BACK -> CameraSelector.DEFAULT_BACK_CAMERA

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -109,15 +109,15 @@ constructor(
         // updates values for available camera lens
         val availableCameraLens =
             listOf(
-                CameraSelector.LENS_FACING_BACK,
-                CameraSelector.LENS_FACING_FRONT
+                LensFacing.FRONT,
+                LensFacing.BACK
             ).filter { lensFacing ->
-                cameraProvider.hasCamera(cameraLensToSelector(lensFacing))
+                cameraProvider.hasCamera(lensFacing.toCameraSelector())
             }
 
         settingsRepository.updateAvailableCameraLens(
-            availableCameraLens.contains(CameraSelector.LENS_FACING_FRONT),
-            availableCameraLens.contains(CameraSelector.LENS_FACING_BACK)
+            availableCameraLens.contains(LensFacing.FRONT),
+            availableCameraLens.contains(LensFacing.BACK)
         )
 
         currentSettings.value = settingsRepository.cameraAppSettings.first()
@@ -161,10 +161,9 @@ constructor(
                     zoomScale = currentCameraSettings.zoomScale
                 )
 
-                val cameraSelector = if (currentCameraSettings.isFrontCameraFacing) {
-                    CameraSelector.DEFAULT_FRONT_CAMERA
-                } else {
-                    CameraSelector.DEFAULT_BACK_CAMERA
+                val cameraSelector = when (currentCameraSettings.cameraLensFacing) {
+                    LensFacing.FRONT -> CameraSelector.DEFAULT_FRONT_CAMERA
+                    LensFacing.BACK -> CameraSelector.DEFAULT_BACK_CAMERA
                 }
 
                 PerpetualSessionSettings(
@@ -368,7 +367,7 @@ constructor(
     // Sets the camera to the designated lensFacing direction
     override suspend fun setLensFacing(lensFacing: LensFacing) {
         currentSettings.update { old ->
-            old?.copy(isFrontCameraFacing = lensFacing == LensFacing.FRONT)
+            old?.copy(cameraLensFacing = lensFacing)
         }
     }
 
@@ -544,12 +543,10 @@ constructor(
             )
     }
 
-    private fun cameraLensToSelector(@CameraSelector.LensFacing lensFacing: Int): CameraSelector =
-        when (lensFacing) {
-            CameraSelector.LENS_FACING_FRONT -> CameraSelector.DEFAULT_FRONT_CAMERA
-            CameraSelector.LENS_FACING_BACK -> CameraSelector.DEFAULT_BACK_CAMERA
-            else -> throw IllegalArgumentException("Invalid lens facing type: $lensFacing")
-        }
+    private fun LensFacing.toCameraSelector(): CameraSelector = when (this) {
+        LensFacing.FRONT -> CameraSelector.DEFAULT_FRONT_CAMERA
+        LensFacing.BACK -> CameraSelector.DEFAULT_BACK_CAMERA
+    }
 
     companion object {
         /**

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -25,6 +25,7 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -166,9 +167,9 @@ class FakeCameraUseCase(
         }
     }
 
-    override suspend fun flipCamera(isFrontFacing: Boolean) {
+    override suspend fun setLensFacing(lensFacing: LensFacing) {
         currentSettings.update { old ->
-            old.copy(isFrontCameraFacing = isFrontFacing)
+            old.copy(isFrontCameraFacing = lensFacing == LensFacing.FRONT)
         }
     }
 

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -18,7 +18,6 @@ package com.google.jetpackcamera.domain.camera.test
 import android.content.ContentResolver
 import android.net.Uri
 import android.view.Display
-import androidx.camera.core.CameraSelector
 import androidx.camera.core.SurfaceRequest
 import com.google.jetpackcamera.domain.camera.CameraUseCase
 import com.google.jetpackcamera.settings.model.AspectRatio
@@ -43,8 +42,7 @@ class FakeCameraUseCase(
         CoroutineScope(SupervisorJob() + Dispatchers.Default),
     defaultCameraSettings: CameraAppSettings = CameraAppSettings()
 ) : CameraUseCase {
-    private val availableLenses =
-        listOf(CameraSelector.LENS_FACING_FRONT, CameraSelector.LENS_FACING_BACK)
+    private val availableLenses = listOf(LensFacing.FRONT, LensFacing.BACK)
     private var initialized = false
     private var useCasesBinded = false
 
@@ -65,12 +63,7 @@ class FakeCameraUseCase(
     }
 
     override suspend fun runCamera() {
-        val lensFacing =
-            if (currentSettings.value.isFrontCameraFacing) {
-                CameraSelector.LENS_FACING_FRONT
-            } else {
-                CameraSelector.LENS_FACING_BACK
-            }
+        val lensFacing = currentSettings.value.cameraLensFacing
 
         if (!initialized) {
             throw IllegalStateException("CameraProvider not initialized")
@@ -88,7 +81,7 @@ class FakeCameraUseCase(
                 useCasesBinded = true
                 previewStarted = true
 
-                isLensFacingFront = it.isFrontCameraFacing
+                isLensFacingFront = it.cameraLensFacing == LensFacing.FRONT
                 isScreenFlash =
                     isLensFacingFront &&
                     (it.flashMode == FlashMode.AUTO || it.flashMode == FlashMode.ON)
@@ -169,7 +162,7 @@ class FakeCameraUseCase(
 
     override suspend fun setLensFacing(lensFacing: LensFacing) {
         currentSettings.update { old ->
-            old.copy(isFrontCameraFacing = lensFacing == LensFacing.FRONT)
+            old.copy(cameraLensFacing = lensFacing)
         }
     }
 

--- a/domain/camera/src/test/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCaseTest.kt
+++ b/domain/camera/src/test/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCaseTest.kt
@@ -17,8 +17,8 @@ package com.google.jetpackcamera.domain.camera.test
 
 import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.domain.camera.CameraUseCase
-import com.google.jetpackcamera.domain.camera.CameraUseCase.LensFacing
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList

--- a/domain/camera/src/test/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCaseTest.kt
+++ b/domain/camera/src/test/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCaseTest.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera.domain.camera.test
 
 import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.domain.camera.CameraUseCase
+import com.google.jetpackcamera.domain.camera.CameraUseCase.LensFacing
 import com.google.jetpackcamera.settings.model.FlashMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -65,7 +66,7 @@ class FakeCameraUseCaseTest {
     fun screenFlashDisabled_whenFlashModeOffAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
         cameraUseCase.setFlashMode(flashMode = FlashMode.OFF)
         advanceUntilIdle()
 
@@ -76,7 +77,7 @@ class FakeCameraUseCaseTest {
     fun screenFlashDisabled_whenFlashModeOnAndNotFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.flipCamera(isFrontFacing = false)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.BACK)
         cameraUseCase.setFlashMode(flashMode = FlashMode.ON)
         advanceUntilIdle()
 
@@ -87,7 +88,7 @@ class FakeCameraUseCaseTest {
     fun screenFlashDisabled_whenFlashModeAutoAndNotFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.flipCamera(isFrontFacing = false)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.BACK)
         cameraUseCase.setFlashMode(flashMode = FlashMode.AUTO)
         advanceUntilIdle()
 
@@ -98,7 +99,7 @@ class FakeCameraUseCaseTest {
     fun screenFlashEnabled_whenFlashModeOnAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
         cameraUseCase.setFlashMode(flashMode = FlashMode.ON)
         advanceUntilIdle()
 
@@ -109,7 +110,7 @@ class FakeCameraUseCaseTest {
     fun screenFlashEnabled_whenFlashModeAutoAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
         cameraUseCase.setFlashMode(flashMode = FlashMode.AUTO)
         advanceUntilIdle()
 
@@ -127,7 +128,7 @@ class FakeCameraUseCaseTest {
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash
-        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
         cameraUseCase.setFlashMode(FlashMode.ON)
         advanceUntilIdle()
         cameraUseCase.takePicture()

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -49,6 +50,7 @@ import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreenOverlay
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 
 private const val TAG = "PreviewScreen"
 
@@ -89,7 +91,7 @@ fun PreviewScreen(
             surfaceRequest = surfaceRequest,
             onNavigateToSettings = onNavigateToSettings,
             onClearUiScreenBrightness = viewModel.screenFlash::setClearUiScreenBrightness,
-            onFlipCamera = viewModel::flipCamera,
+            onSetLensFacing = viewModel::setLensFacing,
             onTapToFocus = viewModel::tapToFocus,
             onChangeZoomScale = viewModel::setZoomScale,
             onChangeFlash = viewModel::setFlash,
@@ -113,7 +115,7 @@ private fun ContentScreen(
     surfaceRequest: SurfaceRequest?,
     onNavigateToSettings: () -> Unit = {},
     onClearUiScreenBrightness: (Float) -> Unit = {},
-    onFlipCamera: () -> Unit = {},
+    onSetLensFacing: (newLensFacing: LensFacing) -> Unit = {},
     onTapToFocus: (Display, Int, Int, Float, Float) -> Unit = { _, _, _, _, _ -> },
     onChangeZoomScale: (Float) -> Unit = {},
     onChangeFlash: (FlashMode) -> Unit = {},
@@ -130,6 +132,15 @@ private fun ContentScreen(
     onStopVideoRecording: () -> Unit = {},
     onToastShown: () -> Unit = {}
 ) {
+    val lensFacing = remember(previewUiState) {
+        previewUiState.currentCameraSettings.cameraLensFacing
+    }
+
+    val onFlipCamera = remember(lensFacing) {
+        {
+            onSetLensFacing(lensFacing.flip())
+        }
+    }
     // display camera feed. this stays behind everything else
     PreviewDisplay(
         onFlipCamera = onFlipCamera,
@@ -144,7 +155,7 @@ private fun ContentScreen(
         isOpen = previewUiState.quickSettingsIsOpen,
         toggleIsOpen = onToggleQuickSettings,
         currentCameraSettings = previewUiState.currentCameraSettings,
-        onLensFaceClick = { onFlipCamera() },
+        onLensFaceClick = onSetLensFacing,
         onFlashModeClick = onChangeFlash,
         onAspectRatioClick = onChangeAspectRatio,
         onCaptureModeClick = onChangeCaptureMode

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -29,6 +29,7 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -146,10 +147,14 @@ class PreviewViewModel @Inject constructor(
             if (previewUiState.value.currentCameraSettings.isBackCameraAvailable &&
                 previewUiState.value.currentCameraSettings.isFrontCameraAvailable
             ) {
+                val newLensFacing =
+                    if (previewUiState.value.currentCameraSettings.isFrontCameraFacing) {
+                        LensFacing.BACK
+                    } else {
+                        LensFacing.FRONT
+                    }
                 // apply to cameraUseCase
-                cameraUseCase.flipCamera(
-                    !previewUiState.value.currentCameraSettings.isFrontCameraFacing
-                )
+                cameraUseCase.setLensFacing(newLensFacing)
             }
         }
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -140,19 +140,19 @@ class PreviewViewModel @Inject constructor(
         }
     }
 
-    // sets the camera to a designated direction
-    fun flipCamera() {
+    /** Sets the camera to a designated lens facing */
+    fun setLensFacing(newLensFacing: LensFacing) {
         viewModelScope.launch {
-            // only flip if 2 directions are available
-            if (previewUiState.value.currentCameraSettings.isBackCameraAvailable &&
-                previewUiState.value.currentCameraSettings.isFrontCameraAvailable
+            // TODO(tm): Move constraint checks into CameraUseCase
+            if ((
+                    newLensFacing == LensFacing.BACK &&
+                        previewUiState.value.currentCameraSettings.isBackCameraAvailable
+                    ) ||
+                (
+                    newLensFacing == LensFacing.FRONT &&
+                        previewUiState.value.currentCameraSettings.isFrontCameraAvailable
+                    )
             ) {
-                val newLensFacing =
-                    if (previewUiState.value.currentCameraSettings.isFrontCameraFacing) {
-                        LensFacing.BACK
-                    } else {
-                        LensFacing.FRONT
-                    }
                 // apply to cameraUseCase
                 cameraUseCase.setLensFacing(newLensFacing)
             }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.jetpackcamera.feature.preview.MultipleEventsCutter
@@ -202,7 +201,7 @@ private fun ControlsBottom(
                 if (!isQuickSettingsOpen && videoRecordingState == VideoRecordingState.INACTIVE) {
                     FlipCameraButton(
                         modifier = Modifier.testTag(FLIP_CAMERA_BUTTON),
-                        onFlipCameraClick = onFlipCamera,
+                        onClick = onFlipCamera,
                         // enable only when phone has front and rear camera
                         enabledCondition = currentCameraSettings.isBackCameraAvailable &&
                             currentCameraSettings.isFrontCameraAvailable

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.jetpackcamera.feature.preview.MultipleEventsCutter
@@ -200,6 +201,7 @@ private fun ControlsBottom(
             Row(Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceEvenly) {
                 if (!isQuickSettingsOpen && videoRecordingState == VideoRecordingState.INACTIVE) {
                     FlipCameraButton(
+                        modifier = Modifier.testTag(FLIP_CAMERA_BUTTON),
                         onFlipCameraClick = onFlipCamera,
                         // enable only when phone has front and rear camera
                         enabledCondition = currentCameraSettings.isBackCameraAvailable &&

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -200,7 +200,7 @@ private fun ControlsBottom(
             Row(Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceEvenly) {
                 if (!isQuickSettingsOpen && videoRecordingState == VideoRecordingState.INACTIVE) {
                     FlipCameraButton(
-                        onClick = onFlipCamera,
+                        onFlipCameraClick = onFlipCamera,
                         // enable only when phone has front and rear camera
                         enabledCondition = currentCameraSettings.isBackCameraAvailable &&
                             currentCameraSettings.isFrontCameraAvailable

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -44,8 +44,10 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -117,6 +119,8 @@ fun PreviewDisplay(
         }
     )
 
+    val currentOnFlipCamera by rememberUpdatedState(onFlipCamera)
+
     surfaceRequest?.let {
         BoxWithConstraints(
             Modifier
@@ -127,7 +131,7 @@ fun PreviewDisplay(
                         onDoubleTap = { offset ->
                             // double tap to flip camera
                             Log.d(TAG, "onDoubleTap $offset")
-                            onFlipCamera()
+                            currentOnFlipCamera()
                         }
                     )
                 },
@@ -195,11 +199,11 @@ fun TestingButton(modifier: Modifier = Modifier, onClick: () -> Unit, text: Stri
 fun FlipCameraButton(
     modifier: Modifier = Modifier,
     enabledCondition: Boolean,
-    onClick: () -> Unit
+    onFlipCameraClick: () -> Unit
 ) {
     IconButton(
         modifier = modifier.size(40.dp),
-        onClick = onClick,
+        onClick = { onFlipCameraClick() },
         enabled = enabledCondition
     ) {
         Icon(

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -124,6 +124,7 @@ fun PreviewDisplay(
     surfaceRequest?.let {
         BoxWithConstraints(
             Modifier
+                .testTag(PREVIEW_DISPLAY)
                 .fillMaxSize()
                 .background(Color.Black)
                 .pointerInput(Unit) {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -203,11 +203,11 @@ fun TestingButton(modifier: Modifier = Modifier, onClick: () -> Unit, text: Stri
 fun FlipCameraButton(
     modifier: Modifier = Modifier,
     enabledCondition: Boolean,
-    onFlipCameraClick: () -> Unit
+    onClick: () -> Unit
 ) {
     IconButton(
         modifier = modifier.size(40.dp),
-        onClick = { onFlipCameraClick() },
+        onClick = onClick,
         enabled = enabledCondition
     ) {
         Icon(

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -19,6 +19,7 @@ import android.content.ContentResolver
 import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.domain.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -104,14 +105,14 @@ class PreviewViewModelTest {
     fun flipCamera() = runTest(StandardTestDispatcher()) {
         // initial default value should be back
         previewViewModel.startCamera()
-        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.isFrontCameraFacing)
-            .isFalse()
-        previewViewModel.flipCamera()
+        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.cameraLensFacing)
+            .isEqualTo(LensFacing.BACK)
+        previewViewModel.setLensFacing(LensFacing.FRONT)
 
         advanceUntilIdle()
         // ui state and camera should both be true now
-        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.isFrontCameraFacing)
-            .isTrue()
+        assertThat(previewViewModel.previewUiState.value.currentCameraSettings.cameraLensFacing)
+            .isEqualTo(LensFacing.FRONT)
         assertThat(cameraUseCase.isLensFacingFront).isTrue()
     }
 

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -21,6 +21,7 @@ import com.google.jetpackcamera.domain.camera.CameraUseCase
 import com.google.jetpackcamera.domain.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.feature.preview.rules.MainDispatcherRule
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -63,7 +64,7 @@ class ScreenFlashTest {
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash
-        cameraUseCase.setLensFacing(lensFacing = true)
+        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
         cameraUseCase.setFlashMode(FlashMode.ON)
         val contentResolver: ContentResolver = Mockito.mock()
         cameraUseCase.takePicture(contentResolver, null)

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -63,7 +63,7 @@ class ScreenFlashTest {
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash
-        cameraUseCase.flipCamera(isFrontFacing = true)
+        cameraUseCase.setLensFacing(lensFacing = true)
         cameraUseCase.setFlashMode(FlashMode.ON)
         val contentResolver: ContentResolver = Mockito.mock()
         cameraUseCase.takePicture(contentResolver, null)

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import com.google.jetpackcamera.feature.quicksettings.ui.ExpandedQuickSetRatio
+import com.google.jetpackcamera.feature.quicksettings.ui.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
 import com.google.jetpackcamera.feature.quicksettings.ui.QuickFlipCamera
 import com.google.jetpackcamera.feature.quicksettings.ui.QuickSetCaptureMode
 import com.google.jetpackcamera.feature.quicksettings.ui.QuickSetFlash
@@ -165,7 +166,7 @@ private fun ExpandedQuickSettingsUi(
                         },
                         {
                             QuickFlipCamera(
-                                modifier = Modifier.testTag("QuickSetFlipCamera"),
+                                modifier = Modifier.testTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON),
                                 setLensFacing = { l: LensFacing -> onLensFaceClick(l) },
                                 currentLensFacing = currentCameraSettings.cameraLensFacing
                             )

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/QuickSettingsScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
@@ -48,18 +47,18 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 
 /**
  * The UI component for quick settings.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun QuickSettingsScreenOverlay(
     modifier: Modifier = Modifier,
     currentCameraSettings: CameraAppSettings,
     isOpen: Boolean = false,
     toggleIsOpen: () -> Unit,
-    onLensFaceClick: (lensFace: Boolean) -> Unit,
+    onLensFaceClick: (lensFace: LensFacing) -> Unit,
     onFlashModeClick: (flashMode: FlashMode) -> Unit,
     onAspectRatioClick: (aspectRation: AspectRatio) -> Unit,
     onCaptureModeClick: (captureMode: CaptureMode) -> Unit
@@ -135,7 +134,7 @@ private enum class IsExpandedQuickSetting {
 @Composable
 private fun ExpandedQuickSettingsUi(
     currentCameraSettings: CameraAppSettings,
-    onLensFaceClick: (lensFacingFront: Boolean) -> Unit,
+    onLensFaceClick: (newLensFace: LensFacing) -> Unit,
     onFlashModeClick: (flashMode: FlashMode) -> Unit,
     onAspectRatioClick: (aspectRation: AspectRatio) -> Unit,
     onCaptureModeClick: (captureMode: CaptureMode) -> Unit,
@@ -167,8 +166,8 @@ private fun ExpandedQuickSettingsUi(
                         {
                             QuickFlipCamera(
                                 modifier = Modifier.testTag("QuickSetFlipCamera"),
-                                flipCamera = { b: Boolean -> onLensFaceClick(b) },
-                                currentFacingFront = currentCameraSettings.isFrontCameraFacing
+                                setLensFacing = { l: LensFacing -> onLensFaceClick(l) },
+                                currentLensFacing = currentCameraSettings.cameraLensFacing
                             )
                         },
                         {

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -51,6 +51,7 @@ import com.google.jetpackcamera.quicksettings.R
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import kotlin.math.min
 
 // completed components ready to go into preview screen
@@ -144,13 +145,13 @@ fun QuickSetFlash(
 @Composable
 fun QuickFlipCamera(
     modifier: Modifier = Modifier,
-    flipCamera: (Boolean) -> Unit,
-    currentFacingFront: Boolean
+    setLensFacing: (LensFacing) -> Unit,
+    currentLensFacing: LensFacing
 ) {
     val enum =
-        when (currentFacingFront) {
-            true -> CameraLensFace.FRONT
-            false -> CameraLensFace.BACK
+        when (currentLensFacing) {
+            LensFacing.FRONT -> CameraLensFace.FRONT
+            LensFacing.BACK -> CameraLensFace.BACK
         }
     QuickSettingUiItem(
         modifier = modifier
@@ -162,7 +163,7 @@ fun QuickFlipCamera(
                     }
             },
         enum = enum,
-        onClick = { flipCamera(!currentFacingFront) }
+        onClick = { setLensFacing(currentLensFacing.flip()) }
     )
 }
 

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/QuickSettingsComponents.kt
@@ -154,14 +154,7 @@ fun QuickFlipCamera(
             LensFacing.BACK -> CameraLensFace.BACK
         }
     QuickSettingUiItem(
-        modifier = modifier
-            .semantics {
-                contentDescription =
-                    when (enum) {
-                        CameraLensFace.FRONT -> "QUICK SETTINGS LENS FACING FRONT"
-                        CameraLensFace.BACK -> "QUICK SETTINGS LENS FACING BACK"
-                    }
-            },
+        modifier = modifier,
         enum = enum,
         onClick = { setLensFacing(currentLensFacing.flip()) }
     )
@@ -202,7 +195,11 @@ fun ToggleQuickSettingsButton(toggleDropDown: () -> Unit, isOpen: Boolean) {
         // dropdown icon
         Icon(
             painter = painterResource(R.drawable.baseline_expand_more_72),
-            contentDescription = stringResource(R.string.quick_settings_dropdown_description),
+            contentDescription = if (isOpen) {
+                stringResource(R.string.quick_settings_dropdown_open_description)
+            } else {
+                stringResource(R.string.quick_settings_dropdown_closed_description)
+            },
             modifier = Modifier
                 .testTag("QuickSettingDropDown")
                 .size(72.dp)

--- a/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/TestTags.kt
+++ b/feature/quicksettings/src/main/java/com/google/jetpackcamera/feature/quicksettings/ui/TestTags.kt
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.jetpackcamera.feature.preview.ui
+package com.google.jetpackcamera.feature.quicksettings.ui
 
-const val CAPTURE_BUTTON = "CaptureButton"
-const val SETTINGS_BUTTON = "SettingsButton"
-const val PREVIEW_DISPLAY = "PreviewDisplay"
-const val FLIP_CAMERA_BUTTON = "FlipCameraButton"
-const val QUICK_SETTINGS_BUTTON = "QuickSettingDropDown"
-const val QUICK_SETTINGS_RATIO_BUTTON = "QuickSetAspectRatio"
-const val QUICK_SETTINGS_RATIO_1_1_BUTTON = "QuickSetAspectRatio1:1"
+const val QUICK_SETTINGS_FLIP_CAMERA_BUTTON = "QuickSettingsFlipCameraButton"

--- a/feature/quicksettings/src/main/res/values/strings.xml
+++ b/feature/quicksettings/src/main/res/values/strings.xml
@@ -39,5 +39,6 @@
     <string name="quick_settings_capture_mode_single_description">Single-stream capture mode on</string>
     <string name="quick_settings_capture_mode_multi_description">Multi-stream capture mode on</string>
 
-    <string name="quick_settings_dropdown_description">Quick settings drop down</string>
+    <string name="quick_settings_dropdown_open_description">Quick settings open</string>
+    <string name="quick_settings_dropdown_closed_description">Quick settings closed</string>
 </resources>

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -78,10 +78,11 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
     testImplementation(libs.mockito.core)
     testImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.truth)
 
     implementation(libs.androidx.core.ktx)
 

--- a/feature/settings/src/androidTest/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/androidTest/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -21,12 +21,12 @@ import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import java.io.File
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -89,17 +89,19 @@ internal class CameraAppSettingsViewModelTest {
 
     @Test
     fun setDefaultToFrontCamera() = runTest(StandardTestDispatcher()) {
-        val initialFrontCameraValue =
-            settingsViewModel.settingsUiState.value.cameraAppSettings.isFrontCameraFacing
-        settingsViewModel.setDefaultToFrontCamera()
+        val initialCameraLensFacing =
+            settingsViewModel.settingsUiState.value.cameraAppSettings.cameraLensFacing
+        val nextCameraLensFacing = if (initialCameraLensFacing == LensFacing.FRONT) {
+            LensFacing.BACK
+        } else {
+            LensFacing.FRONT
+        }
+        settingsViewModel.setDefaultLensFacing(nextCameraLensFacing)
 
         advanceUntilIdle()
 
-        val newFrontCameraValue =
-            settingsViewModel.settingsUiState.value.cameraAppSettings.isFrontCameraFacing
-
-        assertFalse(initialFrontCameraValue)
-        assertTrue(newFrontCameraValue)
+        assertThat(settingsViewModel.settingsUiState.value.cameraAppSettings.cameraLensFacing)
+            .isEqualTo(nextCameraLensFacing)
     }
 
     @Test

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -58,7 +58,7 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
 
     DefaultCameraFacing(
         cameraAppSettings = uiState.cameraAppSettings,
-        onClick = viewModel::setDefaultToFrontCamera
+        setDefaultLensFacing = viewModel::setDefaultLensFacing
     )
 
     FlashModeSetting(

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -23,6 +23,7 @@ import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.DarkMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.Stabilization
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -75,14 +76,13 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun setDefaultToFrontCamera() {
-        // true means default is front
+    fun setDefaultLensFacing(lensFacing: LensFacing) {
         viewModelScope.launch {
-            settingsRepository.updateDefaultToFrontCamera()
+            settingsRepository.updateDefaultLensFacing(lensFacing)
             Log.d(
                 TAG,
                 "set camera default facing: " +
-                    "${settingsRepository.getCameraAppSettings().isFrontCameraFacing}"
+                    "${settingsRepository.getCameraAppSettings().cameraLensFacing}"
             )
         }
     }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -54,6 +54,7 @@ import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DarkMode
 import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.Stabilization
 import com.google.jetpackcamera.settings.model.SupportedStabilizationMode
 
@@ -99,15 +100,17 @@ fun SectionHeader(modifier: Modifier = Modifier, title: String) {
 fun DefaultCameraFacing(
     modifier: Modifier = Modifier,
     cameraAppSettings: CameraAppSettings,
-    onClick: () -> Unit
+    setDefaultLensFacing: (LensFacing) -> Unit
 ) {
     SwitchSettingUI(
         modifier = modifier,
         title = stringResource(id = R.string.default_facing_camera_title),
         description = null,
         leadingIcon = null,
-        onClick = { onClick() },
-        settingValue = cameraAppSettings.isFrontCameraFacing,
+        onSwitchChanged = { on ->
+            setDefaultLensFacing(if (on) LensFacing.FRONT else LensFacing.BACK)
+        },
+        settingValue = cameraAppSettings.cameraLensFacing == LensFacing.FRONT,
         enabled = cameraAppSettings.isBackCameraAvailable &&
             cameraAppSettings.isFrontCameraAvailable
     )
@@ -407,7 +410,7 @@ fun SwitchSettingUI(
     title: String,
     description: String?,
     leadingIcon: @Composable (() -> Unit)?,
-    onClick: () -> Unit,
+    onSwitchChanged: (Boolean) -> Unit,
     settingValue: Boolean,
     enabled: Boolean
 ) {
@@ -416,7 +419,7 @@ fun SwitchSettingUI(
             enabled = enabled,
             role = Role.Switch,
             value = settingValue,
-            onValueChange = { _ -> onClick() }
+            onValueChange = { value -> onSwitchChanged(value) }
         ),
         enabled = enabled,
         title = title,
@@ -426,8 +429,8 @@ fun SwitchSettingUI(
             Switch(
                 enabled = enabled,
                 checked = settingValue,
-                onCheckedChange = {
-                    onClick()
+                onCheckedChange = { value ->
+                    onSwitchChanged(value)
                 }
             )
         }


### PR DESCRIPTION
This PR switches our model to explicitly set the LensFacing direction rather than relying on booleans that specify whether it is the front camera that is showing. This will allow for more flexibility in the future for pulling out camera constraints and for supporting more than 2 lens facing directions.

Changes:
- Add LensFacing to model
- Remove unused CameraUseCase data classes
- Change CameraUseCase.flipCamera() to setLensFacing()
- Use of setLensFacing rather than flipCamera
