### PR TITLE
Add compileSdkPreview and targetSdkPreview to build files, in order to use VanillaIceCream builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,12 +23,14 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
     namespace = "com.google.jetpackcamera"
 
     defaultConfig {
         applicationId = "com.google.jetpackcamera"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
+        targetSdkPreview = libs.versions.targetSdkPreview.get()
         versionCode = 1
         versionName = "0.1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.benchmark"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -36,6 +37,7 @@ android {
         //Our app has a minSDK of 21, but in order for the benchmark tool to function, it must be 23
         minSdk = 23
         targetSdk = libs.versions.targetSdk.get().toInt()
+        targetSdkPreview = libs.versions.targetSdkPreview.get()
 
         // allows the benchmark to be run on an emulator
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] =

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.core.common"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.data.settings"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/domain/camera/build.gradle.kts
+++ b/domain/camera/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.data.camera"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/permissions/build.gradle.kts
+++ b/feature/permissions/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.permissions"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.feature.preview"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 android {
     namespace = "com.google.jetpackcamera.settings"
     compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdkPreview = libs.versions.compileSdkPreview.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,10 @@
 [versions]
 # Used directly in build.gradle.kts files
 compileSdk = "34"
+compileSdkPreview = "VanillaIceCream"
 minSdk = "21"
 targetSdk = "34"
+targetSdkPreview = "VanillaIceCream"
 composeCompiler = "1.5.10"
 
 # Used below in dependency definitions


### PR DESCRIPTION
Add compileSdkPreview and targetSdkPreview to build files, in order to use VanillaIceCream builds

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/google/jetpack-camera-app/pull/229).
* #216
* #230
* __->__ #229