### PR TITLE
Refactor ScreenFlash UI state

### DIFF
--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -116,6 +116,7 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
+    testImplementation(kotlin("test"))
     debugImplementation(libs.androidx.test.monitor)
     implementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/feature/preview/src/androidTest/java/com/google/jetpackcamera/feature/preview/ui/ScreenFlashComponentsKtTest.kt
+++ b/feature/preview/src/androidTest/java/com/google/jetpackcamera/feature/preview/ui/ScreenFlashComponentsKtTest.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.jetpackcamera.feature.preview.ScreenFlash
+import com.google.jetpackcamera.feature.preview.ScreenFlashUiState
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -42,8 +42,8 @@ class ScreenFlashComponentsKtTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private val screenFlashUiState: MutableState<ScreenFlash.ScreenFlashUiState> =
-        mutableStateOf(ScreenFlash.ScreenFlashUiState())
+    private val screenFlashUiState: MutableState<ScreenFlashUiState> =
+        mutableStateOf(ScreenFlashUiState.NotApplied())
 
     @Before
     fun setUp() {
@@ -63,7 +63,7 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_existsAfterStateIsEnabled() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
 
         composeTestRule.awaitIdle()
         composeTestRule.onNode(hasTestTag("ScreenFlashOverlay")).assertExists()
@@ -71,8 +71,8 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_doesNotExistWhenDisabledAfterEnabled() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = false)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
+        screenFlashUiState.value = ScreenFlashUiState.NotApplied()
 
         composeTestRule.awaitIdle()
         composeTestRule.onNode(hasTestTag("ScreenFlashOverlay")).assertDoesNotExist()
