### PR TITLE
Use EMBEDDED ImplementationMode when SDK level is <= 24

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -16,10 +16,12 @@
 package com.google.jetpackcamera.feature.preview.ui
 
 import android.content.res.Configuration
+import android.os.Build
 import android.util.Log
 import android.view.Display
 import android.widget.Toast
 import androidx.camera.core.SurfaceRequest
+import androidx.camera.viewfinder.surface.ImplementationMode
 import androidx.compose.animation.core.EaseOutExpo
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -302,6 +304,10 @@ fun PreviewDisplay(
                 CameraXViewfinder(
                     modifier = Modifier.fillMaxSize(),
                     surfaceRequest = it,
+                    implementationMode = when {
+                        Build.VERSION.SDK_INT > 24 -> ImplementationMode.EXTERNAL
+                        else -> ImplementationMode.EMBEDDED
+                    },
                     onRequestWindowColorMode = onRequestWindowColorMode
                 )
             }


### PR DESCRIPTION
Temporary fix for #207 until we fix the problem in camerax-viewfinder-compose

![image](https://github.com/google/jetpack-camera-app/assets/417355/ef179056-e23a-4929-a88f-4e44329b9428)
