### PR TITLE
Fix FakeCameraUseCaseTest compilation errors

### DIFF
--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
@@ -22,6 +22,7 @@ import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.LensFacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -40,7 +41,7 @@ class FakeCameraUseCaseTest {
     private val testScope = TestScope()
     private val testDispatcher = StandardTestDispatcher(testScope.testScheduler)
 
-    private val cameraUseCase = FakeCameraUseCase(testScope)
+    private val cameraUseCase = FakeCameraUseCase()
 
     @Before
     fun setup() {
@@ -128,7 +129,7 @@ class FakeCameraUseCaseTest {
         initAndRunCamera()
         val events = mutableListOf<CameraUseCase.ScreenFlashEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.getScreenFlashEvents().toList(events)
+            cameraUseCase.getScreenFlashEvents().consumeAsFlow().toList(events)
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash


### PR DESCRIPTION
 This test was missed during the concurrent camera refactor.
 Fixed with two changes fixing build failures.
