### PR TITLE
Add rounded corners to viewfinder

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -314,6 +314,7 @@ fun PreviewDisplay(
                     .height(height)
                     .transformable(state = transformableState)
                     .alpha(imageAlpha)
+                    .clip(RoundedCornerShape(16.dp))
             ) {
                 CameraXViewfinder(
                     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
 Adds a rounded corner shaped clip to the Viewfinder using compose
<img src="https://github.com/google/jetpack-camera-app/assets/1455403/55d393f9-692a-4cd7-88e7-e58bf81a68af" width="300">
<img src="https://github.com/google/jetpack-camera-app/assets/1455403/1f2ef4bf-32fc-47b9-994a-6599a3beec8d" width="300">
