### PR TITLE
Remove usages of deprecated proto fields

### DIFF
--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/JcaSettingsSerializer.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/JcaSettingsSerializer.kt
@@ -25,7 +25,7 @@ object JcaSettingsSerializer : Serializer<JcaSettings> {
 
     override val defaultValue: JcaSettings = JcaSettings.newBuilder()
         .setDarkModeStatus(DarkMode.DARK_MODE_SYSTEM)
-        .setDefaultFrontCamera(false)
+        .setDefaultLensFacing(LensFacing.LENS_FACING_BACK)
         .setBackCameraAvailable(true)
         .setFrontCameraAvailable(true)
         .setFlashModeStatus(FlashMode.FLASH_MODE_OFF)

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/LocalSettingsRepository.kt
@@ -125,13 +125,7 @@ class LocalSettingsRepository @Inject constructor(
         // if a front or back lens is not present, the option to change
         // the direction of the camera should be disabled
         jcaSettings.updateData { currentSettings ->
-            val newLensFacing = if (currentSettings.defaultFrontCamera) {
-                frontLensAvailable
-            } else {
-                false
-            }
             currentSettings.toBuilder()
-                .setDefaultFrontCamera(newLensFacing)
                 .setFrontCameraAvailable(frontLensAvailable)
                 .setBackCameraAvailable(backLensAvailable)
                 .build()

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeJcaSettingsSerializer.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/test/FakeJcaSettingsSerializer.kt
@@ -22,6 +22,7 @@ import com.google.jetpackcamera.settings.CaptureMode
 import com.google.jetpackcamera.settings.DarkMode
 import com.google.jetpackcamera.settings.FlashMode
 import com.google.jetpackcamera.settings.JcaSettings
+import com.google.jetpackcamera.settings.LensFacing
 import com.google.jetpackcamera.settings.PreviewStabilization
 import com.google.jetpackcamera.settings.VideoStabilization
 import com.google.protobuf.InvalidProtocolBufferException
@@ -35,7 +36,7 @@ class FakeJcaSettingsSerializer(
 
     override val defaultValue: JcaSettings = JcaSettings.newBuilder()
         .setDarkModeStatus(DarkMode.DARK_MODE_SYSTEM)
-        .setDefaultFrontCamera(false)
+        .setDefaultLensFacing(LensFacing.LENS_FACING_BACK)
         .setBackCameraAvailable(true)
         .setFrontCameraAvailable(true)
         .setFlashModeStatus(FlashMode.FLASH_MODE_OFF)


### PR DESCRIPTION
 Replace some usage of boolean lens facing tracking with enum version
 that was missed in #133
