### PR TITLE
Immediately sync default settings changes to camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ local.properties
 .idea/deploymentTargetDropDown.xml
 .idea/gradle.xml
 .idea/deploymentTargetSelector.xml
+.idea/androidTestResultsUserPreferences.xml

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -100,6 +100,12 @@ interface CameraUseCase {
 
     suspend fun setAudioMuted(isAudioMuted: Boolean)
 
+    suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization)
+
+    suspend fun setPreviewStabilization(previewStabilization: Stabilization)
+
+    suspend fun setTargetFrameRate(targetFrameRate: Int)
+
     /**
      * Represents the events required for screen flash.
      */
@@ -120,10 +126,6 @@ interface CameraUseCase {
 
         object OnVideoRecordError : OnVideoRecordEvent
     }
-
-    suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization)
-    suspend fun setPreviewStabilization(previewStabilization: Stabilization)
-    suspend fun setTargetFrameRate(targetFrameRate: Int)
 }
 
 data class CameraState(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -123,6 +123,7 @@ interface CameraUseCase {
 
     suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization)
     suspend fun setPreviewStabilization(previewStabilization: Stabilization)
+    suspend fun setTargetFrameRate(targetFrameRate: Int)
 }
 
 data class CameraState(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -27,6 +27,7 @@ import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
 import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.LowLightBoost
+import com.google.jetpackcamera.settings.model.Stabilization
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -119,6 +120,9 @@ interface CameraUseCase {
 
         object OnVideoRecordError : OnVideoRecordEvent
     }
+
+    suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization)
+    suspend fun setPreviewStabilization(previewStabilization: Stabilization)
 }
 
 data class CameraState(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -39,7 +39,7 @@ interface CameraUseCase {
      *
      * @return list of available lenses.
      */
-    suspend fun initialize(disableVideoCapture: Boolean)
+    suspend fun initialize(cameraAppSettings: CameraAppSettings, disableVideoCapture: Boolean)
 
     /**
      * Starts the camera.

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -155,7 +155,8 @@ constructor(
                         }
                         isFirstFrameTimestampUpdated.value = true
                     }
-                } catch (_: Exception) {}
+                } catch (_: Exception) {
+                }
             }
         }
 
@@ -531,12 +532,14 @@ constructor(
                                         onVideoRecord(
                                             CameraUseCase.OnVideoRecordEvent.OnVideoRecorded
                                         )
+
                                     else ->
                                         onVideoRecord(
                                             CameraUseCase.OnVideoRecordEvent.OnVideoRecordError
                                         )
                                 }
                             }
+
                             is VideoRecordEvent.Status -> {
                                 onVideoRecord(
                                     CameraUseCase.OnVideoRecordEvent.OnVideoRecordStatus(
@@ -755,6 +758,7 @@ constructor(
             captureMode = sessionSettings.captureMode
         }.build()
     }
+
     override suspend fun setDynamicRange(dynamicRange: DynamicRange) {
         currentSettings.update { old ->
             old?.copy(dynamicRange = dynamicRange)
@@ -795,8 +799,7 @@ constructor(
     @OptIn(ExperimentalImageCaptureOutputFormat::class)
     private fun createImageUseCase(
         cameraInfo: CameraInfo,
-        sessionSettings: PerpetualSessionSettings,
-        onCloseTrace: () -> Unit = {}
+        sessionSettings: PerpetualSessionSettings
     ): ImageCapture {
         val builder = ImageCapture.Builder()
         builder.setResolutionSelector(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -128,7 +128,6 @@ constructor(
     private val application: Application,
     private val coroutineScope: CoroutineScope,
     private val defaultDispatcher: CoroutineDispatcher,
-    private val settingsRepository: SettingsRepository,
     private val constraintsRepository: SettableConstraintsRepository
 ) : CameraUseCase {
     private lateinit var cameraProvider: ProcessCameraProvider
@@ -181,7 +180,7 @@ constructor(
 
     private val currentSettings = MutableStateFlow<CameraAppSettings?>(null)
 
-    override suspend fun initialize(externalImageCapture: Boolean) {
+    override suspend fun initialize(cameraAppSettings: CameraAppSettings, externalImageCapture: Boolean) {
         this.disableVideoCapture = externalImageCapture
         cameraProvider = ProcessCameraProvider.awaitInstance(application)
 
@@ -243,7 +242,7 @@ constructor(
         constraintsRepository.updateSystemConstraints(systemConstraints)
 
         currentSettings.value =
-            settingsRepository.defaultCameraAppSettings.first()
+                cameraAppSettings
                 .tryApplyDynamicRangeConstraints()
                 .tryApplyAspectRatioForExternalCapture(externalImageCapture)
                 .tryApplyImageFormatConstraints()

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -779,6 +779,12 @@ constructor(
         }
     }
 
+    override suspend fun setTargetFrameRate(targetFrameRate: Int) {
+        currentSettings.update { old ->
+            old?.copy(targetFrameRate = targetFrameRate)
+        }
+    }
+
     @OptIn(ExperimentalImageCaptureOutputFormat::class)
     private fun getSupportedImageFormats(cameraInfo: CameraInfo): Set<ImageOutputFormat> {
         return ImageCapture.getImageCaptureCapabilities(cameraInfo).supportedOutputFormats

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -326,7 +326,7 @@ constructor(
                     systemConstraints.perLensConstraints[lensFacing]
                 ) {
                     "Unable to retrieve CameraConstraints for $lensFacing. " +
-                            "Was the use case initialized?"
+                        "Was the use case initialized?"
                 }
 
                 val initialTransientSettings = transientSettings
@@ -377,7 +377,7 @@ constructor(
                             setFlashModeInternal(
                                 flashMode = newTransientSettings.flashMode,
                                 isFrontFacing = sessionSettings.cameraSelector
-                                        == CameraSelector.DEFAULT_FRONT_CAMERA
+                                    == CameraSelector.DEFAULT_FRONT_CAMERA
                             )
                         }
 
@@ -387,8 +387,8 @@ constructor(
                             Log.d(
                                 TAG,
                                 "Updating device rotation from " +
-                                        "${prevTransientSettings.deviceRotation} -> " +
-                                        "${newTransientSettings.deviceRotation}"
+                                    "${prevTransientSettings.deviceRotation} -> " +
+                                    "${newTransientSettings.deviceRotation}"
                             )
                             val targetRotation =
                                 newTransientSettings.deviceRotation.toUiSurfaceRotation()
@@ -520,12 +520,12 @@ constructor(
         // the toggle should only affect whether or not the audio is muted.
         // the permission will determine whether or not the audio is enabled.
         val audioEnabled = (
-                checkSelfPermission(
-                    this.application.baseContext,
-                    Manifest.permission.RECORD_AUDIO
-                )
-                        == PackageManager.PERMISSION_GRANTED
-                )
+            checkSelfPermission(
+                this.application.baseContext,
+                Manifest.permission.RECORD_AUDIO
+            )
+                == PackageManager.PERMISSION_GRANTED
+            )
         val captureTypeString =
             when (captureMode) {
                 CaptureMode.MULTI_STREAM -> "MultiStream"
@@ -546,9 +546,9 @@ constructor(
 
         val callbackExecutor: Executor =
             (
-                    currentCoroutineContext()[ContinuationInterceptor] as?
-                            CoroutineDispatcher
-                    )?.asExecutor() ?: ContextCompat.getMainExecutor(application)
+                currentCoroutineContext()[ContinuationInterceptor] as?
+                    CoroutineDispatcher
+                )?.asExecutor() ?: ContextCompat.getMainExecutor(application)
         recording =
             videoCaptureUseCase!!.output
                 .prepareRecording(application, mediaStoreOutput)
@@ -681,8 +681,8 @@ constructor(
 
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
-                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY)
-                    && (currentFrameRate != TARGET_FPS_60)
+                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY) &&
+                    (currentFrameRate != TARGET_FPS_60)
                 ) {
                     // unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
                     videoCaptureStabilization
@@ -779,7 +779,7 @@ constructor(
 
     override fun isScreenFlashEnabled() =
         imageCaptureUseCase.flashMode == ImageCapture.FLASH_MODE_SCREEN &&
-                imageCaptureUseCase.screenFlash != null
+            imageCaptureUseCase.screenFlash != null
 
     override suspend fun setAspectRatio(aspectRatio: AspectRatio) {
         currentSettings.update { old ->
@@ -977,12 +977,12 @@ constructor(
     ): Boolean {
         // video is on and target fps is not 60
         return (sessionSettings.targetFrameRate != TARGET_FPS_60) &&
-                (supportedStabilizationModes.contains(SupportedStabilizationMode.HIGH_QUALITY)) &&
-                // high quality (video only) selected
-                (
-                        sessionSettings.stabilizeVideoMode == Stabilization.ON &&
-                                sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
-                        )
+            (supportedStabilizationModes.contains(SupportedStabilizationMode.HIGH_QUALITY)) &&
+            // high quality (video only) selected
+            (
+                sessionSettings.stabilizeVideoMode == Stabilization.ON &&
+                    sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
+                )
     }
 
     private fun createPreviewUseCase(
@@ -1040,9 +1040,11 @@ constructor(
         supportedStabilizationModes: Set<SupportedStabilizationMode>
     ): Boolean {
         // only supported if target fps is 30 or none
-        return ((sessionSettings.targetFrameRate in setOf(TARGET_FPS_AUTO, TARGET_FPS_30)))
-                && (supportedStabilizationModes.contains(SupportedStabilizationMode.ON)
-                && sessionSettings.stabilizePreviewMode == Stabilization.ON)
+        return ((sessionSettings.targetFrameRate in setOf(TARGET_FPS_AUTO, TARGET_FPS_30))) &&
+            (
+                supportedStabilizationModes.contains(SupportedStabilizationMode.ON) &&
+                    sessionSettings.stabilizePreviewMode == Stabilization.ON
+                )
     }
 
     companion object {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -677,12 +677,10 @@ constructor(
     }
 
     private fun CameraAppSettings.tryApplyStabilizationConstraints(): CameraAppSettings {
-        val currentFrameRate = currentSettings.value?.targetFrameRate ?: return this
-
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
                 val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY) &&
-                    (currentFrameRate != TARGET_FPS_60)
+                    (targetFrameRate != TARGET_FPS_60)
                 ) {
                     // unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
                     videoCaptureStabilization
@@ -690,7 +688,7 @@ constructor(
                     Stabilization.UNDEFINED
                 }
                 val newPreviewStabilization = if (contains(SupportedStabilizationMode.ON) &&
-                    (currentFrameRate in setOf(TARGET_FPS_AUTO, TARGET_FPS_30))
+                    (targetFrameRate in setOf(TARGET_FPS_AUTO, TARGET_FPS_30))
                 ) {
                     previewStabilization
                 } else {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -765,6 +765,18 @@ constructor(
         }
     }
 
+    override suspend fun setPreviewStabilization(previewStabilization: Stabilization){
+        currentSettings.update { old ->
+            old?.copy(previewStabilization = previewStabilization)
+        }
+    }
+
+    override suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization){
+        currentSettings.update { old ->
+            old?.copy(videoCaptureStabilization = videoCaptureStabilization)
+        }
+    }
+
     @OptIn(ExperimentalImageCaptureOutputFormat::class)
     private fun getSupportedImageFormats(cameraInfo: CameraInfo): Set<ImageOutputFormat> {
         return ImageCapture.getImageCaptureCapabilities(cameraInfo).supportedOutputFormats

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -67,7 +67,6 @@ import androidx.core.content.ContextCompat.checkSelfPermission
 import com.google.jetpackcamera.core.camera.CameraUseCase.ScreenFlashEvent.Type
 import com.google.jetpackcamera.core.camera.effects.SingleSurfaceForcingEffect
 import com.google.jetpackcamera.settings.SettableConstraintsRepository
-import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
@@ -180,7 +179,10 @@ constructor(
 
     private val currentSettings = MutableStateFlow<CameraAppSettings?>(null)
 
-    override suspend fun initialize(cameraAppSettings: CameraAppSettings, externalImageCapture: Boolean) {
+    override suspend fun initialize(
+        cameraAppSettings: CameraAppSettings,
+        externalImageCapture: Boolean
+    ) {
         this.disableVideoCapture = externalImageCapture
         cameraProvider = ProcessCameraProvider.awaitInstance(application)
 
@@ -242,7 +244,7 @@ constructor(
         constraintsRepository.updateSystemConstraints(systemConstraints)
 
         currentSettings.value =
-                cameraAppSettings
+            cameraAppSettings
                 .tryApplyDynamicRangeConstraints()
                 .tryApplyAspectRatioForExternalCapture(externalImageCapture)
                 .tryApplyImageFormatConstraints()
@@ -765,13 +767,13 @@ constructor(
         }
     }
 
-    override suspend fun setPreviewStabilization(previewStabilization: Stabilization){
+    override suspend fun setPreviewStabilization(previewStabilization: Stabilization) {
         currentSettings.update { old ->
             old?.copy(previewStabilization = previewStabilization)
         }
     }
 
-    override suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization){
+    override suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization) {
         currentSettings.update { old ->
             old?.copy(videoCaptureStabilization = videoCaptureStabilization)
         }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -627,7 +627,6 @@ constructor(
         } ?: this
     }
 
-
     private fun CameraAppSettings.tryApplyFrameRateConstraints(): CameraAppSettings {
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedFixedFrameRates) {
@@ -654,8 +653,7 @@ constructor(
                 }
                 val newPreviewStabilization = if (contains(SupportedStabilizationMode.ON)) {
                     previewStabilization
-                }
-                else {
+                } else {
                     Stabilization.UNDEFINED
                 }
 
@@ -666,8 +664,6 @@ constructor(
             }
         } ?: this
     }
-
-
 
     override suspend fun tapToFocus(x: Float, y: Float) {
         Log.d(TAG, "tapToFocus, sending FocusMeteringEvent")
@@ -817,13 +813,17 @@ constructor(
 
     override suspend fun setPreviewStabilization(previewStabilization: Stabilization) {
         currentSettings.update { old ->
-            old?.copy(previewStabilization = previewStabilization)?.tryApplyStabilizationConstraints()
+            old?.copy(
+                previewStabilization = previewStabilization
+            )?.tryApplyStabilizationConstraints()
         }
     }
 
     override suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization) {
         currentSettings.update { old ->
-            old?.copy(videoCaptureStabilization = videoCaptureStabilization)?.tryApplyStabilizationConstraints()
+            old?.copy(
+                videoCaptureStabilization = videoCaptureStabilization
+            )?.tryApplyStabilizationConstraints()
         }
     }
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -644,7 +644,8 @@ constructor(
     }
 
     private fun CameraAppSettings.tryApplyStabilizationConstraints(): CameraAppSettings {
-        val currentFrameRate = currentSettings.value!!.targetFrameRate
+        val currentFrameRate = currentSettings.value?.targetFrameRate ?: return this
+
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
                 val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY) &&

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -647,15 +647,16 @@ constructor(
         val currentFrameRate = currentSettings.value!!.targetFrameRate
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
-                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY)
-                    && currentFrameRate <= TARGET_FPS_60 ) {
-                    //unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
+                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY) &&
+                    currentFrameRate <= TARGET_FPS_60
+                ) {
+                    // unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
                     videoCaptureStabilization
                 } else {
                     Stabilization.UNDEFINED
                 }
-                val newPreviewStabilization = if ( contains(SupportedStabilizationMode.ON)
-                    && currentFrameRate <= TARGET_FPS_15
+                val newPreviewStabilization = if (contains(SupportedStabilizationMode.ON) &&
+                    currentFrameRate <= TARGET_FPS_15
                 ) {
                     previewStabilization
                 } else {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -649,7 +649,7 @@ constructor(
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
                 val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY) &&
-                    currentFrameRate <= TARGET_FPS_60
+                    (currentFrameRate == TARGET_FPS_AUTO || currentFrameRate == TARGET_FPS_30)
                 ) {
                     // unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
                     videoCaptureStabilization

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -644,14 +644,19 @@ constructor(
     }
 
     private fun CameraAppSettings.tryApplyStabilizationConstraints(): CameraAppSettings {
+        val currentFrameRate = currentSettings.value!!.targetFrameRate
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
-                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY)) {
+                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY)
+                    && currentFrameRate <= TARGET_FPS_60 ) {
+                    //unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
                     videoCaptureStabilization
                 } else {
                     Stabilization.UNDEFINED
                 }
-                val newPreviewStabilization = if (contains(SupportedStabilizationMode.ON)) {
+                val newPreviewStabilization = if ( contains(SupportedStabilizationMode.ON)
+                    && currentFrameRate <= TARGET_FPS_15
+                ) {
                     previewStabilization
                 } else {
                     Stabilization.UNDEFINED

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -326,7 +326,7 @@ constructor(
                     systemConstraints.perLensConstraints[lensFacing]
                 ) {
                     "Unable to retrieve CameraConstraints for $lensFacing. " +
-                        "Was the use case initialized?"
+                            "Was the use case initialized?"
                 }
 
                 val initialTransientSettings = transientSettings
@@ -377,7 +377,7 @@ constructor(
                             setFlashModeInternal(
                                 flashMode = newTransientSettings.flashMode,
                                 isFrontFacing = sessionSettings.cameraSelector
-                                    == CameraSelector.DEFAULT_FRONT_CAMERA
+                                        == CameraSelector.DEFAULT_FRONT_CAMERA
                             )
                         }
 
@@ -387,8 +387,8 @@ constructor(
                             Log.d(
                                 TAG,
                                 "Updating device rotation from " +
-                                    "${prevTransientSettings.deviceRotation} -> " +
-                                    "${newTransientSettings.deviceRotation}"
+                                        "${prevTransientSettings.deviceRotation} -> " +
+                                        "${newTransientSettings.deviceRotation}"
                             )
                             val targetRotation =
                                 newTransientSettings.deviceRotation.toUiSurfaceRotation()
@@ -520,12 +520,12 @@ constructor(
         // the toggle should only affect whether or not the audio is muted.
         // the permission will determine whether or not the audio is enabled.
         val audioEnabled = (
-            checkSelfPermission(
-                this.application.baseContext,
-                Manifest.permission.RECORD_AUDIO
-            )
-                == PackageManager.PERMISSION_GRANTED
-            )
+                checkSelfPermission(
+                    this.application.baseContext,
+                    Manifest.permission.RECORD_AUDIO
+                )
+                        == PackageManager.PERMISSION_GRANTED
+                )
         val captureTypeString =
             when (captureMode) {
                 CaptureMode.MULTI_STREAM -> "MultiStream"
@@ -546,9 +546,9 @@ constructor(
 
         val callbackExecutor: Executor =
             (
-                currentCoroutineContext()[ContinuationInterceptor] as?
-                    CoroutineDispatcher
-                )?.asExecutor() ?: ContextCompat.getMainExecutor(application)
+                    currentCoroutineContext()[ContinuationInterceptor] as?
+                            CoroutineDispatcher
+                    )?.asExecutor() ?: ContextCompat.getMainExecutor(application)
         recording =
             videoCaptureUseCase!!.output
                 .prepareRecording(application, mediaStoreOutput)
@@ -681,8 +681,8 @@ constructor(
 
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedStabilizationModes) {
-                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY) &&
-                    (currentFrameRate == TARGET_FPS_AUTO || currentFrameRate == TARGET_FPS_30)
+                val newVideoStabilization = if (contains(SupportedStabilizationMode.HIGH_QUALITY)
+                    && (currentFrameRate != TARGET_FPS_60)
                 ) {
                     // unlike shouldVideoBeStabilized, doesn't check value of previewStabilization
                     videoCaptureStabilization
@@ -690,7 +690,7 @@ constructor(
                     Stabilization.UNDEFINED
                 }
                 val newPreviewStabilization = if (contains(SupportedStabilizationMode.ON) &&
-                    currentFrameRate <= TARGET_FPS_15
+                    (currentFrameRate in setOf(TARGET_FPS_AUTO, TARGET_FPS_30))
                 ) {
                     previewStabilization
                 } else {
@@ -779,7 +779,7 @@ constructor(
 
     override fun isScreenFlashEnabled() =
         imageCaptureUseCase.flashMode == ImageCapture.FLASH_MODE_SCREEN &&
-            imageCaptureUseCase.screenFlash != null
+                imageCaptureUseCase.screenFlash != null
 
     override suspend fun setAspectRatio(aspectRatio: AspectRatio) {
         currentSettings.update { old ->
@@ -977,12 +977,12 @@ constructor(
     ): Boolean {
         // video is on and target fps is not 60
         return (sessionSettings.targetFrameRate != TARGET_FPS_60) &&
-            (supportedStabilizationModes.contains(SupportedStabilizationMode.HIGH_QUALITY)) &&
-            // high quality (video only) selected
-            (
-                sessionSettings.stabilizeVideoMode == Stabilization.ON &&
-                    sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
-                )
+                (supportedStabilizationModes.contains(SupportedStabilizationMode.HIGH_QUALITY)) &&
+                // high quality (video only) selected
+                (
+                        sessionSettings.stabilizeVideoMode == Stabilization.ON &&
+                                sessionSettings.stabilizePreviewMode == Stabilization.UNDEFINED
+                        )
     }
 
     private fun createPreviewUseCase(
@@ -1040,16 +1040,9 @@ constructor(
         supportedStabilizationModes: Set<SupportedStabilizationMode>
     ): Boolean {
         // only supported if target fps is 30 or none
-        return (
-            when (sessionSettings.targetFrameRate) {
-                TARGET_FPS_AUTO, TARGET_FPS_30 -> true
-                else -> false
-            }
-            ) &&
-            (
-                supportedStabilizationModes.contains(SupportedStabilizationMode.ON) &&
-                    sessionSettings.stabilizePreviewMode == Stabilization.ON
-                )
+        return ((sessionSettings.targetFrameRate in setOf(TARGET_FPS_AUTO, TARGET_FPS_30)))
+                && (supportedStabilizationModes.contains(SupportedStabilizationMode.ON)
+                && sessionSettings.stabilizePreviewMode == Stabilization.ON)
     }
 
     companion object {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -30,6 +30,7 @@ import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
 import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.LowLightBoost
+import com.google.jetpackcamera.settings.model.Stabilization
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -213,4 +214,14 @@ class FakeCameraUseCase(
             old.copy(audioMuted = isAudioMuted)
         }
     }
+
+    override suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization) {
+        currentSettings.update { old ->
+            old.copy(videoCaptureStabilization = videoCaptureStabilization)
+        }    }
+
+    override suspend fun setPreviewStabilization(previewStabilization: Stabilization) {
+        currentSettings.update { old ->
+            old.copy(previewStabilization = previewStabilization)
+        }    }
 }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -64,7 +64,10 @@ class FakeCameraUseCase(
 
     private val currentSettings = MutableStateFlow(defaultCameraSettings)
 
-    override suspend fun initialize(cameraAppSettings: CameraAppSettings, disableVideoCapture: Boolean) {
+    override suspend fun initialize(
+        cameraAppSettings: CameraAppSettings,
+        disableVideoCapture: Boolean
+    ) {
         initialized = true
     }
 
@@ -218,10 +221,12 @@ class FakeCameraUseCase(
     override suspend fun setVideoCaptureStabilization(videoCaptureStabilization: Stabilization) {
         currentSettings.update { old ->
             old.copy(videoCaptureStabilization = videoCaptureStabilization)
-        }    }
+        }
+    }
 
     override suspend fun setPreviewStabilization(previewStabilization: Stabilization) {
         currentSettings.update { old ->
             old.copy(previewStabilization = previewStabilization)
-        }    }
+        }
+    }
 }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -63,7 +63,7 @@ class FakeCameraUseCase(
 
     private val currentSettings = MutableStateFlow(defaultCameraSettings)
 
-    override suspend fun initialize(disableVideoCapture: Boolean) {
+    override suspend fun initialize(cameraAppSettings: CameraAppSettings, disableVideoCapture: Boolean) {
         initialized = true
     }
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -229,4 +229,10 @@ class FakeCameraUseCase(
             old.copy(previewStabilization = previewStabilization)
         }
     }
+
+    override suspend fun setTargetFrameRate(targetFrameRate: Int) {
+        currentSettings.update { old ->
+            old.copy(targetFrameRate = targetFrameRate)
+        }
+    }
 }

--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera.core.camera.test
 
 import com.google.common.truth.Truth
 import com.google.jetpackcamera.core.camera.CameraUseCase
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.Dispatchers
@@ -53,7 +54,7 @@ class FakeCameraUseCaseTest {
 
     @Test
     fun canInitialize() = runTest(testDispatcher) {
-        cameraUseCase.initialize(false)
+        cameraUseCase.initialize( cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS, disableVideoCapture = false)
     }
 
     @Test
@@ -144,7 +145,7 @@ class FakeCameraUseCaseTest {
 
     private fun TestScope.initAndRunCamera() {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.initialize(false)
+            cameraUseCase.initialize(cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS, disableVideoCapture = false)
             cameraUseCase.runCamera()
         }
     }

--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
@@ -54,7 +54,10 @@ class FakeCameraUseCaseTest {
 
     @Test
     fun canInitialize() = runTest(testDispatcher) {
-        cameraUseCase.initialize( cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS, disableVideoCapture = false)
+        cameraUseCase.initialize(
+            cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS,
+            disableVideoCapture = false
+        )
     }
 
     @Test
@@ -145,7 +148,10 @@ class FakeCameraUseCaseTest {
 
     private fun TestScope.initAndRunCamera() {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.initialize(cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS, disableVideoCapture = false)
+            cameraUseCase.initialize(
+                cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS,
+                disableVideoCapture = false
+            )
             cameraUseCase.runCamera()
         }
     }

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -89,6 +89,8 @@ android {
 }
 
 dependencies {
+    // Reflect
+    implementation(libs.kotlin.reflect)
     // Compose
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -160,7 +160,7 @@ class PreviewViewModel @AssistedInject constructor(
 
     /**
      * Returns the difference between two [CameraAppSettings] as a queue of
-     * [Pair]<[SettingNames], [Any]>.
+     * [Pair]<[KProperty], [Any]>.
      */
     private fun getSettingsDiff(
         oldCameraAppSettings: CameraAppSettings,
@@ -212,17 +212,7 @@ class PreviewViewModel @AssistedInject constructor(
                     cameraUseCase.setTargetFrameRate(pair.second as Int)
                 }
 
-                CameraAppSettings::lowLightBoost -> {
-                    cameraUseCase.setLowLightBoost(pair.second as LowLightBoost)
-                }
-
-                CameraAppSettings::audioMuted -> {
-                    cameraUseCase.setAudioMuted(pair.second as Boolean)
-                }
-
-                CameraAppSettings::imageFormat -> {
-                    cameraUseCase.setImageFormat(pair.second as ImageOutputFormat)
-                }
+                CameraAppSettings::darkMode -> {}
 
                 else -> TODO("Unhandled CameraAppSetting $pair")
             }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -48,6 +48,9 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlin.reflect.KProperty
+import kotlin.reflect.full.memberProperties
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
@@ -64,9 +67,6 @@ import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.reflect.KProperty
-import kotlin.reflect.full.memberProperties
-import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "PreviewViewModel"
 private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
@@ -179,7 +179,9 @@ class PreviewViewModel @AssistedInject constructor(
      * Iterates through a queue of [Pair]<[KProperty], [Any]> and attempt to apply them to
      * [CameraUseCase].
      */
-    private suspend fun applySettingsDiff(newSettingsDiff: ArrayDeque<Pair<KProperty<Any?>, Any?>>) {
+    private suspend fun applySettingsDiff(
+        newSettingsDiff: ArrayDeque<Pair<KProperty<Any?>, Any?>>
+    ) {
         newSettingsDiff.forEach { pair ->
             when (pair.first) {
                 CameraAppSettings::cameraLensFacing -> {
@@ -242,10 +244,10 @@ class PreviewViewModel @AssistedInject constructor(
                 it.size > 1
             } ?: false
         val isShown = previewMode is PreviewMode.ExternalImageCaptureMode ||
-                cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
-                cameraAppSettings.dynamicRange == DynamicRange.HLG10
+            cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
+            cameraAppSettings.dynamicRange == DynamicRange.HLG10
         val enabled = previewMode !is PreviewMode.ExternalImageCaptureMode &&
-                hdrDynamicRangeSupported && hdrImageFormatSupported
+            hdrDynamicRangeSupported && hdrImageFormatSupported
         return if (isShown) {
             val currentMode = if (previewMode is PreviewMode.ExternalImageCaptureMode ||
                 cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR
@@ -518,7 +520,7 @@ class PreviewViewModel @AssistedInject constructor(
     fun startVideoRecording() {
         if (previewUiState.value is PreviewUiState.Ready &&
             (previewUiState.value as PreviewUiState.Ready).previewMode is
-                    PreviewMode.ExternalImageCaptureMode
+                PreviewMode.ExternalImageCaptureMode
         ) {
             Log.d(TAG, "externalVideoRecording")
             viewModelScope.launch {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -31,6 +31,7 @@ import com.google.jetpackcamera.feature.preview.ui.IMAGE_CAPTURE_SUCCESS_TAG
 import com.google.jetpackcamera.feature.preview.ui.SnackbarData
 import com.google.jetpackcamera.feature.preview.ui.VIDEO_CAPTURE_EXTERNAL_UNSUPPORTED_TAG
 import com.google.jetpackcamera.settings.ConstraintsRepository
+import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
@@ -58,6 +59,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -72,6 +74,7 @@ private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
 class PreviewViewModel @AssistedInject constructor(
     @Assisted val previewMode: PreviewMode,
     private val cameraUseCase: CameraUseCase,
+    private val settingsRepository: SettingsRepository,
     private val constraintsRepository: ConstraintsRepository
 ) : ViewModel() {
     private val _previewUiState: MutableStateFlow<PreviewUiState> =
@@ -94,7 +97,9 @@ class PreviewViewModel @AssistedInject constructor(
     // Eagerly initialize the CameraUseCase and encapsulate in a Deferred that can be
     // used to ensure we don't start the camera before initialization is complete.
     private var initializationDeferred: Deferred<Unit> = viewModelScope.async {
-        cameraUseCase.initialize(previewMode is PreviewMode.ExternalImageCaptureMode)
+        cameraUseCase.initialize(
+            cameraAppSettings = settingsRepository.defaultCameraAppSettings.first(),
+            disableVideoCapture = previewMode is PreviewMode.ExternalImageCaptureMode)
     }
 
     init {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -134,6 +134,7 @@ class PreviewViewModel @AssistedInject constructor(
                                     cameraAppSettings
                                 )
                             )
+
                         is PreviewUiState.NotReady ->
                             PreviewUiState.Ready(
                                 currentCameraSettings = cameraAppSettings,
@@ -153,7 +154,7 @@ class PreviewViewModel @AssistedInject constructor(
     }
 
     /**
-     * Returns the diff of new default settings and the previous default settings as a queue of [Pair]<[SettingNames],[Any]>
+     * Returns the diff of new default settings and the previous default settings as a queue of [Pair]<[SettingNames], [Any]>
      */
     private fun diffNewSettings(
         newCameraAppSettings: CameraAppSettings
@@ -161,7 +162,6 @@ class PreviewViewModel @AssistedInject constructor(
         val queue = ArrayDeque<Pair<SettingNames, Any>>()
         if (newCameraAppSettings.cameraLensFacing != oldCameraDefaultSettings.cameraLensFacing) {
             queue.add(Pair(SettingNames.CAMERA_LENS_FACING, newCameraAppSettings.cameraLensFacing))
-
         }
         if (newCameraAppSettings.flashMode != oldCameraDefaultSettings.flashMode) {
             queue.add(Pair(SettingNames.FLASH_MODE, newCameraAppSettings.flashMode))
@@ -172,7 +172,9 @@ class PreviewViewModel @AssistedInject constructor(
         if (newCameraAppSettings.aspectRatio != oldCameraDefaultSettings.aspectRatio) {
             queue.add(Pair(SettingNames.ASPECT_RATIO, newCameraAppSettings.aspectRatio))
         }
-        if (newCameraAppSettings.previewStabilization != oldCameraDefaultSettings.previewStabilization) {
+        if (newCameraAppSettings.previewStabilization != oldCameraDefaultSettings
+                .previewStabilization
+        ) {
             queue.add(
                 Pair(
                     SettingNames.PREVIEW_STABILIZATION,
@@ -180,7 +182,9 @@ class PreviewViewModel @AssistedInject constructor(
                 )
             )
         }
-        if (newCameraAppSettings.videoCaptureStabilization != oldCameraDefaultSettings.videoCaptureStabilization) {
+        if (newCameraAppSettings.videoCaptureStabilization != oldCameraDefaultSettings
+                .videoCaptureStabilization
+        ) {
             queue.add(
                 Pair(
                     SettingNames.VIDEO_CAPTURE_STABILIZATION,
@@ -198,7 +202,7 @@ class PreviewViewModel @AssistedInject constructor(
     }
 
     /**
-     * Iterates through a queue of [Pair]<[SettingNames],[Any]> and attempt to apply them
+     * Iterates through a queue of [Pair]<[SettingNames], [Any]> and attempt to apply them
      */
     private suspend fun applyDiff(newSettings: ArrayDeque<Pair<SettingNames, Any>>) {
         newSettings.forEach { pair ->
@@ -221,7 +225,6 @@ class PreviewViewModel @AssistedInject constructor(
 
                 SettingNames.PREVIEW_STABILIZATION -> {
                     cameraUseCase.setPreviewStabilization(pair.second as Stabilization)
-
                 }
 
                 SettingNames.VIDEO_CAPTURE_STABILIZATION -> {
@@ -236,7 +239,7 @@ class PreviewViewModel @AssistedInject constructor(
                 SettingNames.MUTE_AUDIO -> TODO()
                 SettingNames.LOW_LIGHT_BOOST -> TODO()
             }
-            //newSettings.removeFirst()
+            // newSettings.removeFirst()
             Log.d(TAG, "${newSettings.size} changed default settings")
         }
     }
@@ -256,10 +259,10 @@ class PreviewViewModel @AssistedInject constructor(
                 it.size > 1
             } ?: false
         val isShown = previewMode is PreviewMode.ExternalImageCaptureMode ||
-                cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
-                cameraAppSettings.dynamicRange == DynamicRange.HLG10
+            cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
+            cameraAppSettings.dynamicRange == DynamicRange.HLG10
         val enabled = previewMode !is PreviewMode.ExternalImageCaptureMode &&
-                hdrDynamicRangeSupported && hdrImageFormatSupported
+            hdrDynamicRangeSupported && hdrImageFormatSupported
         return if (isShown) {
             val currentMode = if (previewMode is PreviewMode.ExternalImageCaptureMode ||
                 cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR
@@ -532,7 +535,7 @@ class PreviewViewModel @AssistedInject constructor(
     fun startVideoRecording() {
         if (previewUiState.value is PreviewUiState.Ready &&
             (previewUiState.value as PreviewUiState.Ready).previewMode is
-                    PreviewMode.ExternalImageCaptureMode
+                PreviewMode.ExternalImageCaptureMode
         ) {
             Log.d(TAG, "externalVideoRecording")
             viewModelScope.launch {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -48,7 +48,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.HashMap
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.memberProperties
 import kotlin.time.Duration.Companion.seconds
@@ -173,7 +172,6 @@ class PreviewViewModel @AssistedInject constructor(
         }
     }
 
-
     /**
      * Iterates through a queue of [Pair]<[KProperty], [Any]> and attempt to apply them to
      * [CameraUseCase].
@@ -194,11 +192,11 @@ class PreviewViewModel @AssistedInject constructor(
                 }
 
                 CameraAppSettings::aspectRatio -> {
-                    cameraUseCase.setAspectRatio(entry.value  as AspectRatio)
+                    cameraUseCase.setAspectRatio(entry.value as AspectRatio)
                 }
 
                 CameraAppSettings::previewStabilization -> {
-                    cameraUseCase.setPreviewStabilization(entry.value  as Stabilization)
+                    cameraUseCase.setPreviewStabilization(entry.value as Stabilization)
                 }
 
                 CameraAppSettings::videoCaptureStabilization -> {
@@ -233,10 +231,10 @@ class PreviewViewModel @AssistedInject constructor(
                 it.size > 1
             } ?: false
         val isShown = previewMode is PreviewMode.ExternalImageCaptureMode ||
-                cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
-                cameraAppSettings.dynamicRange == DynamicRange.HLG10
+            cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
+            cameraAppSettings.dynamicRange == DynamicRange.HLG10
         val enabled = previewMode !is PreviewMode.ExternalImageCaptureMode &&
-                hdrDynamicRangeSupported && hdrImageFormatSupported
+            hdrDynamicRangeSupported && hdrImageFormatSupported
         return if (isShown) {
             val currentMode = if (previewMode is PreviewMode.ExternalImageCaptureMode ||
                 cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR
@@ -509,7 +507,7 @@ class PreviewViewModel @AssistedInject constructor(
     fun startVideoRecording() {
         if (previewUiState.value is PreviewUiState.Ready &&
             (previewUiState.value as PreviewUiState.Ready).previewMode is
-                    PreviewMode.ExternalImageCaptureMode
+                PreviewMode.ExternalImageCaptureMode
         ) {
             Log.d(TAG, "externalVideoRecording")
             viewModelScope.launch {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -165,56 +165,55 @@ class PreviewViewModel @AssistedInject constructor(
     private fun getSettingsDiff(
         oldCameraAppSettings: CameraAppSettings,
         newCameraAppSettings: CameraAppSettings
-    ): Map<KProperty<Any?>, Any?> {
-        val diffSettingsMap = HashMap<KProperty<Any?>, Any?>()
+    ): Map<KProperty<Any?>, Any?> = buildMap<KProperty<Any?>, Any?> {
         CameraAppSettings::class.memberProperties.forEach { property ->
             if (property.get(oldCameraAppSettings) != property.get(newCameraAppSettings)) {
-                diffSettingsMap[property] = property.get(newCameraAppSettings)
+                put(property, property.get(newCameraAppSettings))
             }
         }
-        return diffSettingsMap
     }
+
 
     /**
      * Iterates through a queue of [Pair]<[KProperty], [Any]> and attempt to apply them to
      * [CameraUseCase].
      */
     private suspend fun applySettingsDiff(diffSettingsMap: Map<KProperty<Any?>, Any?>) {
-        diffSettingsMap.keys.forEach { key ->
-            when (key) {
+        diffSettingsMap.entries.forEach { entry ->
+            when (entry.key) {
                 CameraAppSettings::cameraLensFacing -> {
-                    cameraUseCase.setLensFacing(diffSettingsMap[key] as LensFacing)
+                    cameraUseCase.setLensFacing(entry.value as LensFacing)
                 }
 
                 CameraAppSettings::flashMode -> {
-                    cameraUseCase.setFlashMode(diffSettingsMap[key] as FlashMode)
+                    cameraUseCase.setFlashMode(entry.value as FlashMode)
                 }
 
                 CameraAppSettings::captureMode -> {
-                    cameraUseCase.setCaptureMode(diffSettingsMap[key] as CaptureMode)
+                    cameraUseCase.setCaptureMode(entry.value as CaptureMode)
                 }
 
                 CameraAppSettings::aspectRatio -> {
-                    cameraUseCase.setAspectRatio(diffSettingsMap[key] as AspectRatio)
+                    cameraUseCase.setAspectRatio(entry.value  as AspectRatio)
                 }
 
                 CameraAppSettings::previewStabilization -> {
-                    cameraUseCase.setPreviewStabilization(diffSettingsMap[key] as Stabilization)
+                    cameraUseCase.setPreviewStabilization(entry.value  as Stabilization)
                 }
 
                 CameraAppSettings::videoCaptureStabilization -> {
                     cameraUseCase.setVideoCaptureStabilization(
-                        diffSettingsMap[key] as Stabilization
+                        entry.value as Stabilization
                     )
                 }
 
                 CameraAppSettings::targetFrameRate -> {
-                    cameraUseCase.setTargetFrameRate(diffSettingsMap[key] as Int)
+                    cameraUseCase.setTargetFrameRate(entry.value as Int)
                 }
 
                 CameraAppSettings::darkMode -> {}
 
-                else -> TODO("Unhandled CameraAppSetting $key")
+                else -> TODO("Unhandled CameraAppSetting $entry")
             }
         }
     }
@@ -234,10 +233,10 @@ class PreviewViewModel @AssistedInject constructor(
                 it.size > 1
             } ?: false
         val isShown = previewMode is PreviewMode.ExternalImageCaptureMode ||
-            cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
-            cameraAppSettings.dynamicRange == DynamicRange.HLG10
+                cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR ||
+                cameraAppSettings.dynamicRange == DynamicRange.HLG10
         val enabled = previewMode !is PreviewMode.ExternalImageCaptureMode &&
-            hdrDynamicRangeSupported && hdrImageFormatSupported
+                hdrDynamicRangeSupported && hdrImageFormatSupported
         return if (isShown) {
             val currentMode = if (previewMode is PreviewMode.ExternalImageCaptureMode ||
                 cameraAppSettings.imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR
@@ -510,7 +509,7 @@ class PreviewViewModel @AssistedInject constructor(
     fun startVideoRecording() {
         if (previewUiState.value is PreviewUiState.Ready &&
             (previewUiState.value as PreviewUiState.Ready).previewMode is
-                PreviewMode.ExternalImageCaptureMode
+                    PreviewMode.ExternalImageCaptureMode
         ) {
             Log.d(TAG, "externalVideoRecording")
             viewModelScope.launch {

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -22,6 +22,7 @@ import com.google.jetpackcamera.settings.SettableConstraintsRepositoryImpl
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.TYPICAL_SYSTEM_CONSTRAINTS
+import com.google.jetpackcamera.settings.test.FakeSettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -47,8 +48,9 @@ class PreviewViewModelTest {
         Dispatchers.setMain(StandardTestDispatcher())
         previewViewModel = PreviewViewModel(
             PreviewMode.StandardMode {},
-            cameraUseCase,
-            constraintsRepository
+            cameraUseCase = cameraUseCase,
+            constraintsRepository = constraintsRepository,
+            settingsRepository = FakeSettingsRepository
         )
         advanceUntilIdle()
     }

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.core.camera.CameraUseCase
 import com.google.jetpackcamera.core.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.feature.preview.rules.MainDispatcherRule
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -109,7 +110,7 @@ class ScreenFlashTest {
 
     private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.initialize(false)
+            cameraUseCase.initialize(DEFAULT_CAMERA_APP_SETTINGS, false)
             cameraUseCase.runCamera()
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref
 futures-ktx = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "androidxConcurrentFutures" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }
 junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinPlugin" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinxAtomicfu" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }


### PR DESCRIPTION
![gif of robots from evangelion sync](https://github.com/google/jetpack-camera-app/assets/20013168/1effc3b9-bb54-41bf-a2a6-26a003b46844)

Changes made on default settings screen are now immediately active on Camera.
Notable Changes:
* Moved default settings flow out of  `CameraXCameraUseCase` and into `PreviewViewModel`
* Map only the NEW changes from default settings and apply them to `CameraXCameraUseCase`
* New Settings added to settings screen must be accounted for in `applySettingsDiff()` function, or will throw a `TODO()` error when attempting to change the setting
* Frame rate and stabilization settings  apply following constraints

_May experience some unintended behavior, as settings still need to be locked to SystemConstraints to prevent invalid settings configurations._

closes #174 

