### PR TITLE
SnackBar queueing fix

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -119,7 +119,7 @@ fun PreviewScreen(
             onStopVideoRecording = viewModel::stopVideoRecording,
             onToastShown = viewModel::onToastShown,
             onRequestWindowColorMode = onRequestWindowColorMode,
-            onSnackBarResult = viewModel::onSnackBarResult
+            resetSnackBarData = viewModel::resetSnackBarData
         )
     }
 }
@@ -153,7 +153,7 @@ private fun ContentScreen(
     onStopVideoRecording: () -> Unit = {},
     onToastShown: () -> Unit = {},
     onRequestWindowColorMode: (Int) -> Unit = {},
-    onSnackBarResult: () -> Unit = {}
+    resetSnackBarData: () -> Unit = {}
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
@@ -224,7 +224,7 @@ private fun ContentScreen(
                     snackBarToShow = previewUiState.snackBarToShow,
                     scope = scope,
                     snackbarHostState = snackbarHostState,
-                    onSnackBarResult = onSnackBarResult
+                    resetSnackBarData = resetSnackBarData
                 )
             }
             // Screen flash overlay that stays on top of everything but invisible normally. This should

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -315,7 +315,7 @@ class PreviewViewModel @Inject constructor(
         }
     }
 
-    fun onSnackBarResult() {
+    fun resetSnackBarData() {
         viewModelScope.launch {
             _previewUiState.update { old ->
                 (old as? PreviewUiState.Ready)?.copy(

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -117,8 +117,11 @@ fun TestableSnackBar(
     snackBarToShow: SnackBarData,
     scope: CoroutineScope,
     snackbarHostState: SnackbarHostState,
-    onSnackBarResult: () -> Unit
+    onSnackBarResult: () -> Unit = {},
+    resetSnackBarData: () -> Unit
 ) {
+    // Reset SnackBarData in PreviewUiState to null since the SnackBar is guaranteed to show
+    resetSnackBarData()
     Box(
         // box seems to need to have some size to be detected by UiAutomator
         modifier = modifier
@@ -127,6 +130,10 @@ fun TestableSnackBar(
     ) {
         val context = LocalContext.current
         scope.launch {
+            // Dismiss actively shown SnackBar if any before showing a new one
+            if (snackbarHostState.currentSnackbarData != null) {
+                snackbarHostState.currentSnackbarData!!.dismiss()
+            }
             val result =
                 snackbarHostState.showSnackbar(
                     message = context.getString(snackBarToShow.stringResource),
@@ -142,9 +149,7 @@ fun TestableSnackBar(
                 SnackbarResult.ActionPerformed -> {
                     onSnackBarResult()
                 }
-                SnackbarResult.Dismissed -> {
-                    onSnackBarResult()
-                }
+                SnackbarResult.Dismissed -> {}
             }
         }
         Log.d(


### PR DESCRIPTION

https://github.com/google/jetpack-camera-app/assets/125502967/10bad22f-f28f-43ad-8904-7d08312b4c28

Everytime a new snackbar shows, the old one is dismissed. Making it always a queue of 1 and reflecting the latest capture