### PR TITLE
Make TestableSnackbar more robust

### DIFF
--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -127,6 +127,8 @@ dependencies {
     //Tracing
     implementation(libs.androidx.tracing)
 
+    implementation(libs.kotlinx.atomicfu)
+
     // Project dependencies
     implementation(project(":data:settings"))
     implementation(project(":domain:camera"))

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -52,7 +52,7 @@ import com.google.jetpackcamera.feature.preview.ui.BlinkState
 import com.google.jetpackcamera.feature.preview.ui.CameraControlsOverlay
 import com.google.jetpackcamera.feature.preview.ui.PreviewDisplay
 import com.google.jetpackcamera.feature.preview.ui.ScreenFlashScreen
-import com.google.jetpackcamera.feature.preview.ui.TestableSnackBar
+import com.google.jetpackcamera.feature.preview.ui.TestableSnackbar
 import com.google.jetpackcamera.feature.preview.ui.TestableToast
 import com.google.jetpackcamera.feature.quicksettings.QuickSettingsScreenOverlay
 import com.google.jetpackcamera.settings.model.AspectRatio
@@ -119,7 +119,7 @@ fun PreviewScreen(
             onStopVideoRecording = viewModel::stopVideoRecording,
             onToastShown = viewModel::onToastShown,
             onRequestWindowColorMode = onRequestWindowColorMode,
-            resetSnackBarData = viewModel::resetSnackBarData
+            onSnackBarResult = viewModel::onSnackBarResult
         )
     }
 }
