### PR TITLE
Make captures use gyro to determine orientation

### DIFF
--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -22,6 +22,7 @@ import androidx.camera.core.SurfaceRequest
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
+import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
@@ -92,6 +93,8 @@ interface CameraUseCase {
     suspend fun setCaptureMode(captureMode: CaptureMode)
 
     suspend fun setDynamicRange(dynamicRange: DynamicRange)
+
+    fun setDeviceRotation(deviceRotation: DeviceRotation)
 
     suspend fun setLowLightBoost(lowLightBoost: LowLightBoost)
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -72,6 +72,7 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import com.google.jetpackcamera.settings.model.CaptureMode
+import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
@@ -274,9 +275,10 @@ constructor(
      * The use cases typically will not need to be re-bound.
      */
     private data class TransientSessionSettings(
+        val audioMuted: Boolean,
+        val deviceRotation: DeviceRotation,
         val flashMode: FlashMode,
-        val zoomScale: Float,
-        val audioMuted: Boolean
+        val zoomScale: Float
     )
 
     override suspend fun runCamera() = coroutineScope {
@@ -287,8 +289,9 @@ constructor(
             .filterNotNull()
             .map { currentCameraSettings ->
                 transientSettings.value = TransientSessionSettings(
-                    flashMode = currentCameraSettings.flashMode,
                     audioMuted = currentCameraSettings.audioMuted,
+                    deviceRotation = currentCameraSettings.deviceRotation,
+                    flashMode = currentCameraSettings.flashMode,
                     zoomScale = currentCameraSettings.zoomScale
                 )
 
@@ -372,6 +375,36 @@ constructor(
                                 isFrontFacing = sessionSettings.cameraSelector
                                     == CameraSelector.DEFAULT_FRONT_CAMERA
                             )
+                        }
+
+                        if (prevTransientSettings.deviceRotation
+                            != newTransientSettings.deviceRotation
+                        ) {
+                            Log.d(
+                                TAG,
+                                "Updating device rotation from " +
+                                    "${prevTransientSettings.deviceRotation} -> " +
+                                    "${newTransientSettings.deviceRotation}"
+                            )
+                            val targetRotation =
+                                newTransientSettings.deviceRotation.toUiSurfaceRotation()
+                            useCaseGroup.useCases.forEach {
+                                when (it) {
+                                    is Preview -> {
+                                        // Preview rotation should always be natural orientation
+                                        // in order to support seamless handling of orientation
+                                        // configuration changes in UI
+                                    }
+
+                                    is ImageCapture -> {
+                                        it.targetRotation = targetRotation
+                                    }
+
+                                    is VideoCapture<*> -> {
+                                        it.targetRotation = targetRotation
+                                    }
+                                }
+                            }
                         }
 
                         prevTransientSettings = newTransientSettings
@@ -730,10 +763,14 @@ constructor(
         )
 
         return UseCaseGroup.Builder().apply {
+            Log.d(
+                TAG,
+                "Setting initial device rotation to ${initialTransientSettings.deviceRotation}"
+            )
             setViewPort(
                 ViewPort.Builder(
                     sessionSettings.aspectRatio.ratio,
-                    previewUseCase.targetRotation
+                    initialTransientSettings.deviceRotation.toUiSurfaceRotation()
                 ).build()
             )
             addUseCase(previewUseCase)
@@ -757,6 +794,12 @@ constructor(
     override suspend fun setDynamicRange(dynamicRange: DynamicRange) {
         currentSettings.update { old ->
             old?.copy(dynamicRange = dynamicRange)
+        }
+    }
+
+    override fun setDeviceRotation(deviceRotation: DeviceRotation) {
+        currentSettings.update { old ->
+            old?.copy(deviceRotation = deviceRotation)
         }
     }
 
@@ -874,8 +917,12 @@ constructor(
         sessionSettings: PerpetualSessionSettings,
         supportedStabilizationModes: Set<SupportedStabilizationMode>
     ): Preview {
-        val previewUseCaseBuilder = Preview.Builder()
+        val previewUseCaseBuilder = Preview.Builder().apply {
+            setTargetRotation(DeviceRotation.Natural.toUiSurfaceRotation())
+        }
+
         setOnCaptureCompletedCallback(previewUseCaseBuilder)
+
         // set preview stabilization
         if (shouldPreviewBeStabilized(sessionSettings, supportedStabilizationModes)) {
             previewUseCaseBuilder.setPreviewStabilizationEnabled(true)

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -25,6 +25,7 @@ import com.google.jetpackcamera.core.camera.CameraUseCase
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CaptureMode
+import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
@@ -193,6 +194,12 @@ class FakeCameraUseCase(
     override suspend fun setDynamicRange(dynamicRange: DynamicRange) {
         currentSettings.update { old ->
             old.copy(dynamicRange = dynamicRange)
+        }
+    }
+
+    override fun setDeviceRotation(deviceRotation: DeviceRotation) {
+        currentSettings.update { old ->
+            old.copy(deviceRotation = deviceRotation)
         }
     }
 

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -34,7 +34,8 @@ data class CameraAppSettings(
     val zoomScale: Float = 1f,
     val targetFrameRate: Int = TARGET_FPS_AUTO,
     val imageFormat: ImageOutputFormat = ImageOutputFormat.JPEG,
-    val audioMuted: Boolean = false
+    val audioMuted: Boolean = false,
+    val deviceRotation: DeviceRotation = DeviceRotation.Natural
 )
 
 fun SystemConstraints.forCurrentLens(cameraAppSettings: CameraAppSettings): CameraConstraints? {

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/DeviceRotation.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/DeviceRotation.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.settings.model
+
+import android.view.Surface
+
+enum class DeviceRotation {
+    Natural,
+    Rotated90,
+    Rotated180,
+    Rotated270;
+
+    /**
+     * Returns the rotation of the UI, expressed as a [Surface] rotation constant, needed to
+     * compensate for device rotation.
+     *
+     * These values do not match up with the device rotation angle. When the device is rotated,
+     * the UI must rotate in the opposite direction to compensate, so the angles 90 and 270 will
+     * be swapped in UI rotation compared to device rotation.
+     */
+    fun toUiSurfaceRotation(): Int {
+        return when (this) {
+            Natural -> Surface.ROTATION_0
+            Rotated90 -> Surface.ROTATION_270
+            Rotated180 -> Surface.ROTATION_180
+            Rotated270 -> Surface.ROTATION_90
+        }
+    }
+
+    fun toClockwiseRotationDegrees(): Int {
+        return when (this) {
+            Natural -> 0
+            Rotated90 -> 90
+            Rotated180 -> 180
+            Rotated270 -> 270
+        }
+    }
+
+    companion object {
+        fun snapFrom(degrees: Int): DeviceRotation {
+            check(degrees in 0..359) {
+                "Degrees must be in the range [0, 360)"
+            }
+
+            return when (val snappedDegrees = ((degrees + 45) / 90 * 90) % 360) {
+                0 -> Natural
+                90 -> Rotated90
+                180 -> Rotated180
+                270 -> Rotated270
+                else -> throw IllegalStateException(
+                    "Unexpected snapped degrees: $snappedDegrees" +
+                        ". Should be one of 0, 90, 180 or 270."
+                )
+            }
+        }
+    }
+}

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -55,6 +56,7 @@ import com.google.jetpackcamera.feature.preview.ui.PreviewDisplay
 import com.google.jetpackcamera.feature.preview.ui.ScreenFlashScreen
 import com.google.jetpackcamera.feature.preview.ui.TestableSnackbar
 import com.google.jetpackcamera.feature.preview.ui.TestableToast
+import com.google.jetpackcamera.feature.preview.ui.debouncedOrientationFlow
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
@@ -118,33 +120,40 @@ fun PreviewScreen(
 
     when (val currentUiState = previewUiState) {
         is PreviewUiState.NotReady -> LoadingScreen()
-        is PreviewUiState.Ready -> ContentScreen(
-            modifier = modifier,
-            previewUiState = currentUiState,
-            screenFlashUiState = screenFlashUiState,
-            surfaceRequest = surfaceRequest,
-            onNavigateToSettings = onNavigateToSettings,
-            onClearUiScreenBrightness = viewModel.screenFlash::setClearUiScreenBrightness,
-            onSetLensFacing = viewModel::setLensFacing,
-            onTapToFocus = viewModel::tapToFocus,
-            onChangeZoomScale = viewModel::setZoomScale,
-            onChangeFlash = viewModel::setFlash,
-            onChangeAspectRatio = viewModel::setAspectRatio,
-            onChangeCaptureMode = viewModel::setCaptureMode,
-            onChangeDynamicRange = viewModel::setDynamicRange,
-            onLowLightBoost = viewModel::setLowLightBoost,
-            onChangeImageFormat = viewModel::setImageFormat,
-            onToggleWhenDisabled = viewModel::showSnackBarForDisabledHdrToggle,
-            onToggleQuickSettings = viewModel::toggleQuickSettings,
-            onMuteAudio = viewModel::setAudioMuted,
-            onCaptureImage = viewModel::captureImage,
-            onCaptureImageWithUri = viewModel::captureImageWithUri,
-            onStartVideoRecording = viewModel::startVideoRecording,
-            onStopVideoRecording = viewModel::stopVideoRecording,
-            onToastShown = viewModel::onToastShown,
-            onRequestWindowColorMode = onRequestWindowColorMode,
-            onSnackBarResult = viewModel::onSnackBarResult
-        )
+        is PreviewUiState.Ready -> {
+            val context = LocalContext.current
+            LaunchedEffect(Unit) {
+                debouncedOrientationFlow(context).collect(viewModel::setDisplayRotation)
+            }
+
+            ContentScreen(
+                modifier = modifier,
+                previewUiState = currentUiState,
+                screenFlashUiState = screenFlashUiState,
+                surfaceRequest = surfaceRequest,
+                onNavigateToSettings = onNavigateToSettings,
+                onClearUiScreenBrightness = viewModel.screenFlash::setClearUiScreenBrightness,
+                onSetLensFacing = viewModel::setLensFacing,
+                onTapToFocus = viewModel::tapToFocus,
+                onChangeZoomScale = viewModel::setZoomScale,
+                onChangeFlash = viewModel::setFlash,
+                onChangeAspectRatio = viewModel::setAspectRatio,
+                onChangeCaptureMode = viewModel::setCaptureMode,
+                onChangeDynamicRange = viewModel::setDynamicRange,
+                onLowLightBoost = viewModel::setLowLightBoost,
+                onChangeImageFormat = viewModel::setImageFormat,
+                onToggleWhenDisabled = viewModel::showSnackBarForDisabledHdrToggle,
+                onToggleQuickSettings = viewModel::toggleQuickSettings,
+                onMuteAudio = viewModel::setAudioMuted,
+                onCaptureImage = viewModel::captureImage,
+                onCaptureImageWithUri = viewModel::captureImageWithUri,
+                onStartVideoRecording = viewModel::startVideoRecording,
+                onStopVideoRecording = viewModel::stopVideoRecording,
+                onToastShown = viewModel::onToastShown,
+                onRequestWindowColorMode = onRequestWindowColorMode,
+                onSnackBarResult = viewModel::onSnackBarResult
+            )
+        }
     }
 }
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -35,6 +35,7 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import com.google.jetpackcamera.settings.model.CaptureMode
+import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
@@ -573,6 +574,12 @@ class PreviewViewModel @AssistedInject constructor(
                     }
                 } ?: old
             }
+        }
+    }
+
+    fun setDisplayRotation(deviceRotation: DeviceRotation) {
+        viewModelScope.launch {
+            cameraUseCase.setDeviceRotation(deviceRotation)
         }
     }
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/DebouncedOrientationFlow.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/DebouncedOrientationFlow.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.feature.preview.ui
+
+import android.content.Context
+import android.view.OrientationEventListener
+import android.view.OrientationEventListener.ORIENTATION_UNKNOWN
+import com.google.jetpackcamera.settings.model.DeviceRotation
+import kotlin.math.abs
+import kotlin.math.min
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.runningFold
+
+/** Orientation hysteresis amount used in rounding, in degrees. */
+private const val ORIENTATION_HYSTERESIS = 5
+
+fun debouncedOrientationFlow(context: Context) = callbackFlow {
+    val orientationListener = object : OrientationEventListener(context) {
+        override fun onOrientationChanged(orientation: Int) {
+            trySend(orientation)
+        }
+    }
+
+    orientationListener.enable()
+
+    awaitClose {
+        orientationListener.disable()
+    }
+}.buffer(capacity = CONFLATED)
+    .runningFold(initial = DeviceRotation.Natural) { prevSnap, newDegrees ->
+        if (
+            newDegrees != ORIENTATION_UNKNOWN &&
+            abs(prevSnap.toClockwiseRotationDegrees() - newDegrees).let { min(it, 360 - it) } >=
+            45 + ORIENTATION_HYSTERESIS
+        ) {
+            DeviceRotation.snapFrom(newDegrees)
+        } else {
+            prevSnap
+        }
+    }.distinctUntilChanged()


### PR DESCRIPTION
 Videos and images will be captured based on the orientation
 of the device. This is independent of the screen's orientation,
 which will currently still be locked to portrait.