@@ -80,7 +80,7 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_sizeFillsMaxSize() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
 
         composeTestRule.awaitIdle()
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
@@ -92,7 +92,7 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_fullWhiteWhenEnabled() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
 
         composeTestRule.awaitIdle()
         val overlayScreenShot =

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -71,7 +71,7 @@ fun PreviewScreen(
 
     val previewUiState: PreviewUiState by viewModel.previewUiState.collectAsState()
 
-    val screenFlashUiState: ScreenFlash.ScreenFlashUiState
+    val screenFlashUiState: ScreenFlashUiState
         by viewModel.screenFlash.screenFlashUiState.collectAsState()
 
     val surfaceRequest: SurfaceRequest?
@@ -113,7 +113,7 @@ fun PreviewScreen(
 private fun ContentScreen(
     previewUiState: PreviewUiState,
     previewMode: PreviewMode,
-    screenFlashUiState: ScreenFlash.ScreenFlashUiState,
+    screenFlashUiState: ScreenFlashUiState,
     surfaceRequest: SurfaceRequest?,
     onNavigateToSettings: () -> Unit = {},
     onClearUiScreenBrightness: (Float) -> Unit = {},
@@ -224,7 +224,7 @@ private fun ContentScreenPreview() {
         ContentScreen(
             previewUiState = PreviewUiState(),
             previewMode = PreviewMode.StandardMode {},
-            screenFlashUiState = ScreenFlash.ScreenFlashUiState(),
+            screenFlashUiState = ScreenFlashUiState.NotApplied(),
             surfaceRequest = null
         )
     }
@@ -239,7 +239,7 @@ private fun ContentScreen_WhileRecording() {
                 videoRecordingState = VideoRecordingState.ACTIVE
             ),
             previewMode = PreviewMode.StandardMode {},
-            screenFlashUiState = ScreenFlash.ScreenFlashUiState(),
+            screenFlashUiState = ScreenFlashUiState.NotApplied(),
             surfaceRequest = null
         )
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ScreenFlash.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ScreenFlash.kt
@@ -33,23 +33,24 @@ class ScreenFlash(
     cameraUseCase: CameraUseCase,
     scope: CoroutineScope
 ) {
-    private var screenBrightnessToRestore : Float? = null
+    private var screenBrightnessToRestore: Float? = null
 
-    val screenFlashUiState: StateFlow<ScreenFlashUiState> = cameraUseCase.getScreenFlashEvents().map { event ->
-        when (event.type) {
-            CameraUseCase.ScreenFlashEvent.Type.APPLY_UI ->
-                ScreenFlashUiState.Applied(onComplete = event.onComplete)
-            CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI -> {
-                ScreenFlashUiState.NotApplied(
-                    screenBrightnessToRestore = screenBrightnessToRestore
-                )
+    val screenFlashUiState: StateFlow<ScreenFlashUiState> =
+        cameraUseCase.getScreenFlashEvents().map { event ->
+            when (event.type) {
+                CameraUseCase.ScreenFlashEvent.Type.APPLY_UI ->
+                    ScreenFlashUiState.Applied(onComplete = event.onComplete)
+                CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI -> {
+                    ScreenFlashUiState.NotApplied(
+                        screenBrightnessToRestore = screenBrightnessToRestore
+                    )
+                }
             }
-        }
-    }.stateIn(
-        scope = scope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = ScreenFlashUiState.NotApplied()
-    )
+        }.stateIn(
+            scope = scope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ScreenFlashUiState.NotApplied()
+        )
 
     /**
      * Set the screen brightness to restore to after a screen flash has been applied.

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ScreenFlash.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ScreenFlash.kt
@@ -17,9 +17,10 @@ package com.google.jetpackcamera.feature.preview
 
 import com.google.jetpackcamera.domain.camera.CameraUseCase
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 private const val TAG = "ScreenFlash"
 
@@ -29,59 +30,36 @@ private const val TAG = "ScreenFlash"
 // TODO: Add this to ViewModelScoped so that it can be injected automatically. However, the current
 //  ViewModel and Hilt APIs probably don't support injecting the viewModelScope.
 class ScreenFlash(
-    private val cameraUseCase: CameraUseCase,
-    private val scope: CoroutineScope
+    cameraUseCase: CameraUseCase,
+    scope: CoroutineScope
 ) {
-    data class ScreenFlashUiState(
-        val enabled: Boolean = false,
-        val onChangeComplete: () -> Unit = {},
-        // restored during CLEAR_UI event
-        val screenBrightnessToRestore: Float? = null
-    )
+    private var screenBrightnessToRestore : Float? = null
 
-    private val _screenFlashUiState: MutableStateFlow<ScreenFlashUiState> =
-        MutableStateFlow(ScreenFlashUiState())
-    val screenFlashUiState: StateFlow<ScreenFlashUiState> = _screenFlashUiState
-
-    init {
-        scope.launch {
-            cameraUseCase.getScreenFlashEvents().collect { event ->
-                _screenFlashUiState.emit(
-                    when (event.type) {
-                        CameraUseCase.ScreenFlashEvent.Type.APPLY_UI ->
-                            screenFlashUiState.value.copy(
-                                enabled = true,
-                                onChangeComplete = event.onComplete
-                            )
-
-                        CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI ->
-                            screenFlashUiState.value.copy(
-                                enabled = false,
-                                onChangeComplete = {
-                                    event.onComplete()
-                                    // reset ui state on CLEAR_UI event completion
-                                    scope.launch {
-                                        _screenFlashUiState.emit(
-                                            ScreenFlashUiState()
-                                        )
-                                    }
-                                }
-                            )
-                    }
+    val screenFlashUiState: StateFlow<ScreenFlashUiState> = cameraUseCase.getScreenFlashEvents().map { event ->
+        when (event.type) {
+            CameraUseCase.ScreenFlashEvent.Type.APPLY_UI ->
+                ScreenFlashUiState.Applied(onComplete = event.onComplete)
+            CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI -> {
+                ScreenFlashUiState.NotApplied(
+                    screenBrightnessToRestore = screenBrightnessToRestore
                 )
             }
         }
-    }
+    }.stateIn(
+        scope = scope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = ScreenFlashUiState.NotApplied()
+    )
 
     /**
-     * Sets the screenBrightness value to the value right before APPLY_UI event for the next
-     * CLEAR_UI event, will be set to unknown (null) again after CLEAR_UI event is completed.
+     * Set the screen brightness to restore to after a screen flash has been applied.
      */
     fun setClearUiScreenBrightness(brightness: Float) {
-        scope.launch {
-            _screenFlashUiState.emit(
-                screenFlashUiState.value.copy(screenBrightnessToRestore = brightness)
-            )
-        }
+        screenBrightnessToRestore = brightness
     }
+}
+
+sealed interface ScreenFlashUiState {
+    data class Applied(val onComplete: () -> Unit) : ScreenFlashUiState
+    data class NotApplied(val screenBrightnessToRestore: Float? = null) : ScreenFlashUiState
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ScreenFlashComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ScreenFlashComponents.kt
@@ -43,7 +43,7 @@ fun ScreenFlashScreen(
 ) {
     ScreenFlashOverlay(screenFlashUiState)
 
-    when(screenFlashUiState){
+    when (screenFlashUiState) {
         is ScreenFlashUiState.Applied -> {
             BrightnessMaximization(onInitialBrightnessCalculated = onInitialBrightnessCalculated)
         }

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -34,6 +34,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
+import kotlin.test.assertIs
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ScreenFlashTest {
@@ -49,19 +50,21 @@ class ScreenFlashTest {
     @Before
     fun setup() = runTest(testDispatcher) {
         screenFlash = ScreenFlash(cameraUseCase, testScope)
+        advanceUntilIdle() // Ensure that the subject under test has finished initializing.
     }
 
     @Test
-    fun initialScreenFlashUiState_disabledByDefault() {
-        assertThat(screenFlash.screenFlashUiState.value.enabled).isFalse()
+    fun initialScreenFlashUiState_notAppliedByDefault() {
+        assertIs<ScreenFlashUiState.NotApplied>(screenFlash.screenFlashUiState.value)
     }
 
     @Test
     fun captureScreenFlashImage_screenFlashUiStateChangedInCorrectSequence() = runCameraTest {
-        val states = mutableListOf<ScreenFlash.ScreenFlashUiState>()
+        val states = mutableListOf<ScreenFlashUiState>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             screenFlash.screenFlashUiState.toList(states)
         }
+        advanceUntilIdle()
 
         // FlashMode.ON in front facing camera automatically enables screen flash
         cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
@@ -70,7 +73,7 @@ class ScreenFlashTest {
         cameraUseCase.takePicture(contentResolver, null)
 
         advanceUntilIdle()
-        assertThat(states.map { it.enabled }).containsExactlyElementsIn(
+        assertThat(states.map { it is ScreenFlashUiState.Applied }).containsExactlyElementsIn(
             listOf(
                 false,
                 true,
@@ -81,30 +84,22 @@ class ScreenFlashTest {
 
     @Test
     fun emitClearUiEvent_screenFlashUiStateContainsClearUiScreenBrightness() = runCameraTest {
+
         screenFlash.setClearUiScreenBrightness(5.0f)
+
+        backgroundScope.launch {
+            screenFlash.screenFlashUiState.collect { state ->
+                assertIs<ScreenFlashUiState.NotApplied>(state)
+                assertThat(state.screenBrightnessToRestore)
+                    .isWithin(FLOAT_TOLERANCE)
+                    .of(5.0f)
+            }
+        }
+
         cameraUseCase.emitScreenFlashEvent(
             CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
         )
 
-        advanceUntilIdle()
-        assertThat(screenFlash.screenFlashUiState.value.screenBrightnessToRestore)
-            .isWithin(FLOAT_TOLERANCE)
-            .of(5.0f)
-    }
-
-    @Test
-    fun invokeOnChangeCompleteAfterClearUiEvent_screenFlashUiStateReset() = runCameraTest {
-        screenFlash.setClearUiScreenBrightness(5.0f)
-        cameraUseCase.emitScreenFlashEvent(
-            CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
-        )
-
-        advanceUntilIdle()
-        screenFlash.screenFlashUiState.value.onChangeComplete()
-
-        advanceUntilIdle()
-        assertThat(ScreenFlash.ScreenFlashUiState())
-            .isEqualTo(screenFlash.screenFlashUiState.value)
     }
 
     private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
@@ -112,7 +107,6 @@ class ScreenFlashTest {
             cameraUseCase.initialize()
             cameraUseCase.runCamera()
         }
-
         testBody()
     }
 

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -22,6 +22,7 @@ import com.google.jetpackcamera.domain.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.feature.preview.rules.MainDispatcherRule
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.LensFacing
+import kotlin.test.assertIs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -34,7 +35,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
-import kotlin.test.assertIs
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ScreenFlashTest {
@@ -84,7 +84,6 @@ class ScreenFlashTest {
 
     @Test
     fun emitClearUiEvent_screenFlashUiStateContainsClearUiScreenBrightness() = runCameraTest {
-
         screenFlash.setClearUiScreenBrightness(5.0f)
 
         backgroundScope.launch {
@@ -99,7 +98,6 @@ class ScreenFlashTest {
         cameraUseCase.emitScreenFlashEvent(
             CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
         )
-
     }
 
     private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ui/ScreenFlashComponentsKtTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ui/ScreenFlashComponentsKtTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
-import com.google.jetpackcamera.feature.preview.ScreenFlash
+import com.google.jetpackcamera.feature.preview.ScreenFlashUiState
 import com.google.jetpackcamera.feature.preview.rules.MainDispatcherRule
 import com.google.jetpackcamera.feature.preview.workaround.captureToImage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -59,8 +59,8 @@ class ScreenFlashComponentsKtTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private val screenFlashUiState: MutableState<ScreenFlash.ScreenFlashUiState> =
-        mutableStateOf(ScreenFlash.ScreenFlashUiState())
+    private val screenFlashUiState: MutableState<ScreenFlashUiState> =
+        mutableStateOf(ScreenFlashUiState.NotApplied())
 
     @Before
     fun setUp() {
@@ -80,7 +80,7 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_existsAfterStateIsEnabled() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
 
         advanceUntilIdle()
         composeTestRule.onNode(hasTestTag("ScreenFlashOverlay")).assertExists()
@@ -88,8 +88,8 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_doesNotExistWhenDisabledAfterEnabled() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = false)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
+        screenFlashUiState.value = ScreenFlashUiState.NotApplied()
 
         advanceUntilIdle()
         composeTestRule.onNode(hasTestTag("ScreenFlashOverlay")).assertDoesNotExist()
@@ -97,7 +97,7 @@ class ScreenFlashComponentsKtTest {
 
     @Test
     fun screenFlashOverlay_sizeFillsMaxSize() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
 
         advanceUntilIdle()
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
@@ -111,7 +111,7 @@ class ScreenFlashComponentsKtTest {
     @GraphicsMode(GraphicsMode.Mode.NATIVE)
     @Config(shadows = [ShadowPixelCopy::class])
     fun screenFlashOverlay_fullWhiteWhenEnabled() = runTest {
-        screenFlashUiState.value = ScreenFlash.ScreenFlashUiState(enabled = true)
+        screenFlashUiState.value = ScreenFlashUiState.Applied(onComplete = {})
 
         advanceUntilIdle()
         val overlayScreenShot =


### PR DESCRIPTION
**What I have done and why**

- Moved `ScreenFlashUiState` out of `ScreenFlash` to reduce verbosity for callers
- Refactored `ScreenFlashUiState` into a sealed interface hierarchy (`Applied` and `NotApplied`) to make it clearer which states are valid, and what those states represent
- Changed the way that the UI state flow is initialized. It is now done by mapping events from the `cameraUseCase.getScreenFlashEvents` flow to their relevant UI states. This avoids having an intermediate `MutableStateFlow` and by using `.stateIn(started = WhileSubscribed)` we will only receive events when we have downstream subscribers (i.e. the UI)
- Setting the screen brightness to restore no longer triggers an event
- CoroutineScope is only used during `ScreenFlash` initialization (no heap allocated coroutine scope - more info: https://www.droidcon.com/2023/10/06/coroutines-flow-android-the-good-parts/ see around 11 mins in)