### PR TITLE
Bump CameraX version for temporal noise fix

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         maven {
-            setUrl("https://androidx.dev/snapshots/builds/11445438/artifacts/repository")
+            setUrl("https://androidx.dev/snapshots/builds/11683807/artifacts/repository")
         }
         google()
         mavenCentral()


### PR DESCRIPTION
 This bumps the snapshot version to the build that includes
 aosp/3029366.
