### PR TITLE
debug mode always shows preview zoom ratio

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -58,6 +58,7 @@ import com.google.jetpackcamera.feature.preview.ui.PreviewDisplay
 import com.google.jetpackcamera.feature.preview.ui.ScreenFlashScreen
 import com.google.jetpackcamera.feature.preview.ui.TestableSnackbar
 import com.google.jetpackcamera.feature.preview.ui.TestableToast
+import com.google.jetpackcamera.feature.preview.ui.ZoomLevelDisplayState
 import com.google.jetpackcamera.feature.preview.ui.debouncedOrientationFlow
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CaptureMode
@@ -154,7 +155,8 @@ fun PreviewScreen(
                 onStopVideoRecording = viewModel::stopVideoRecording,
                 onToastShown = viewModel::onToastShown,
                 onRequestWindowColorMode = onRequestWindowColorMode,
-                onSnackBarResult = viewModel::onSnackBarResult
+                onSnackBarResult = viewModel::onSnackBarResult,
+                isDebugMode = isDebugMode
             )
         }
     }
@@ -196,7 +198,8 @@ private fun ContentScreen(
     onStopVideoRecording: () -> Unit = {},
     onToastShown: () -> Unit = {},
     onRequestWindowColorMode: (Int) -> Unit = {},
-    onSnackBarResult: (String) -> Unit = {}
+    onSnackBarResult: (String) -> Unit = {},
+    isDebugMode: Boolean = false,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
@@ -256,7 +259,8 @@ private fun ContentScreen(
                 onCaptureImage = onCaptureImage,
                 onCaptureImageWithUri = onCaptureImageWithUri,
                 onStartVideoRecording = onStartVideoRecording,
-                onStopVideoRecording = onStopVideoRecording
+                onStopVideoRecording = onStopVideoRecording,
+                zoomLevelDisplayState = remember { ZoomLevelDisplayState(isDebugMode) }
             )
             // displays toast when there is a message to show
             if (previewUiState.toastMessageToShow != null) {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -199,7 +199,7 @@ private fun ContentScreen(
     onToastShown: () -> Unit = {},
     onRequestWindowColorMode: (Int) -> Unit = {},
     onSnackBarResult: (String) -> Unit = {},
-    isDebugMode: Boolean = false,
+    isDebugMode: Boolean = false
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -72,14 +72,16 @@ import com.google.jetpackcamera.settings.model.SystemConstraints
 import com.google.jetpackcamera.settings.model.TYPICAL_SYSTEM_CONSTRAINTS
 import kotlinx.coroutines.delay
 
-class ZoomLevelDisplayState(showInitially: Boolean = false) {
-    private var _showZoomLevel = mutableStateOf(showInitially)
+class ZoomLevelDisplayState(private val alwaysDisplay: Boolean = false) {
+    private var _showZoomLevel = mutableStateOf(alwaysDisplay)
     val showZoomLevel: Boolean get() = _showZoomLevel.value
 
     suspend fun showZoomLevel() {
-        _showZoomLevel.value = true
-        delay(3000)
-        _showZoomLevel.value = false
+        if (!alwaysDisplay) {
+            _showZoomLevel.value = true
+            delay(3000)
+            _showZoomLevel.value = false
+        }
     }
 }
 


### PR DESCRIPTION
As titled. To make it more convenient for ITS test_zoom. This is reasonable since we want to display as much information in debug mode anyway