### PR TITLE
use 4:3 as the default aspect ratio for camera use cases in case of 1:1

### DIFF
--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -775,7 +775,7 @@ constructor(
         return when (aspectRatio) {
             AspectRatio.THREE_FOUR -> RATIO_4_3
             AspectRatio.NINE_SIXTEEN -> RATIO_16_9
-            else -> RATIO_DEFAULT
+            else -> RATIO_4_3
         }
     }
 
@@ -818,7 +818,7 @@ constructor(
         val aspectRatioStrategy = when (aspectRatio) {
             AspectRatio.THREE_FOUR -> AspectRatioStrategy.RATIO_4_3_FALLBACK_AUTO_STRATEGY
             AspectRatio.NINE_SIXTEEN -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
-            else -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
+            else -> AspectRatioStrategy.RATIO_4_3_FALLBACK_AUTO_STRATEGY
         }
         return ResolutionSelector.Builder().setAspectRatioStrategy(aspectRatioStrategy).build()
     }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -27,7 +27,6 @@ import android.util.Log
 import android.util.Range
 import androidx.camera.core.AspectRatio.RATIO_16_9
 import androidx.camera.core.AspectRatio.RATIO_4_3
-import androidx.camera.core.AspectRatio.RATIO_DEFAULT
 import androidx.camera.core.CameraEffect
 import androidx.camera.core.CameraInfo
 import androidx.camera.core.CameraSelector


### PR DESCRIPTION
as titled. We want 4:3 to be the default because it is the uncropped one. Simple change