### PR TITLE
Remove deprecated targetSdk property in library modules

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -28,7 +28,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/domain/camera/build.gradle.kts
+++ b/domain/camera/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/feature/quicksettings/build.gradle.kts
+++ b/feature/quicksettings/build.gradle.kts
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
As per https://stackoverflow.com/questions/75256272/kotlin-multiplatform-mobile-targetsdk-deprecated, the targetSdk property is not needed in library modules. This PR removes them.