### PR TITLE
Fix settings screen transition animation

### DIFF
--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -16,9 +16,11 @@
 package com.google.jetpackcamera.settings
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -88,6 +90,7 @@ private fun SettingsScreen(
     Column(
         modifier = Modifier
             .verticalScroll(rememberScrollState())
+            .background(color = MaterialTheme.colorScheme.background)
     ) {
         SettingsPageHeader(
             title = stringResource(id = R.string.settings_title),
@@ -178,7 +181,7 @@ data class VersionInfoHolder(
     val buildType: String
 )
 
-@Preview(name = "Light Mode", showBackground = true)
+@Preview(name = "Light Mode")
 @Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun Preview_SettingsScreen() {


### PR DESCRIPTION
 - The settings screen column didn't have a background, so during
   the transition animation, any elements without a background
   use the old background until the transition is complete. This
   adds a background to the settings screen column.

**Before**:
![image](https://github.com/google/jetpack-camera-app/assets/1455403/c7734c40-4326-46c9-b164-c869eb7bb42f)

**After**:
![image](https://github.com/google/jetpack-camera-app/assets/1455403/ef24c21c-a9eb-4a32-8a3e-bda4a5369ccf)

