### PR TITLE
Flip while recording

### DIFF
--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -100,7 +100,6 @@ context(CameraSessionContext)
 @kotlin.OptIn(ExperimentalCoroutinesApi::class)
 internal suspend fun runSingleCameraSession(
     videoCapture: VideoCapture<Recorder>?,
-    onFlipCamera: () -> Unit,
     sessionSettings: PerpetualSessionSettings.SingleCamera,
     useCaseMode: CameraUseCase.UseCaseMode,
     // TODO(tm): ImageCapture should go through an event channel like VideoCapture
@@ -169,7 +168,6 @@ internal suspend fun runSingleCameraSession(
             useCaseGroup,
             initialTransientSettings,
             transientSettings,
-            onFlipCamera,
             onRebind.getCompleted()
         )
     }
@@ -181,7 +179,6 @@ internal suspend fun processTransientSettingEvents(
     useCaseGroup: UseCaseGroup,
     initialTransientSettings: TransientSessionSettings,
     transientSettings: StateFlow<TransientSessionSettings?>,
-    onFlipCamera: () -> Unit,
     onRebind : (CameraSelector, UseCaseGroup) -> Unit,
 
     ) {
@@ -201,12 +198,12 @@ internal suspend fun processTransientSettingEvents(
                 }
             }
         }
-
+        //todo(kc) unable to zoom on flipped camera... continues to zooms on the initial camera
         if (prevTransientSettings.cameraInfo != newTransientSettings.cameraInfo) {
-            //unbind and rebind with the new camerainfo
-            Log.d(TAG, "I WANNA REBIND!!!")
+            //when we want to flip, unbind and rebind with the new camerainfo
             cameraProvider.unbindAll()
             onRebind(transientSettings.value!!.cameraInfo.cameraSelector, useCaseGroup)
+            // its like magic
         }
 
         useCaseGroup.getImageCapture()?.let { imageCapture ->

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionSettings.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionSettings.kt
@@ -34,7 +34,7 @@ internal sealed interface PerpetualSessionSettings {
     val aspectRatio: AspectRatio
 
     data class SingleCamera(
-        val cameraInfo: CameraInfo,
+        // val cameraInfo: CameraInfo,
         override val aspectRatio: AspectRatio,
         val captureMode: CaptureMode,
         val targetFrameRate: Int,
@@ -62,5 +62,6 @@ internal data class TransientSessionSettings(
     val audioMuted: Boolean,
     val deviceRotation: DeviceRotation,
     val flashMode: FlashMode,
-    val zoomScale: Float
+    val zoomScale: Float,
+    val cameraInfo: CameraInfo
 )

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
@@ -43,7 +43,6 @@ context(CameraSessionContext)
 @SuppressLint("RestrictedApi")
 internal suspend fun runConcurrentCameraSession(
     videoCapture: VideoCapture<Recorder>?,
-    onFlipCamera: () -> Unit,
     sessionSettings: PerpetualSessionSettings.ConcurrentCamera,
     useCaseMode: CameraUseCase.UseCaseMode
 ) = coroutineScope {
@@ -124,7 +123,6 @@ internal suspend fun runConcurrentCameraSession(
             useCaseGroup,
             initialTransientSettings,
             transientSettings,
-            onFlipCamera,
             onRebind.getCompleted()
         )
     }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
@@ -19,6 +19,8 @@ import android.annotation.SuppressLint
 import android.util.Log
 import androidx.camera.core.CompositionSettings
 import androidx.camera.core.TorchState
+import androidx.camera.video.Recorder
+import androidx.camera.video.VideoCapture
 import androidx.lifecycle.asFlow
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
@@ -35,6 +37,7 @@ private const val TAG = "ConcurrentCameraSession"
 context(CameraSessionContext)
 @SuppressLint("RestrictedApi")
 internal suspend fun runConcurrentCameraSession(
+    videoCapture: VideoCapture<Recorder>?,
     sessionSettings: PerpetualSessionSettings.ConcurrentCamera,
     useCaseMode: CameraUseCase.UseCaseMode
 ) = coroutineScope {
@@ -59,8 +62,9 @@ internal suspend fun runConcurrentCameraSession(
         targetFrameRate = TARGET_FPS_AUTO,
         dynamicRange = DynamicRange.SDR,
         imageFormat = ImageOutputFormat.JPEG,
-        useCaseMode = useCaseMode
-    )
+        useCaseMode = useCaseMode,
+        videoCapture = videoCapture,
+        )
 
     val cameraConfigs = listOf(
         Pair(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CoroutineCameraProvider.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CoroutineCameraProvider.kt
@@ -41,10 +41,15 @@ import kotlinx.coroutines.coroutineScope
 suspend fun <R> ProcessCameraProvider.runWith(
     cameraSelector: CameraSelector,
     useCases: UseCaseGroup,
-    block: suspend CoroutineScope.(Camera) -> R
+    onRebindLifeCycle: ((CameraSelector, UseCaseGroup) -> Unit) -> Unit,
+    block: suspend CoroutineScope.(Camera) -> R,
 ): R = coroutineScope {
     val scopedLifecycle = CoroutineLifecycleOwner(coroutineContext)
-    block(this@runWith.bindToLifecycle(scopedLifecycle, cameraSelector, useCases))
+    val rebind = fun(newCameraSelector:CameraSelector, newUseCaseGroup:UseCaseGroup){
+        bindToLifecycle(scopedLifecycle, newCameraSelector, newUseCaseGroup)
+    }
+    onRebindLifeCycle(rebind)
+    block((this@runWith.bindToLifecycle(scopedLifecycle, cameraSelector, useCases)))
 }
 
 @SuppressLint("RestrictedApi")

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -450,6 +450,7 @@ class PreviewViewModel @AssistedInject constructor(
         viewModelScope.launch {
             // apply to cameraUseCase
             cameraUseCase.setLensFacing(newLensFacing)
+            Log.d(TAG, "set lens to $newLensFacing")
         }
     }
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -265,7 +265,7 @@ private fun ControlsBottom(
         ) {
             // Row that holds flip camera, capture button, and audio
             Row(Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceEvenly) {
-                if (!isQuickSettingsOpen && videoRecordingState is VideoRecordingState.Inactive) {
+                if (!isQuickSettingsOpen) {
                     FlipCameraButton(
                         modifier = Modifier.testTag(FLIP_CAMERA_BUTTON),
                         onClick = onFlipCamera,

--- a/feature/settings/src/androidTest/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/androidTest/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -64,6 +64,7 @@ internal class CameraAppSettingsViewModelTest {
             updateSystemConstraints(TYPICAL_SYSTEM_CONSTRAINTS)
         }
         settingsViewModel = SettingsViewModel(settingsRepository, constraintsRepository)
+
         advanceUntilIdle()
     }
 


### PR DESCRIPTION
![standoff](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGQwcnM5c2lxbGx5eGdoN2pvbDhzMzFmMnIzYXVvamQ2Nmltdms1MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/T0Zzs2VVfX2Eg/giphy.gif)
🔨🚧🔨🚧🔨 **WIP: This is a working wip that allows the user to flip the camera while recording** 
still need to address:
* zoom only zooms the initial lens direction, even when flipped
* `videoUseCase` passed into `concurrentCameraSession `
* verify tap to focus on flipped screen
