### PR TITLE
Only request audio permission in Standard mode

### DIFF
--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -68,6 +68,7 @@ private fun JetpackCameraNavHost(
     ) {
         composable(PERMISSIONS_ROUTE) {
             PermissionsScreen(
+                shouldRequestAudioPermission = previewMode is PreviewMode.StandardMode,
                 onNavigateToPreview = {
                     navController.navigate(PREVIEW_ROUTE) {
                         // cannot navigate back to permissions after leaving

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
@@ -47,7 +47,7 @@ fun PermissionsScreen(
             )
         } else {
             listOf(
-                Manifest.permission.CAMERA,
+                Manifest.permission.CAMERA
             )
         }
     )
@@ -71,9 +71,9 @@ fun PermissionsScreen(
     openAppSettings: () -> Unit,
     permissionStates: MultiplePermissionsState,
     viewModel: PermissionsViewModel = hiltViewModel<
-            PermissionsViewModel,
-            PermissionsViewModel.Factory
-            > { factory -> factory.create(permissionStates) }
+        PermissionsViewModel,
+        PermissionsViewModel.Factory
+        > { factory -> factory.create(permissionStates) }
 ) {
     Log.d(TAG, "PermissionsScreen")
     val permissionsUiState: PermissionsUiState by viewModel.permissionsUiState.collectAsState()

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
@@ -34,12 +34,22 @@ private const val TAG = "PermissionsScreen"
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun PermissionsScreen(onNavigateToPreview: () -> Unit, openAppSettings: () -> Unit) {
+fun PermissionsScreen(
+    shouldRequestAudioPermission: Boolean,
+    onNavigateToPreview: () -> Unit,
+    openAppSettings: () -> Unit
+) {
     val permissionStates = rememberMultiplePermissionsState(
-        permissions = listOf(
-            Manifest.permission.CAMERA,
-            Manifest.permission.RECORD_AUDIO
-        )
+        permissions = if (shouldRequestAudioPermission) {
+            listOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO
+            )
+        } else {
+            listOf(
+                Manifest.permission.CAMERA,
+            )
+        }
     )
     PermissionsScreen(
         permissionStates = permissionStates,
@@ -61,9 +71,9 @@ fun PermissionsScreen(
     openAppSettings: () -> Unit,
     permissionStates: MultiplePermissionsState,
     viewModel: PermissionsViewModel = hiltViewModel<
-        PermissionsViewModel,
-        PermissionsViewModel.Factory
-        > { factory -> factory.create(permissionStates) }
+            PermissionsViewModel,
+            PermissionsViewModel.Factory
+            > { factory -> factory.create(permissionStates) }
 ) {
     Log.d(TAG, "PermissionsScreen")
     val permissionsUiState: PermissionsUiState by viewModel.permissionsUiState.collectAsState()


### PR DESCRIPTION
As titled.

I didn't add or modify any test for this because I think it makes sense to work on top of Kim's permission tests. I did locally tested removing the audio permission in ImageCaptureDeviceTest, and observed that the external intent capture tests would pass and the standard capture would fail.