### PR TITLE
Show version information in SettingsScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         minSdk = 21
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0"
+        versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -26,10 +26,12 @@ import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
+import com.google.jetpackcamera.BuildConfig
 import com.google.jetpackcamera.feature.preview.PreviewMode
 import com.google.jetpackcamera.feature.preview.PreviewScreen
 import com.google.jetpackcamera.feature.preview.PreviewViewModel
 import com.google.jetpackcamera.settings.SettingsScreen
+import com.google.jetpackcamera.settings.VersionInfoHolder
 import com.google.jetpackcamera.ui.Routes.PREVIEW_ROUTE
 import com.google.jetpackcamera.ui.Routes.SETTINGS_ROUTE
 
@@ -72,6 +74,10 @@ private fun JetpackCameraNavHost(
         }
         composable(SETTINGS_ROUTE) {
             SettingsScreen(
+                versionInfo = VersionInfoHolder(
+                    versionName = BuildConfig.VERSION_NAME,
+                    buildType = BuildConfig.BUILD_TYPE
+                ),
                 onNavigateBack = { navController.popBackStack() }
             )
         }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.settings
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -23,7 +24,15 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.jetpackcamera.settings.model.AspectRatio
+import com.google.jetpackcamera.settings.model.CaptureMode
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
+import com.google.jetpackcamera.settings.model.DarkMode
+import com.google.jetpackcamera.settings.model.FlashMode
+import com.google.jetpackcamera.settings.model.LensFacing
+import com.google.jetpackcamera.settings.model.Stabilization
 import com.google.jetpackcamera.settings.ui.AspectRatioSetting
 import com.google.jetpackcamera.settings.ui.CaptureModeSetting
 import com.google.jetpackcamera.settings.ui.DarkModeSetting
@@ -32,14 +41,47 @@ import com.google.jetpackcamera.settings.ui.FlashModeSetting
 import com.google.jetpackcamera.settings.ui.SectionHeader
 import com.google.jetpackcamera.settings.ui.SettingsPageHeader
 import com.google.jetpackcamera.settings.ui.StabilizationSetting
+import com.google.jetpackcamera.settings.ui.VersionInfo
+import com.google.jetpackcamera.settings.ui.theme.SettingsPreviewTheme
 
 /**
  * Screen used for the Settings feature.
  */
 @Composable
-fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel(), onNavigateBack: () -> Unit) {
+fun SettingsScreen(
+    versionInfo: VersionInfoHolder,
+    viewModel: SettingsViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit
+) {
     val settingsUiState by viewModel.settingsUiState.collectAsState()
 
+    SettingsScreen(
+        uiState = settingsUiState,
+        versionInfo = versionInfo,
+        onNavigateBack = onNavigateBack,
+        setDefaultLensFacing = viewModel::setDefaultLensFacing,
+        setFlashMode = viewModel::setFlashMode,
+        setAspectRatio = viewModel::setAspectRatio,
+        setCaptureMode = viewModel::setCaptureMode,
+        setVideoStabilization = viewModel::setVideoStabilization,
+        setPreviewStabilization = viewModel::setPreviewStabilization,
+        setDarkMode = viewModel::setDarkMode
+    )
+}
+
+@Composable
+private fun SettingsScreen(
+    uiState: SettingsUiState,
+    versionInfo: VersionInfoHolder,
+    onNavigateBack: () -> Unit = {},
+    setDefaultLensFacing: (LensFacing) -> Unit = {},
+    setFlashMode: (FlashMode) -> Unit = {},
+    setAspectRatio: (AspectRatio) -> Unit = {},
+    setCaptureMode: (CaptureMode) -> Unit = {},
+    setVideoStabilization: (Stabilization) -> Unit = {},
+    setPreviewStabilization: (Stabilization) -> Unit = {},
+    setDarkMode: (DarkMode) -> Unit = {}
+) {
     Column(
         modifier = Modifier
             .verticalScroll(rememberScrollState())
@@ -48,32 +90,52 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel(), onNavigateBac
             title = stringResource(id = R.string.settings_title),
             navBack = onNavigateBack
         )
-        SettingsList(uiState = settingsUiState, viewModel = viewModel)
+        SettingsList(
+            uiState = uiState,
+            versionInfo = versionInfo,
+            setDefaultLensFacing = setDefaultLensFacing,
+            setFlashMode = setFlashMode,
+            setAspectRatio = setAspectRatio,
+            setCaptureMode = setCaptureMode,
+            setVideoStabilization = setVideoStabilization,
+            setPreviewStabilization = setPreviewStabilization,
+            setDarkMode = setDarkMode
+        )
     }
 }
 
 @Composable
-fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
+fun SettingsList(
+    uiState: SettingsUiState,
+    versionInfo: VersionInfoHolder,
+    setDefaultLensFacing: (LensFacing) -> Unit = {},
+    setFlashMode: (FlashMode) -> Unit = {},
+    setAspectRatio: (AspectRatio) -> Unit = {},
+    setCaptureMode: (CaptureMode) -> Unit = {},
+    setVideoStabilization: (Stabilization) -> Unit = {},
+    setPreviewStabilization: (Stabilization) -> Unit = {},
+    setDarkMode: (DarkMode) -> Unit = {}
+) {
     SectionHeader(title = stringResource(id = R.string.section_title_camera_settings))
 
     DefaultCameraFacing(
         cameraAppSettings = uiState.cameraAppSettings,
-        setDefaultLensFacing = viewModel::setDefaultLensFacing
+        setDefaultLensFacing = setDefaultLensFacing
     )
 
     FlashModeSetting(
         currentFlashMode = uiState.cameraAppSettings.flashMode,
-        setFlashMode = viewModel::setFlashMode
+        setFlashMode = setFlashMode
     )
 
     AspectRatioSetting(
         currentAspectRatio = uiState.cameraAppSettings.aspectRatio,
-        setAspectRatio = viewModel::setAspectRatio
+        setAspectRatio = setAspectRatio
     )
 
     CaptureModeSetting(
         currentCaptureMode = uiState.cameraAppSettings.captureMode,
-        setCaptureMode = viewModel::setCaptureMode
+        setCaptureMode = setCaptureMode
     )
 
     // TODO: b/326140212 - stabilization setting not changing active stabilization mode
@@ -82,14 +144,41 @@ fun SettingsList(uiState: SettingsUiState, viewModel: SettingsViewModel) {
         currentVideoStabilization = uiState.cameraAppSettings.videoCaptureStabilization,
         currentPreviewStabilization = uiState.cameraAppSettings.previewStabilization,
         supportedStabilizationMode = uiState.cameraAppSettings.supportedStabilizationModes,
-        setVideoStabilization = viewModel::setVideoStabilization,
-        setPreviewStabilization = viewModel::setPreviewStabilization
+        setVideoStabilization = setVideoStabilization,
+        setPreviewStabilization = setPreviewStabilization
     )
 
     SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
 
     DarkModeSetting(
         currentDarkMode = uiState.cameraAppSettings.darkMode,
-        setDarkMode = viewModel::setDarkMode
+        setDarkMode = setDarkMode
     )
+
+    SectionHeader(title = stringResource(id = R.string.section_title_software_info))
+
+    VersionInfo(
+        versionName = versionInfo.versionName,
+        buildType = versionInfo.buildType
+    )
+}
+
+data class VersionInfoHolder(
+    val versionName: String,
+    val buildType: String
+)
+
+@Preview(name = "Light Mode", showBackground = true)
+@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun Preview_SettingsScreen() {
+    SettingsPreviewTheme {
+        SettingsScreen(
+            uiState = SettingsUiState(DEFAULT_CAMERA_APP_SETTINGS),
+            versionInfo = VersionInfoHolder(
+                versionName = "1.0.0",
+                buildType = "release"
+            )
+        )
+    }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -41,9 +41,9 @@ import com.google.jetpackcamera.settings.ui.FlashModeSetting
 import com.google.jetpackcamera.settings.ui.SectionHeader
 import com.google.jetpackcamera.settings.ui.SettingsPageHeader
 import com.google.jetpackcamera.settings.ui.StabilizationSetting
+import com.google.jetpackcamera.settings.ui.TargetFpsSetting
 import com.google.jetpackcamera.settings.ui.VersionInfo
 import com.google.jetpackcamera.settings.ui.theme.SettingsPreviewTheme
-import com.google.jetpackcamera.settings.ui.TargetFpsSetting
 
 /**
  * Screen used for the Settings feature.

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.settings.ui
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -46,6 +47,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.settings.R
@@ -57,6 +61,7 @@ import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.Stabilization
 import com.google.jetpackcamera.settings.model.SupportedStabilizationMode
+import com.google.jetpackcamera.settings.ui.theme.SettingsPreviewTheme
 
 /**
  * MAJOR SETTING UI COMPONENTS
@@ -357,6 +362,22 @@ fun StabilizationSetting(
     )
 }
 
+@Composable
+fun VersionInfo(versionName: String, buildType: String = "") {
+    SettingUI(
+        title = stringResource(id = R.string.version_info_title),
+        leadingIcon = null
+    ) {
+        val versionString = versionName +
+            if (buildType.isNotEmpty()) {
+                "/${buildType.toUpperCase(Locale.current)}"
+            } else {
+                ""
+            }
+        Text(text = versionString)
+    }
+}
+
 /*
  * Setting UI sub-Components
  * small and whimsical :)
@@ -511,5 +532,14 @@ fun SingleChoiceSelector(
             },
             trailingContent = null
         )
+    }
+}
+
+@Preview(name = "Light Mode")
+@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun Preview_VersionInfo() {
+    SettingsPreviewTheme {
+        VersionInfo(versionName = "0.1.0", buildType = "debug")
     }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -48,10 +48,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.settings.R

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/theme/Theme.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/theme/Theme.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.settings.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun SettingsPreviewTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Dynamic color is available on Android 12+
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme =
+        when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
+
+            darkTheme -> darkColorScheme()
+            else -> lightColorScheme()
+        }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        content = content
+    )
+}

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
 
     <string name="section_title_camera_settings">Default Camera Settings</string>
     <string name="section_title_app_settings">App Settings</string>
+    <string name="section_title_software_info">Software Information</string>
 
     <string name="default_facing_camera_title">Default to Front Camera</string>
     <string name="default_facing_camera_description">Default Front</string>
@@ -84,4 +85,7 @@
     <string name="stabilization_description_high_quality">Stabilization High Quality</string>
     <string name="stabilization_description_off">Stabilization Off</string>
     <string name="stabilization_description_unsupported">Stabilization unsupported</string>
+
+    <!-- Version info strings -->
+    <string name="version_info_title">Version</string>
 </resources>


### PR DESCRIPTION
 Display version information from gradle's generated BuildConfig
 in the app setting screen

 Also adds ability to preview settings screen using Compose previews

![image](https://github.com/google/jetpack-camera-app/assets/1455403/63e61676-994a-4ee7-92db-7c98bc21c204)