@@ -153,7 +153,7 @@ private fun ContentScreen(
     onStopVideoRecording: () -> Unit = {},
     onToastShown: () -> Unit = {},
     onRequestWindowColorMode: (Int) -> Unit = {},
-    resetSnackBarData: () -> Unit = {}
+    onSnackBarResult: (String) -> Unit = {}
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
@@ -219,12 +219,11 @@ private fun ContentScreen(
             }
 
             if (previewUiState.snackBarToShow != null) {
-                TestableSnackBar(
+                TestableSnackbar(
                     modifier = Modifier.testTag(previewUiState.snackBarToShow.testTag),
-                    snackBarToShow = previewUiState.snackBarToShow,
-                    scope = scope,
+                    snackbarToShow = previewUiState.snackBarToShow,
                     snackbarHostState = snackbarHostState,
-                    resetSnackBarData = resetSnackBarData
+                    onSnackbarResult = onSnackBarResult
                 )
             }
             // Screen flash overlay that stays on top of everything but invisible normally. This should

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -15,7 +15,7 @@
  */
 package com.google.jetpackcamera.feature.preview
 
-import com.google.jetpackcamera.feature.preview.ui.SnackBarData
+import com.google.jetpackcamera.feature.preview.ui.SnackbarData
 import com.google.jetpackcamera.feature.preview.ui.ToastMessage
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.SystemConstraints
@@ -36,7 +36,7 @@ sealed interface PreviewUiState {
 
         // todo: remove after implementing post capture screen
         val toastMessageToShow: ToastMessage? = null,
-        val snackBarToShow: SnackBarData? = null
+        val snackBarToShow: SnackbarData? = null
     ) : PreviewUiState
 }
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -26,7 +26,7 @@ import androidx.tracing.traceAsync
 import com.google.jetpackcamera.domain.camera.CameraUseCase
 import com.google.jetpackcamera.feature.preview.ui.IMAGE_CAPTURE_FAILURE_TAG
 import com.google.jetpackcamera.feature.preview.ui.IMAGE_CAPTURE_SUCCESS_TAG
-import com.google.jetpackcamera.feature.preview.ui.SnackBarData
+import com.google.jetpackcamera.feature.preview.ui.SnackbarData
 import com.google.jetpackcamera.settings.ConstraintsRepository
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
@@ -36,6 +36,7 @@ import com.google.jetpackcamera.settings.model.LensFacing
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -73,6 +74,9 @@ class PreviewViewModel @Inject constructor(
     private var recordingJob: Job? = null
 
     val screenFlash = ScreenFlash(cameraUseCase, viewModelScope)
+
+    private val imageCaptureCalledCount = atomic(0)
+    private val videoCaptureStartedCount = atomic(0)
 
     // Eagerly initialize the CameraUseCase and encapsulate in a Deferred that can be
     // used to ensure we don't start the camera before initialization is complete.
@@ -188,14 +192,17 @@ class PreviewViewModel @Inject constructor(
         onSuccess: (T) -> Unit = {},
         onFailure: (exception: Exception) -> Unit = {}
     ) {
+        val cookieInt = imageCaptureCalledCount.incrementAndGet()
+        val cookie = "Image-$cookieInt"
         try {
-            traceAsync(IMAGE_CAPTURE_TRACE, 0) {
+            traceAsync(IMAGE_CAPTURE_TRACE, cookieInt) {
                 doTakePicture()
             }.also { result ->
                 onSuccess(result)
             }
             Log.d(TAG, "cameraUseCase.takePicture success")
-            SnackBarData(
+            SnackbarData(
+                cookie = cookie,
                 stringResource = R.string.toast_image_capture_success,
                 withDismissAction = true,
                 testTag = IMAGE_CAPTURE_SUCCESS_TAG
@@ -203,7 +210,8 @@ class PreviewViewModel @Inject constructor(
         } catch (exception: Exception) {
             onFailure(exception)
             Log.d(TAG, "cameraUseCase.takePicture error", exception)
-            SnackBarData(
+            SnackbarData(
+                cookie = cookie,
                 stringResource = R.string.toast_capture_failure,
                 withDismissAction = true,
                 testTag = IMAGE_CAPTURE_FAILURE_TAG
@@ -211,7 +219,7 @@ class PreviewViewModel @Inject constructor(
         }.also { snackBarData ->
             _previewUiState.update { old ->
                 (old as? PreviewUiState.Ready)?.copy(
-                    // todo: remove toast after postcapture screen implemented
+                    // todo: remove snackBar after postcapture screen implemented
                     snackBarToShow = snackBarData
                 ) ?: old
             }
@@ -221,16 +229,19 @@ class PreviewViewModel @Inject constructor(
     fun startVideoRecording() {
         Log.d(TAG, "startVideoRecording")
         recordingJob = viewModelScope.launch {
+            val cookie = "Video-${videoCaptureStartedCount.incrementAndGet()}"
             try {
                 cameraUseCase.startVideoRecording {
                     val snackBarData = when (it) {
                         CameraUseCase.OnVideoRecordEvent.OnVideoRecorded ->
-                            SnackBarData(
+                            SnackbarData(
+                                cookie = cookie,
                                 stringResource = R.string.toast_video_capture_success,
                                 withDismissAction = true
                             )
                         else ->
-                            SnackBarData(
+                            SnackbarData(
+                                cookie = cookie,
                                 stringResource = R.string.toast_video_capture_failure,
                                 withDismissAction = true
                             )
@@ -315,12 +326,17 @@ class PreviewViewModel @Inject constructor(
         }
     }
 
-    fun resetSnackBarData() {
+    fun onSnackBarResult(cookie: String) {
         viewModelScope.launch {
             _previewUiState.update { old ->
-                (old as? PreviewUiState.Ready)?.copy(
-                    snackBarToShow = null
-                ) ?: old
+                (old as? PreviewUiState.Ready)?.snackBarToShow?.let {
+                    if (it.cookie == cookie) {
+                        // If the latest snackbar had a result, then clear snackBarToShow
+                        old.copy(snackBarToShow = null)
+                    } else {
+                        old
+                    }
+                } ?: old
             }
         }
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/SnackbarData.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/SnackbarData.kt
@@ -17,7 +17,8 @@ package com.google.jetpackcamera.feature.preview.ui
 
 import androidx.compose.material3.SnackbarDuration
 
-data class SnackBarData(
+data class SnackbarData(
+    val cookie: String,
     val stringResource: Int,
     val duration: SnackbarDuration = SnackbarDuration.Short,
     val actionLabelRes: Int? = null,


### PR DESCRIPTION
 Uses LaunchedEffect rather than the coroutineScope passed in.

 Adds a cookie field SnackBarData so it can be differentiated from
 other SnackBarData.

 Updates a counter for each ImageCapture and VideoCapture which
 is used to generate the cookie for SnackBarData. This is also
 used as the cookie for the image capture trace.

 These changes will also ensure that TestableSnackbar's tagged
 Box is visible for as long as the Snackbar is.

 Renames usage of SnackBar -> Snackbar to match framework component
