### PR TITLE
Implement LowLightBoost Capture

### DIFF
--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
@@ -24,6 +24,7 @@ data class CameraConstraints(
     val supportedStabilizationModes: Set<SupportedStabilizationMode>,
     val supportedFixedFrameRates: Set<Int>,
     val supportedDynamicRanges: Set<DynamicRange>,
+    val lowLightBoostSupport: Boolean = false,
     val supportedImageFormatsMap: Map<CaptureMode, Set<ImageOutputFormat>>
 )
 
@@ -41,6 +42,7 @@ val TYPICAL_SYSTEM_CONSTRAINTS =
                         supportedFixedFrameRates = setOf(15, 30),
                         supportedStabilizationModes = emptySet(),
                         supportedDynamicRanges = setOf(DynamicRange.SDR),
+                        lowLightBoostSupport = false,
                         supportedImageFormatsMap = mapOf(
                             Pair(CaptureMode.SINGLE_STREAM, setOf(ImageOutputFormat.JPEG)),
                             Pair(CaptureMode.MULTI_STREAM, setOf(ImageOutputFormat.JPEG))

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LowLightBoost.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LowLightBoost.kt
@@ -17,5 +17,5 @@ package com.google.jetpackcamera.settings.model
 
 enum class LowLightBoost {
     DISABLED,
-    ENABLED,
+    ENABLED
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LowLightBoost.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/LowLightBoost.kt
@@ -17,5 +17,5 @@ package com.google.jetpackcamera.settings.model
 
 enum class LowLightBoost {
     DISABLED,
-    ENABLED
+    ENABLED,
 }

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraUseCase.kt
@@ -73,6 +73,8 @@ interface CameraUseCase {
 
     fun getZoomScale(): StateFlow<Float>
 
+    fun getLowLightBoostActiveStatus(): StateFlow<Boolean>
+
     fun getSurfaceRequest(): StateFlow<SurfaceRequest?>
 
     fun getScreenFlashEvents(): SharedFlow<ScreenFlashEvent>

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -567,6 +567,9 @@ constructor(
     private val _zoomScale = MutableStateFlow(1f)
     override fun getZoomScale(): StateFlow<Float> = _zoomScale.asStateFlow()
 
+    private val _lowLightBoostActiveStatus = MutableStateFlow(true)
+    override fun getLowLightBoostActiveStatus(): StateFlow<Boolean> = _lowLightBoostActiveStatus.asStateFlow()
+
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
@@ -895,8 +898,10 @@ constructor(
                         val boostState = result.get(CaptureResult.CONTROL_LOW_LIGHT_BOOST_STATE)
                         if (boostState == CameraMetadata.CONTROL_LOW_LIGHT_BOOST_STATE_ACTIVE) {
                             Log.d(TAG, "LLB Active")
+                            _lowLightBoostActiveStatus.value = true
                         } else {
                             Log.d(TAG, "LLB Inactive")
+                            _lowLightBoostActiveStatus.value = false
                         }
                     }
                 })

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -227,16 +227,17 @@ constructor(
 
     @androidx.annotation.OptIn(ExperimentalCamera2Interop::class)
     @OptIn(BuildCompat.PrereleaseSdkCheck::class)
-    private fun getLowLightBoostDeviceSupport() =
-        when(BuildCompat.isAtLeastV()) {
-            true -> cameraProvider.availableCameraInfos.map { cameraInfo ->
-                Camera2CameraInfo
-                    .from(cameraInfo)
-                    .getCameraCharacteristic(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES)
-                    ?.contains(CameraMetadata.CONTROL_AE_MODE_ON_LOW_LIGHT_BOOST_BRIGHTNESS_PRIORITY)
-            }.any()
-            false -> false
-        }
+    private fun getLowLightBoostDeviceSupport() = when (BuildCompat.isAtLeastV()) {
+        true -> cameraProvider.availableCameraInfos.map { cameraInfo ->
+            Camera2CameraInfo
+                .from(cameraInfo)
+                .getCameraCharacteristic(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES)
+                ?.contains(
+                    CameraMetadata.CONTROL_AE_MODE_ON_LOW_LIGHT_BOOST_BRIGHTNESS_PRIORITY
+                )
+        }.any()
+        false -> false
+    }
 
     /**
      * Returns the union of supported stabilization modes for a device's cameras
@@ -568,7 +569,8 @@ constructor(
     override fun getZoomScale(): StateFlow<Float> = _zoomScale.asStateFlow()
 
     private val _lowLightBoostActiveStatus = MutableStateFlow(true)
-    override fun getLowLightBoostActiveStatus(): StateFlow<Boolean> = _lowLightBoostActiveStatus.asStateFlow()
+    override fun getLowLightBoostActiveStatus(): StateFlow<Boolean> =
+        _lowLightBoostActiveStatus.asStateFlow()
 
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
@@ -804,11 +806,10 @@ constructor(
                 old?.copy(
                     lowLightBoost = lowLightBoost,
                     captureMode = CaptureMode.SINGLE_STREAM,
-                    flashMode = FlashMode.OFF,
+                    flashMode = FlashMode.OFF
                 )
             }
         }
-
     }
 
     override suspend fun setAudioMuted(isAudioMuted: Boolean) {
@@ -886,9 +887,11 @@ constructor(
             Log.d(TAG, "Adding Control AE_MODE_ON_LOW_LIGHT_BOOST_BRIGHTNESS_PRIORITY")
             val camera2Interop = Camera2Interop.Extender(previewUseCaseBuilder)
             if (Build.VERSION.SDK_INT >= 35) {
-                camera2Interop.setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE,
-                    CameraMetadata.CONTROL_AE_MODE_ON_LOW_LIGHT_BOOST_BRIGHTNESS_PRIORITY)
-                camera2Interop.setSessionCaptureCallback( object : CaptureCallback() {
+                camera2Interop.setCaptureRequestOption(
+                    CaptureRequest.CONTROL_AE_MODE,
+                    CameraMetadata.CONTROL_AE_MODE_ON_LOW_LIGHT_BOOST_BRIGHTNESS_PRIORITY
+                )
+                camera2Interop.setSessionCaptureCallback(object : CaptureCallback() {
                     override fun onCaptureCompleted(
                         session: CameraCaptureSession,
                         request: CaptureRequest,

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/CameraXCameraUseCase.kt
@@ -20,11 +20,16 @@ import android.app.Application
 import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.pm.PackageManager
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraMetadata
 import android.net.Uri
+import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import android.util.Range
+import androidx.camera.camera2.interop.Camera2CameraInfo
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.AspectRatio.RATIO_16_9
 import androidx.camera.core.AspectRatio.RATIO_4_3
 import androidx.camera.core.CameraEffect
@@ -55,6 +60,7 @@ import androidx.camera.video.VideoRecordEvent
 import androidx.camera.video.VideoRecordEvent.Finalize.ERROR_NONE
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.checkSelfPermission
+import androidx.core.os.BuildCompat
 import com.google.jetpackcamera.domain.camera.CameraUseCase.ScreenFlashEvent.Type
 import com.google.jetpackcamera.domain.camera.effects.SingleSurfaceForcingEffect
 import com.google.jetpackcamera.settings.SettableConstraintsRepository
@@ -182,6 +188,7 @@ constructor(
                                 supportedStabilizationModes = supportedStabilizationModes,
                                 supportedFixedFrameRates = supportedFixedFrameRates,
                                 supportedDynamicRanges = supportedDynamicRanges,
+                                lowLightBoostSupport = getLowLightBoostDeviceSupport(),
                                 supportedImageFormatsMap = mapOf(
                                     // Only JPEG is supported in single-stream mode, since
                                     // single-stream mode uses CameraEffect, which does not support
@@ -211,6 +218,19 @@ constructor(
                 )
             ).build()
     }
+
+    @androidx.annotation.OptIn(ExperimentalCamera2Interop::class)
+    @OptIn(BuildCompat.PrereleaseSdkCheck::class)
+    private fun getLowLightBoostDeviceSupport() =
+        when(BuildCompat.isAtLeastV()) {
+            true -> cameraProvider.availableCameraInfos.map { cameraInfo ->
+                Camera2CameraInfo
+                    .from(cameraInfo)
+                    .getCameraCharacteristic(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES)
+                    ?.contains(CameraMetadata.CONTROL_AE_MODE_ON_LOW_LIGHT_BOOST_BRIGHTNESS_PRIORITY)
+            }.any()
+            false -> false
+        }
 
     /**
      * Returns the union of supported stabilization modes for a device's cameras

--- a/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
+++ b/domain/camera/src/main/java/com/google/jetpackcamera/domain/camera/test/FakeCameraUseCase.kt
@@ -149,6 +149,10 @@ class FakeCameraUseCase(
     }
     override fun getZoomScale(): StateFlow<Float> = _zoomScale.asStateFlow()
 
+    override fun getLowLightBoostActiveStatus(): StateFlow<Boolean> {
+        TODO("Not yet implemented")
+    }
+
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -31,6 +31,7 @@ sealed interface PreviewUiState {
         val currentCameraSettings: CameraAppSettings,
         val systemConstraints: SystemConstraints,
         val zoomScale: Float = 1f,
+        val lowLightBoostActiveStatus: Boolean = false,
         val videoRecordingState: VideoRecordingState = VideoRecordingState.INACTIVE,
         val quickSettingsIsOpen: Boolean = false,
         val audioAmplitude: Double = 0.0,

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -93,8 +93,9 @@ class PreviewViewModel @AssistedInject constructor(
             combine(
                 cameraUseCase.getCurrentSettings().filterNotNull(),
                 constraintsRepository.systemConstraints.filterNotNull(),
-                cameraUseCase.getZoomScale()
-            ) { cameraAppSettings, systemConstraints, zoomScale ->
+                cameraUseCase.getZoomScale(),
+                cameraUseCase.getLowLightBoostActiveStatus()
+            ) { cameraAppSettings, systemConstraints, zoomScale, lowLightBoostActiveStatus ->
                 _previewUiState.update { old ->
                     when (old) {
                         is PreviewUiState.Ready ->
@@ -102,6 +103,7 @@ class PreviewViewModel @AssistedInject constructor(
                                 currentCameraSettings = cameraAppSettings,
                                 systemConstraints = systemConstraints,
                                 zoomScale = zoomScale,
+                                lowLightBoostActiveStatus = lowLightBoostActiveStatus,
                                 previewMode = previewMode
                             )
 
@@ -110,6 +112,7 @@ class PreviewViewModel @AssistedInject constructor(
                                 currentCameraSettings = cameraAppSettings,
                                 systemConstraints = systemConstraints,
                                 zoomScale = zoomScale,
+                                lowLightBoostActiveStatus = lowLightBoostActiveStatus,
                                 previewMode = previewMode
                             )
                     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -116,6 +116,7 @@ fun CameraControlsOverlay(
                         .align(Alignment.TopCenter),
                     isQuickSettingsOpen = previewUiState.quickSettingsIsOpen,
                     currentCameraSettings = previewUiState.currentCameraSettings,
+                    lowLightBoostActiveStatus = previewUiState.lowLightBoostActiveStatus,
                     onNavigateToSettings = onNavigateToSettings,
                     onChangeFlash = onChangeFlash,
                     onToggleQuickSettings = onToggleQuickSettings
@@ -151,6 +152,7 @@ fun CameraControlsOverlay(
 private fun ControlsTop(
     isQuickSettingsOpen: Boolean,
     currentCameraSettings: CameraAppSettings,
+    lowLightBoostActiveStatus: Boolean = false,
     modifier: Modifier = Modifier,
     onNavigateToSettings: () -> Unit = {},
     onChangeFlash: (FlashMode) -> Unit = {},
@@ -186,7 +188,8 @@ private fun ControlsTop(
                 previewStabilization = currentCameraSettings.previewStabilization
             )
             LowLightBoostIcon(
-                lowLightBoost = currentCameraSettings.lowLightBoost
+                lowLightBoost = currentCameraSettings.lowLightBoost,
+                active = lowLightBoostActiveStatus
             )
         }
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -358,14 +358,18 @@ fun StabilizationIcon(
  * - enabled and active: filled
  */
 @Composable
-fun LowLightBoostIcon(lowLightBoost: LowLightBoost, modifier: Modifier = Modifier) {
+fun LowLightBoostIcon(
+    lowLightBoost: LowLightBoost,
+    modifier: Modifier = Modifier,
+    active: Boolean = false,
+) {
     when (lowLightBoost) {
         LowLightBoost.ENABLED -> {
             Icon(
-                imageVector = Icons.Outlined.Nightlight,
+                imageVector = if(active) Icons.Filled.Nightlight else Icons.Outlined.Nightlight,
                 contentDescription =
                 stringResource(id = R.string.quick_settings_lowlightboost_enabled),
-                modifier = modifier.alpha(0.5f)
+                modifier = modifier.alpha(if(active) 1.0f else 0.5f)
             )
         }
         LowLightBoost.DISABLED -> {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -361,15 +361,15 @@ fun StabilizationIcon(
 fun LowLightBoostIcon(
     lowLightBoost: LowLightBoost,
     modifier: Modifier = Modifier,
-    active: Boolean = false,
+    active: Boolean = false
 ) {
     when (lowLightBoost) {
         LowLightBoost.ENABLED -> {
             Icon(
-                imageVector = if(active) Icons.Filled.Nightlight else Icons.Outlined.Nightlight,
+                imageVector = if (active) Icons.Filled.Nightlight else Icons.Outlined.Nightlight,
                 contentDescription =
                 stringResource(id = R.string.quick_settings_lowlightboost_enabled),
-                modifier = modifier.alpha(if(active) 1.0f else 0.5f)
+                modifier = modifier.alpha(if (active) 1.0f else 0.5f)
             )
         }
         LowLightBoost.DISABLED -> {


### PR DESCRIPTION
This PR contains the following.

- Low Light Boost(LLB) feature toggle is enabled, if the device supports LLB
- When LLB toggle is turned on, switch to multi-stream mode, and enable LLB capture with Camera2Interop. Show the outlined LLB indicator with 50% opacity
- Query for the LLB active status `CONTROL_LOW_LIGHT_BOOST_STATE_ACTIVE`, if active change the outlined LLB indicator to a filled indicator with full opacity