### PR TITLE
Fix bug causing top app controls to invade the top status bar

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Videocam
@@ -125,7 +126,11 @@ fun CameraControlsOverlay(
     }
 
     CompositionLocalProvider(LocalContentColor provides Color.White) {
-        Box(modifier.fillMaxSize()) {
+        Box(
+            modifier
+                .safeDrawingPadding()
+                .fillMaxSize()
+        ) {
             if (previewUiState.videoRecordingState is VideoRecordingState.Inactive) {
                 ControlsTop(
                     modifier = Modifier


### PR DESCRIPTION
✅ This change adds a modifier to prevent the top controls from occupying the status bar.

🗒️ Context: For some devices, such as the Pixel 9 Pro XL, `Modifier.fillMaxHeight` will cause UI elements to fill to the the top edge of the device's screen. While it is ok for  parts of the app (such as viewfinder) to extend to the top edge of the screen, elements such as buttons should not. 


🧠 For more reference, refer to this Android Developers guide: **[Display content edge-to-edge in your app and handle window insets in Compose](https://developer.android.com/develop/ui/compose/layouts/insets)** 

