### PR TITLE
Add ToggleButton ui component

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -44,7 +44,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.FlipCameraAndroid
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VideoStable
 import androidx.compose.material.icons.filled.Videocam

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -25,43 +25,64 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VideoStable
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.outlined.CameraAlt
+import androidx.compose.material.icons.outlined.Videocam
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.jetpackcamera.feature.preview.PreviewUiState
@@ -69,7 +90,9 @@ import com.google.jetpackcamera.feature.preview.R
 import com.google.jetpackcamera.feature.preview.VideoRecordingState
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.Stabilization
+import kotlin.math.roundToInt
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 private const val TAG = "PreviewScreen"
 private const val BLINK_TIME = 600L
@@ -363,5 +386,171 @@ fun CaptureButton(
                 }
             )
         })
+    }
+}
+
+enum class ToggleState {
+    Left,
+    Right
+}
+
+@Composable
+fun ToggleButton(
+    leftIcon: Painter,
+    rightIcon: Painter,
+    modifier: Modifier = Modifier.width(64.dp).height(32.dp),
+    initialState: ToggleState = ToggleState.Left,
+    onToggleStateChanged: (newState: ToggleState) -> Unit = {},
+    isDisabled: Boolean = false,
+    iconPadding: Dp = 8.dp
+) {
+    val backgroundColor = MaterialTheme.colorScheme.surface
+    val disableColor = MaterialTheme.colorScheme.onSurface
+    val iconSelectionColor = MaterialTheme.colorScheme.onPrimary
+    val iconUnSelectionColor = MaterialTheme.colorScheme.primary
+    val circleSelectionColor = MaterialTheme.colorScheme.primary
+    val circleColor = if (isDisabled) disableColor.copy(alpha = 0.12f) else circleSelectionColor
+    val density = LocalDensity.current
+    var width by remember { mutableStateOf(0.dp) }
+    var height by remember { mutableStateOf(0.dp) }
+    var toggleState by remember { mutableStateOf(initialState) }
+    val animatedTogglePosition by animateFloatAsState(
+        when (toggleState) {
+            ToggleState.Left -> 0f
+            ToggleState.Right -> 1f
+        },
+        label = "anchor"
+    )
+    val scope = rememberCoroutineScope()
+
+    Surface(
+        modifier = modifier
+            .onSizeChanged {
+                width = with(density) { it.width.toDp() }
+                height = with(density) { it.height.toDp() }
+            }
+            .clip(shape = RoundedCornerShape(50))
+            .background(backgroundColor)
+            .then(
+                if (isDisabled) {
+                    Modifier
+                } else {
+                    Modifier.clickable {
+                        scope.launch {
+                            toggleState = when (toggleState) {
+                                ToggleState.Left -> ToggleState.Right
+                                ToggleState.Right -> ToggleState.Left
+                            }
+                            onToggleStateChanged(toggleState)
+                        }
+                    }
+                }
+            )
+    ) {
+        Box {
+            Row(
+                modifier = Modifier.matchParentSize(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    Modifier
+                        .offset {
+                            IntOffset(
+                                x = with(density) {
+                                    animatedTogglePosition * (width - height).toPx()
+                                }.roundToInt(),
+                                y = 0
+                            )
+                        }
+                        .size(height)
+                        .clip(RoundedCornerShape(50))
+                        .background(circleColor)
+                )
+            }
+            Row(
+                modifier = Modifier.matchParentSize().then(
+                    if (isDisabled) Modifier.alpha(0.38f) else Modifier
+                ),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Icon(
+                    painter = leftIcon,
+                    contentDescription = "leftIcon",
+                    modifier = Modifier.padding(iconPadding),
+                    tint = if (isDisabled) {
+                        disableColor
+                    } else if (toggleState == ToggleState.Left) {
+                        iconSelectionColor
+                    } else {
+                        iconUnSelectionColor
+                    }
+                )
+                Icon(
+                    painter = rightIcon,
+                    contentDescription = "rightIcon",
+                    modifier = Modifier.padding(iconPadding),
+                    tint = if (isDisabled) {
+                        disableColor
+                    } else if (toggleState == ToggleState.Right) {
+                        iconSelectionColor
+                    } else {
+                        iconUnSelectionColor
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(backgroundColor = 0xFF000000, showBackground = true)
+@Composable
+private fun Preview_ToggleButton_Selecting_Left() {
+    val initialState = ToggleState.Left
+    var toggleState by remember {
+        mutableStateOf(initialState)
+    }
+    CompositionLocalProvider(LocalContentColor provides Color.White) {
+        ToggleButton(
+            leftIcon = if (toggleState == ToggleState.Left) {
+                rememberVectorPainter(image = Icons.Filled.CameraAlt)
+            } else {
+                rememberVectorPainter(image = Icons.Outlined.CameraAlt)
+            },
+            rightIcon = if (toggleState == ToggleState.Right) {
+                rememberVectorPainter(image = Icons.Filled.Videocam)
+            } else {
+                rememberVectorPainter(image = Icons.Outlined.Videocam)
+            },
+            initialState = ToggleState.Left,
+            onToggleStateChanged = {
+                toggleState = it
+            }
+        )
+    }
+}
+
+@Preview(backgroundColor = 0xFF000000, showBackground = true)
+@Composable
+private fun Preview_ToggleButton_Selecting_Right() {
+    CompositionLocalProvider(LocalContentColor provides Color.White) {
+        ToggleButton(
+            leftIcon = rememberVectorPainter(image = Icons.Outlined.CameraAlt),
+            rightIcon = rememberVectorPainter(image = Icons.Filled.Videocam),
+            initialState = ToggleState.Right
+        )
+    }
+}
+
+@Preview(backgroundColor = 0xFF000000, showBackground = true)
+@Composable
+private fun Preview_ToggleButton_Disabled() {
+    CompositionLocalProvider(LocalContentColor provides Color.White) {
+        ToggleButton(
+            leftIcon = rememberVectorPainter(image = Icons.Outlined.CameraAlt),
+            rightIcon = rememberVectorPainter(image = Icons.Filled.Videocam),
+            initialState = ToggleState.Right,
+            isDisabled = true
+        )
     }
 }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -401,6 +401,8 @@ fun ToggleButton(
     initialState: ToggleState = ToggleState.Left,
     onToggleStateChanged: (newState: ToggleState) -> Unit = {},
     enabled: Boolean = true,
+    leftIconDescription: String = "leftIcon",
+    rightIconDescription: String = "rightIcon",
     iconPadding: Dp = 8.dp
 ) {
     val backgroundColor = MaterialTheme.colorScheme.surfaceContainerHighest
@@ -469,7 +471,7 @@ fun ToggleButton(
             ) {
                 Icon(
                     painter = leftIcon,
-                    contentDescription = "leftIcon",
+                    contentDescription = leftIconDescription,
                     modifier = Modifier.padding(iconPadding),
                     tint = if (!enabled) {
                         disableColor
@@ -481,7 +483,7 @@ fun ToggleButton(
                 )
                 Icon(
                     painter = rightIcon,
-                    contentDescription = "rightIcon",
+                    contentDescription = rightIconDescription,
                     modifier = Modifier.padding(iconPadding),
                     tint = if (!enabled) {
                         disableColor

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/theme/Theme.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/theme/Theme.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.feature.preview.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun PreviewPreviewTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Dynamic color is available on Android 12+
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme =
+        when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
+
+            darkTheme -> darkColorScheme()
+            else -> lightColorScheme()
+        }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        content = content
+    )
+}


### PR DESCRIPTION
This adds a ui component that can be used to choose between image capture and video capture when HDR is enabled:

![Screenshot from 2024-05-09 20-30-50](https://github.com/google/jetpack-camera-app/assets/37896299/f8f85e09-5bfd-47b3-a5de-0d5ad1e7a2ed)

The button can be disabled for the case that only HDR video is supported

The animation for transition between different states is also implemented for completeness.
