### PR TITLE
Add RefCounted class

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -51,10 +51,16 @@ android {
 }
 
 dependencies {
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.android.material)
+    implementation(libs.kotlinx.atomicfu)
+
     testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.robolectric)
+
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/core/common/src/main/java/com/google/jetpackcamera/core/common/RefCounted.kt
+++ b/core/common/src/main/java/com/google/jetpackcamera/core/common/RefCounted.kt
@@ -29,7 +29,7 @@ import kotlinx.atomicfu.loop
  */
 class RefCounted<T : Any>(
     private val debugRefCounts: Boolean = false,
-    private val onRelease: (T) -> Unit = {}
+    private val onRelease: (T) -> Unit
 ) {
     private val refCounted = atomic(uninitialized<T>())
 
@@ -37,6 +37,9 @@ class RefCounted<T : Any>(
      * Initializes the ref-count managed object with the object being managed.
      *
      * This also initializes the implicit ref-count to 1.
+     *
+     * All calls to this function must be paired with [release] to ensure the initial implicit
+     * ref count is decremented and the `onRelease` callback can be called.
      *
      */
     fun initialize(newValue: T) {
@@ -105,7 +108,7 @@ class RefCounted<T : Any>(
      */
     fun release() {
         check(refCounted.value != uninitialized<T>()) {
-            "Ref-count managed object has not yet been initialized. Unable to acquire."
+            "Ref-count managed object has not yet been initialized. Unable to release."
         }
 
         refCounted.loop { old ->

--- a/core/common/src/main/java/com/google/jetpackcamera/core/common/RefCounted.kt
+++ b/core/common/src/main/java/com/google/jetpackcamera/core/common/RefCounted.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.common
+
+import android.util.Log
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.loop
+
+/**
+ * A thread-safe, lock-free class for managing the lifecycle of an object using ref-counting.
+ *
+ * The object that is ref-counted can be initialized late using [initialize].
+ *
+ * @param[debugRefCounts] whether to print debug log statements.
+ * @param[onRelease] a block that will be invoked once when the ref-count reaches 0.
+ */
+class RefCounted<T : Any>(
+    private val debugRefCounts: Boolean = false,
+    private val onRelease: (T) -> Unit = {}
+) {
+    private val refCounted = atomic(uninitialized<T>())
+
+    /**
+     * Initializes the ref-count managed object with the object being managed.
+     *
+     * This also initializes the implicit ref-count to 1.
+     *
+     */
+    fun initialize(newValue: T) {
+        val initialVal = Pair(newValue, 1)
+        check(refCounted.compareAndSet(uninitialized(), initialVal)) {
+            "Ref-count managed object has already been initialized."
+        }
+
+        if (debugRefCounts) {
+            Log.d(
+                TAG,
+                "RefCounted@${"%x".format(hashCode())}<${newValue::class.simpleName}> " +
+                    "initialized: [refCount: 1, value: $newValue]",
+                Throwable()
+            )
+        }
+    }
+
+    /**
+     * Retrieves the underlying managed object, increasing the ref-count by 1.
+     *
+     * This increases the ref-count if the object has not already been released. If the object has
+     * been released, `null` is returned.
+     *
+     * All calls to this function must be paired with [release], unless `null` is returned.
+     */
+    fun acquire(): T? {
+        check(refCounted.value != uninitialized<T>()) {
+            "Ref-count managed object has not yet been initialized. Unable to acquire."
+        }
+
+        refCounted.loop { old ->
+            if (old == released<T>()) {
+                if (debugRefCounts) {
+                    Log.d(
+                        TAG,
+                        "RefCounted@${"%x".format(hashCode())}.acquire() failure: " +
+                            "[refCount: 0]",
+                        Throwable()
+                    )
+                }
+                return null
+            }
+
+            val (value, oldCount) = old
+            val new = Pair(value, oldCount + 1)
+            if (refCounted.compareAndSet(old, new)) {
+                if (debugRefCounts) {
+                    Log.d(
+                        TAG,
+                        "RefCounted@${"%x".format(hashCode())}<${value::class.simpleName}>" +
+                            ".acquire() success: [refCount: ${oldCount + 1}, value: $value]",
+                        Throwable()
+                    )
+                }
+                return value
+            }
+        }
+    }
+
+    /**
+     * Decrements the ref-count by 1 after a call to [acquire] or [initialize].
+     *
+     * This should always be called once for each [initialize] call and once for each [acquire]
+     * call that does not return `null`.
+     */
+    fun release() {
+        check(refCounted.value != uninitialized<T>()) {
+            "Ref-count managed object has not yet been initialized. Unable to acquire."
+        }
+
+        refCounted.loop { old ->
+            check(old != released<T>()) {
+                "Release called more times than initialize + acquire."
+            }
+
+            val (value, oldCount) = old
+            val new = if (oldCount == 1) released() else Pair(value, oldCount - 1)
+            if (refCounted.compareAndSet(old, new)) {
+                if (new == released<T>()) {
+                    if (debugRefCounts) {
+                        Log.d(
+                            TAG,
+                            "RefCounted@${"%x".format(hashCode())}<${value::class.simpleName}>" +
+                                ".release() (last ref): [refCount: 0, value: $value]",
+                            Throwable()
+                        )
+                    }
+                    onRelease(value)
+                } else {
+                    if (debugRefCounts) {
+                        Log.d(
+                            TAG,
+                            "RefCounted@${"%x".format(hashCode())}<${value::class.simpleName}>" +
+                                ".release(): [refCount: ${oldCount - 1}, value: $value]",
+                            Throwable()
+                        )
+                    }
+                }
+                return
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "RefCounted"
+        private val UNINITIALIZED = Pair(Unit, -1)
+        private val RELEASED = Pair(Unit, 0)
+
+        @Suppress("UNCHECKED_CAST")
+        private fun <T> uninitialized(): Pair<T, Int> {
+            return UNINITIALIZED as Pair<T, Int>
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        private fun <T> released(): Pair<T, Int> {
+            return RELEASED as Pair<T, Int>
+        }
+    }
+}

--- a/core/common/src/test/java/com/google/jetpackcamera/core/common/RefCountedTest.kt
+++ b/core/common/src/test/java/com/google/jetpackcamera/core/common/RefCountedTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.common
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
+
+@RunWith(RobolectricTestRunner::class)
+class RefCountedTest {
+
+    @Before
+    fun setUp() {
+        ShadowLog.stream = System.out
+    }
+
+    @Test
+    fun onRelease_calledAfterRelease() {
+        var onReleaseCalled = false
+        val refCounted = RefCounted<Unit> {
+            onReleaseCalled = true
+        }.also {
+            it.initialize(Unit)
+        }
+
+        refCounted.release()
+
+        assertThat(onReleaseCalled).isTrue()
+    }
+
+    @Test
+    fun acquireBeforeInitialize_throwsException() {
+        val refCounted = RefCounted<Unit>()
+        assertThrows(IllegalStateException::class.java) {
+            refCounted.acquire()
+        }
+    }
+
+    @Test
+    fun releaseBeforeInitialize_throwsException() {
+        val refCounted = RefCounted<Unit>()
+        assertThrows(IllegalStateException::class.java) {
+            refCounted.release()
+        }
+    }
+
+    @Test
+    fun releaseCalledMoreTimesThanAcquire_throwsException() {
+        val refCounted = RefCounted<Unit>()
+        refCounted.initialize(Unit)
+        refCounted.release()
+
+        assertThrows(IllegalStateException::class.java) {
+            refCounted.release()
+        }
+    }
+
+    @Test
+    fun acquireAfterRelease_returnsNull() {
+        val refCounted = RefCounted<Unit>()
+        refCounted.initialize(Unit)
+        refCounted.release()
+
+        assertThat(refCounted.acquire()).isNull()
+    }
+
+    @Test
+    fun acquireAfterInitialize_returnsValue() {
+        val value = Object()
+        val refCounted = RefCounted<Any>()
+        refCounted.initialize(value)
+
+        assertThat(refCounted.acquire()).isEqualTo(value)
+    }
+
+    @Test
+    fun acquiresWithMatchedRelease_callsOnRelease() = runBlocking {
+        val onReleaseCalled = atomic(false)
+        val refCounted = RefCounted<Unit> {
+            onReleaseCalled.value = true
+        }.also {
+            it.initialize(Unit)
+        }
+
+        // Run many acquire/release pairs in parallel
+        // Wrap in `coroutineScope` to ensure all children coroutines
+        // have finished before continuing
+        coroutineScope {
+            for (i in 1..1000) {
+                launch(Dispatchers.IO) {
+                    refCounted.acquire()
+                    delay(5)
+                    refCounted.release()
+                }
+            }
+        }
+
+        val onReleaseCalledBeforeFinalRelease = onReleaseCalled.value
+
+        // Call final release to match initialize()
+        refCounted.release()
+
+        assertThat(onReleaseCalledBeforeFinalRelease).isFalse()
+        assertThat(onReleaseCalled.value).isTrue()
+    }
+}

--- a/core/common/src/test/java/com/google/jetpackcamera/core/common/RefCountedTest.kt
+++ b/core/common/src/test/java/com/google/jetpackcamera/core/common/RefCountedTest.kt
@@ -53,7 +53,7 @@ class RefCountedTest {
 
     @Test
     fun acquireBeforeInitialize_throwsException() {
-        val refCounted = RefCounted<Unit>()
+        val refCounted = RefCounted<Unit> {}
         assertThrows(IllegalStateException::class.java) {
             refCounted.acquire()
         }
@@ -61,7 +61,7 @@ class RefCountedTest {
 
     @Test
     fun releaseBeforeInitialize_throwsException() {
-        val refCounted = RefCounted<Unit>()
+        val refCounted = RefCounted<Unit> {}
         assertThrows(IllegalStateException::class.java) {
             refCounted.release()
         }
@@ -69,7 +69,7 @@ class RefCountedTest {
 
     @Test
     fun releaseCalledMoreTimesThanAcquire_throwsException() {
-        val refCounted = RefCounted<Unit>()
+        val refCounted = RefCounted<Unit> {}
         refCounted.initialize(Unit)
         refCounted.release()
 
@@ -80,7 +80,7 @@ class RefCountedTest {
 
     @Test
     fun acquireAfterRelease_returnsNull() {
-        val refCounted = RefCounted<Unit>()
+        val refCounted = RefCounted<Unit> {}
         refCounted.initialize(Unit)
         refCounted.release()
 
@@ -90,7 +90,7 @@ class RefCountedTest {
     @Test
     fun acquireAfterInitialize_returnsValue() {
         val value = Object()
-        val refCounted = RefCounted<Any>()
+        val refCounted = RefCounted<Any> {}
         refCounted.initialize(value)
 
         assertThat(refCounted.acquire()).isEqualTo(value)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidxCore = "1.12.0"
 androidxCoreKtx = "1.12.0"
 androidxLifecycle = "2.7.0"
 androidxTracing = "1.2.0"
+atomicfu = "0.23.2"
 benchmarkMacroJunit4 = "1.2.3"
 camerax = "1.4.0-SNAPSHOT"
 camerax-viewfinder-compose = "1.0.0-SNAPSHOT"
@@ -69,6 +70,7 @@ dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref
 futures-ktx = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "futures" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutinesCore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 


### PR DESCRIPTION
 This is used for shared state between threads.

 It will allow us to track and release Surface usage
 between a GL thread and the main thread.

Example of how it is being used [here](https://github.com/google/jetpack-camera-app/pull/132/files#diff-2c5c256dae5a6352542cb2bad6539b3bb4a36935bc7d845c014315339c4bd9ab)
