### PR TITLE
Use nearest sensor aspect ratio for 1:1

### DIFF
--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/AspectRatio.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/AspectRatio.kt
@@ -23,7 +23,9 @@ enum class AspectRatio(val ratio: Rational) {
     NINE_SIXTEEN(Rational(9, 16)),
     ONE_ONE(Rational(1, 1));
 
-    val landscapeRatio: Rational = Rational(ratio.denominator, ratio.numerator)
+    val landscapeRatio: Rational by lazy {
+        Rational(ratio.denominator, ratio.numerator)
+    }
 
     companion object {
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/AspectRatio.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/AspectRatio.kt
@@ -23,6 +23,8 @@ enum class AspectRatio(val ratio: Rational) {
     NINE_SIXTEEN(Rational(9, 16)),
     ONE_ONE(Rational(1, 1));
 
+    val landscapeRatio: Rational = Rational(ratio.denominator, ratio.numerator)
+
     companion object {
 
         /** returns the AspectRatio enum equivalent of a provided AspectRatioProto */

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewUiState.kt
@@ -24,7 +24,7 @@ import com.google.jetpackcamera.settings.model.SystemConstraints
  * Defines the current state of the [PreviewScreen].
  */
 sealed interface PreviewUiState {
-    object NotReady : PreviewUiState
+    data object NotReady : PreviewUiState
 
     data class Ready(
         // "quick" settings


### PR DESCRIPTION
 1:1 is not a natively supported aspect ratio for CameraX. We had
 defaulted to using 4:3 and cropping since most sensors are 4:3.
 However, some emulators may use a 16:9 aspect ratio for their
 sensor, so we should instead use the aspect ratio which is closest
 to the sensor aspect ratio so we maximize support for emulators
 while also maximizing the FOV.
