### PR TITLE
ResolutionSelector aspectRatio fix

### DIFF
--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -740,7 +740,7 @@ constructor(
 
     private fun getResolutionSelector(aspectRatio: AspectRatio): ResolutionSelector {
         val aspectRatioStrategy = when (aspectRatio) {
-            AspectRatio.THREE_FOUR -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
+            AspectRatio.THREE_FOUR -> AspectRatioStrategy.RATIO_4_3_FALLBACK_AUTO_STRATEGY
             AspectRatio.NINE_SIXTEEN -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
             else -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
         }


### PR DESCRIPTION
The FOV issue is fixed by setting the resolutionSelector with the right aspectRatios. I just confused myself and set the aspect ratio incorrectly.

Preview:

https://github.com/google/jetpack-camera-app/assets/125502967/bc5f52d2-854c-4690-b2ff-990ccc90d2bb

Image:
![JCA-2024-05-30-13-47-27-404](https://github.com/google/jetpack-camera-app/assets/125502967/5c01da4b-14c7-4bcf-b470-c98ba03c539f)
![JCA-2024-05-30-13-47-21-009](https://github.com/google/jetpack-camera-app/assets/125502967/540c28c0-b2e0-4c1e-9906-dff54ddb92f7)

Video:

https://github.com/google/jetpack-camera-app/assets/125502967/8b17c37f-c9e7-4c74-a3d6-55214d79316d


https://github.com/google/jetpack-camera-app/assets/125502967/18fef4a3-4c47-4325-9b26-7bc7cc453dbe

