### PR TITLE
update  UseCaseMode to CaptureMode

### DIFF
--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCaseTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCaseTest.kt
@@ -168,7 +168,7 @@ class CameraXCameraUseCaseTest {
         iODispatcher = Dispatchers.IO,
         constraintsRepository = constraintsRepository
     ).apply {
-        initialize(appSettings, CameraUseCase.UseCaseMode.STANDARD) {}
+        initialize(appSettings) {}
         providePreviewSurface()
     }
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -116,7 +116,6 @@ private val QUALITY_RANGE_MAP = mapOf(
 context(CameraSessionContext)
 internal suspend fun runSingleCameraSession(
     sessionSettings: PerpetualSessionSettings.SingleCamera,
-    // useCaseMode: CameraUseCase.UseCaseMode,
     // TODO(tm): ImageCapture should go through an event channel like VideoCapture
     onImageCaptureCreated: (ImageCapture) -> Unit = {}
 ) = coroutineScope {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -68,6 +68,7 @@ import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.lifecycle.asFlow
 import com.google.jetpackcamera.core.camera.effects.SingleSurfaceForcingEffect
 import com.google.jetpackcamera.settings.model.AspectRatio
+import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
@@ -115,7 +116,7 @@ private val QUALITY_RANGE_MAP = mapOf(
 context(CameraSessionContext)
 internal suspend fun runSingleCameraSession(
     sessionSettings: PerpetualSessionSettings.SingleCamera,
-    useCaseMode: CameraUseCase.UseCaseMode,
+    // useCaseMode: CameraUseCase.UseCaseMode,
     // TODO(tm): ImageCapture should go through an event channel like VideoCapture
     onImageCaptureCreated: (ImageCapture) -> Unit = {}
 ) = coroutineScope {
@@ -124,8 +125,8 @@ internal suspend fun runSingleCameraSession(
     val initialCameraSelector = transientSettings.filterNotNull().first()
         .primaryLensFacing.toCameraSelector()
 
-    val videoCaptureUseCase = when (useCaseMode) {
-        CameraUseCase.UseCaseMode.STANDARD, CameraUseCase.UseCaseMode.VIDEO_ONLY ->
+    val videoCaptureUseCase = when (sessionSettings.captureMode) {
+        CaptureMode.DEFAULT, CaptureMode.VIDEO_ONLY ->
             createVideoUseCase(
                 cameraProvider.getCameraInfo(initialCameraSelector),
                 sessionSettings.aspectRatio,
@@ -135,7 +136,6 @@ internal suspend fun runSingleCameraSession(
                 sessionSettings.videoQuality,
                 backgroundDispatcher
             )
-
         else -> {
             null
         }
@@ -164,7 +164,7 @@ internal suspend fun runSingleCameraSession(
             aspectRatio = sessionSettings.aspectRatio,
             dynamicRange = sessionSettings.dynamicRange,
             imageFormat = sessionSettings.imageFormat,
-            useCaseMode = useCaseMode,
+            captureMode = sessionSettings.captureMode,
             effect = when (sessionSettings.streamConfig) {
                 StreamConfig.SINGLE_STREAM -> SingleSurfaceForcingEffect(this@coroutineScope)
                 StreamConfig.MULTI_STREAM -> null
@@ -369,7 +369,7 @@ internal fun createUseCaseGroup(
     videoCaptureUseCase: VideoCapture<Recorder>?,
     dynamicRange: DynamicRange,
     imageFormat: ImageOutputFormat,
-    useCaseMode: CameraUseCase.UseCaseMode,
+    captureMode: CaptureMode,
     effect: CameraEffect? = null
 ): UseCaseGroup {
     val previewUseCase =
@@ -378,7 +378,7 @@ internal fun createUseCaseGroup(
             aspectRatio,
             stabilizationMode
         )
-    val imageCaptureUseCase = if (useCaseMode != CameraUseCase.UseCaseMode.VIDEO_ONLY) {
+    val imageCaptureUseCase = if (captureMode != CaptureMode.VIDEO_ONLY) {
         createImageUseCase(cameraInfo, aspectRatio, dynamicRange, imageFormat)
     } else {
         null

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -125,7 +125,7 @@ internal suspend fun runSingleCameraSession(
         .primaryLensFacing.toCameraSelector()
 
     val videoCaptureUseCase = when (sessionSettings.captureMode) {
-        CaptureMode.DEFAULT, CaptureMode.VIDEO_ONLY ->
+        CaptureMode.STANDARD, CaptureMode.VIDEO_ONLY ->
             createVideoUseCase(
                 cameraProvider.getCameraInfo(initialCameraSelector),
                 sessionSettings.aspectRatio,
@@ -423,13 +423,12 @@ internal fun createUseCaseGroup(
     }.build()
 }
 
-private fun getVideoQualityFromResolution(resolution: Size?): VideoQuality {
-    return resolution?.let { res ->
+private fun getVideoQualityFromResolution(resolution: Size?): VideoQuality =
+    resolution?.let { res ->
         QUALITY_RANGE_MAP.firstNotNullOfOrNull {
             if (it.value.contains(res.height)) it.key else null
         }
     } ?: VideoQuality.UNSPECIFIED
-}
 
 private fun getWidthFromCropRect(cropRect: Rect?): Int {
     if (cropRect == null) {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionSettings.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionSettings.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera.core.camera
 
 import androidx.camera.core.CameraInfo
 import com.google.jetpackcamera.settings.model.AspectRatio
+import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
@@ -34,9 +35,11 @@ import com.google.jetpackcamera.settings.model.VideoQuality
  */
 internal sealed interface PerpetualSessionSettings {
     val aspectRatio: AspectRatio
+    val captureMode: CaptureMode
 
     data class SingleCamera(
         override val aspectRatio: AspectRatio,
+        override val captureMode: CaptureMode,
         val streamConfig: StreamConfig,
         val targetFrameRate: Int,
         val stabilizationMode: StabilizationMode,
@@ -49,7 +52,9 @@ internal sealed interface PerpetualSessionSettings {
         val primaryCameraInfo: CameraInfo,
         val secondaryCameraInfo: CameraInfo,
         override val aspectRatio: AspectRatio
-    ) : PerpetualSessionSettings
+    ) : PerpetualSessionSettings {
+        override val captureMode: CaptureMode = CaptureMode.VIDEO_ONLY
+    }
 }
 
 /**

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionSettings.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionSettings.kt
@@ -48,6 +48,10 @@ internal sealed interface PerpetualSessionSettings {
         val imageFormat: ImageOutputFormat
     ) : PerpetualSessionSettings
 
+    /**
+     * @property captureMode is always [CaptureMode.VIDEO_ONLY] in Concurrent Camera mode.
+     * Concurrent Camera currently only supports video capture
+     */
     data class ConcurrentCamera(
         val primaryCameraInfo: CameraInfo,
         val secondaryCameraInfo: CameraInfo,

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -45,7 +45,7 @@ interface CameraUseCase {
      */
     suspend fun initialize(
         cameraAppSettings: CameraAppSettings,
-        useCaseMode: UseCaseMode,
+        // useCaseMode: UseCaseMode,
         isDebugMode: Boolean = false,
         cameraPropertiesJSONCallback: (result: String) -> Unit
     )
@@ -146,11 +146,11 @@ interface CameraUseCase {
         data class OnVideoRecordError(val error: Throwable) : OnVideoRecordEvent
     }
 
-    enum class UseCaseMode {
+    /*enum class UseCaseMode {
         STANDARD,
         IMAGE_ONLY,
         VIDEO_ONLY
-    }
+    }*/
 }
 
 sealed interface VideoRecordingState {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -45,7 +45,6 @@ interface CameraUseCase {
      */
     suspend fun initialize(
         cameraAppSettings: CameraAppSettings,
-        // useCaseMode: UseCaseMode,
         isDebugMode: Boolean = false,
         cameraPropertiesJSONCallback: (result: String) -> Unit
     )
@@ -145,12 +144,6 @@ interface CameraUseCase {
 
         data class OnVideoRecordError(val error: Throwable) : OnVideoRecordEvent
     }
-
-    /*enum class UseCaseMode {
-        STANDARD,
-        IMAGE_ONLY,
-        VIDEO_ONLY
-    }*/
 }
 
 sealed interface VideoRecordingState {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -101,7 +101,6 @@ constructor(
     private var imageCaptureUseCase: ImageCapture? = null
 
     private lateinit var systemConstraints: SystemConstraints
-    // private var useCaseMode by Delegates.notNull<CameraUseCase.UseCaseMode>()
 
     private val screenFlashEvents: Channel<CameraUseCase.ScreenFlashEvent> =
         Channel(capacity = Channel.UNLIMITED)
@@ -121,11 +120,9 @@ constructor(
 
     override suspend fun initialize(
         cameraAppSettings: CameraAppSettings,
-        // useCaseMode: CameraUseCase.UseCaseMode,
         isDebugMode: Boolean,
         cameraPropertiesJSONCallback: (result: String) -> Unit
     ) {
-        // this.useCaseMode = useCaseMode
         cameraProvider = ProcessCameraProvider.awaitInstance(application)
 
         // updates values for available cameras
@@ -376,12 +373,10 @@ constructor(
                         try {
                             when (sessionSettings) {
                                 is PerpetualSessionSettings.SingleCamera -> runSingleCameraSession(
-                                    sessionSettings,
-                                    // useCaseMode = useCaseMode,
-                                    onImageCaptureCreated = { imageCapture ->
-                                        imageCaptureUseCase = imageCapture
-                                    }
-                                )
+                                    sessionSettings
+                                ) { imageCapture ->
+                                    imageCaptureUseCase = imageCapture
+                                }
 
                                 is PerpetualSessionSettings.ConcurrentCamera ->
                                     runConcurrentCameraSession(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -591,7 +591,7 @@ constructor(
     private fun CameraAppSettings.tryApplyAspectRatioForExternalCapture(
         captureMode: CaptureMode
     ): CameraAppSettings = when (captureMode) {
-        CaptureMode.DEFAULT -> this
+        CaptureMode.STANDARD -> this
         CaptureMode.IMAGE_ONLY ->
             this.copy(aspectRatio = AspectRatio.THREE_FOUR)
         CaptureMode.VIDEO_ONLY ->
@@ -661,8 +661,8 @@ constructor(
                 }
         }
 
-    private fun CameraAppSettings.tryApplyVideoQualityConstraints(): CameraAppSettings {
-        return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
+    private fun CameraAppSettings.tryApplyVideoQualityConstraints(): CameraAppSettings =
+        systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedVideoQualitiesMap) {
                 val newVideoQuality = get(dynamicRange).let {
                     if (it == null) {
@@ -679,7 +679,6 @@ constructor(
                 )
             }
         } ?: this
-    }
 
     private fun CameraAppSettings.tryApplyFlashModeConstraints(): CameraAppSettings =
         systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -43,6 +43,7 @@ import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_15
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_60
+import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.ConcurrentCameraMode
 import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
@@ -62,7 +63,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
-import kotlin.properties.Delegates
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -101,7 +101,7 @@ constructor(
     private var imageCaptureUseCase: ImageCapture? = null
 
     private lateinit var systemConstraints: SystemConstraints
-    private var useCaseMode by Delegates.notNull<CameraUseCase.UseCaseMode>()
+    // private var useCaseMode by Delegates.notNull<CameraUseCase.UseCaseMode>()
 
     private val screenFlashEvents: Channel<CameraUseCase.ScreenFlashEvent> =
         Channel(capacity = Channel.UNLIMITED)
@@ -121,11 +121,11 @@ constructor(
 
     override suspend fun initialize(
         cameraAppSettings: CameraAppSettings,
-        useCaseMode: CameraUseCase.UseCaseMode,
+        // useCaseMode: CameraUseCase.UseCaseMode,
         isDebugMode: Boolean,
         cameraPropertiesJSONCallback: (result: String) -> Unit
     ) {
-        this.useCaseMode = useCaseMode
+        // this.useCaseMode = useCaseMode
         cameraProvider = ProcessCameraProvider.awaitInstance(application)
 
         // updates values for available cameras
@@ -258,7 +258,7 @@ constructor(
         currentSettings.value =
             cameraAppSettings
                 .tryApplyDynamicRangeConstraints()
-                .tryApplyAspectRatioForExternalCapture(this.useCaseMode)
+                .tryApplyAspectRatioForExternalCapture(cameraAppSettings.captureMode)
                 .tryApplyImageFormatConstraints()
                 .tryApplyFrameRateConstraints()
                 .tryApplyStabilizationConstraints()
@@ -316,6 +316,7 @@ constructor(
 
                         PerpetualSessionSettings.SingleCamera(
                             aspectRatio = currentCameraSettings.aspectRatio,
+                            captureMode = currentCameraSettings.captureMode,
                             streamConfig = currentCameraSettings.streamConfig,
                             targetFrameRate = currentCameraSettings.targetFrameRate,
                             stabilizationMode = resolvedStabilizationMode,
@@ -376,7 +377,7 @@ constructor(
                             when (sessionSettings) {
                                 is PerpetualSessionSettings.SingleCamera -> runSingleCameraSession(
                                     sessionSettings,
-                                    useCaseMode = useCaseMode,
+                                    // useCaseMode = useCaseMode,
                                     onImageCaptureCreated = { imageCapture ->
                                         imageCaptureUseCase = imageCapture
                                     }
@@ -384,8 +385,7 @@ constructor(
 
                                 is PerpetualSessionSettings.ConcurrentCamera ->
                                     runConcurrentCameraSession(
-                                        sessionSettings,
-                                        useCaseMode = CameraUseCase.UseCaseMode.VIDEO_ONLY
+                                        sessionSettings
                                     )
                             }
                         } finally {
@@ -594,13 +594,12 @@ constructor(
         } ?: this
 
     private fun CameraAppSettings.tryApplyAspectRatioForExternalCapture(
-        useCaseMode: CameraUseCase.UseCaseMode
-    ): CameraAppSettings = when (useCaseMode) {
-        CameraUseCase.UseCaseMode.STANDARD -> this
-        CameraUseCase.UseCaseMode.IMAGE_ONLY ->
+        captureMode: CaptureMode
+    ): CameraAppSettings = when (captureMode) {
+        CaptureMode.DEFAULT -> this
+        CaptureMode.IMAGE_ONLY ->
             this.copy(aspectRatio = AspectRatio.THREE_FOUR)
-
-        CameraUseCase.UseCaseMode.VIDEO_ONLY ->
+        CaptureMode.VIDEO_ONLY ->
             this.copy(aspectRatio = AspectRatio.NINE_SIXTEEN)
     }
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import androidx.camera.core.CompositionSettings
 import androidx.camera.core.TorchState
 import androidx.lifecycle.asFlow
+import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
 import com.google.jetpackcamera.settings.model.StabilizationMode
@@ -36,8 +37,7 @@ private const val TAG = "ConcurrentCameraSession"
 context(CameraSessionContext)
 @SuppressLint("RestrictedApi")
 internal suspend fun runConcurrentCameraSession(
-    sessionSettings: PerpetualSessionSettings.ConcurrentCamera,
-    useCaseMode: CameraUseCase.UseCaseMode
+    sessionSettings: PerpetualSessionSettings.ConcurrentCamera
 ) = coroutineScope {
     val primaryLensFacing = sessionSettings.primaryCameraInfo.appLensFacing
     val secondaryLensFacing = sessionSettings.secondaryCameraInfo.appLensFacing
@@ -51,7 +51,7 @@ internal suspend fun runConcurrentCameraSession(
         .filterNotNull()
         .first()
 
-    val videoCapture = if (useCaseMode != CameraUseCase.UseCaseMode.IMAGE_ONLY) {
+    val videoCapture = if (sessionSettings.captureMode != CaptureMode.IMAGE_ONLY) {
         createVideoUseCase(
             cameraProvider.getCameraInfo(
                 initialTransientSettings.primaryLensFacing.toCameraSelector()
@@ -74,7 +74,7 @@ internal suspend fun runConcurrentCameraSession(
         aspectRatio = sessionSettings.aspectRatio,
         dynamicRange = DynamicRange.SDR,
         imageFormat = ImageOutputFormat.JPEG,
-        useCaseMode = useCaseMode,
+        captureMode = sessionSettings.captureMode,
         videoCaptureUseCase = videoCapture
     )
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -63,7 +63,6 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
 
     override suspend fun initialize(
         cameraAppSettings: CameraAppSettings,
-        //  useCaseMode: CameraUseCase.UseCaseMode,
         isDebugMode: Boolean,
         cameraPropertiesJSONCallback: (result: String) -> Unit
     ) {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -63,7 +63,7 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
 
     override suspend fun initialize(
         cameraAppSettings: CameraAppSettings,
-        useCaseMode: CameraUseCase.UseCaseMode,
+        //  useCaseMode: CameraUseCase.UseCaseMode,
         isDebugMode: Boolean,
         cameraPropertiesJSONCallback: (result: String) -> Unit
     ) {

--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCaseTest.kt
@@ -56,8 +56,7 @@ class FakeCameraUseCaseTest {
     @Test
     fun canInitialize() = runTest(testDispatcher) {
         cameraUseCase.initialize(
-            cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS,
-            useCaseMode = CameraUseCase.UseCaseMode.STANDARD
+            cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
         ) {}
     }
 
@@ -150,8 +149,7 @@ class FakeCameraUseCaseTest {
     private fun TestScope.initAndRunCamera() {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             cameraUseCase.initialize(
-                cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS,
-                useCaseMode = CameraUseCase.UseCaseMode.STANDARD
+                cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
             ) {}
             cameraUseCase.runCamera()
         }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -24,7 +24,7 @@ val DEFAULT_HDR_IMAGE_OUTPUT = ImageOutputFormat.JPEG_ULTRA_HDR
  * Data layer representation for settings.
  */
 data class CameraAppSettings(
-    val captureMode: CaptureMode = CaptureMode.DEFAULT,
+    val captureMode: CaptureMode = CaptureMode.STANDARD,
     val cameraLensFacing: LensFacing = LensFacing.BACK,
     val darkMode: DarkMode = DarkMode.SYSTEM,
     val flashMode: FlashMode = FlashMode.OFF,

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -24,6 +24,7 @@ val DEFAULT_HDR_IMAGE_OUTPUT = ImageOutputFormat.JPEG_ULTRA_HDR
  * Data layer representation for settings.
  */
 data class CameraAppSettings(
+    val captureMode: CaptureMode = CaptureMode.DEFAULT,
     val cameraLensFacing: LensFacing = LensFacing.BACK,
     val darkMode: DarkMode = DarkMode.SYSTEM,
     val flashMode: FlashMode = FlashMode.OFF,

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
@@ -16,7 +16,7 @@
 package com.google.jetpackcamera.settings.model
 
 enum class CaptureMode {
-    DEFAULT,
+    STANDARD,
     VIDEO_ONLY,
     IMAGE_ONLY
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jetpackcamera.settings.model
+
+enum class CaptureMode {
+    DEFAULT,
+    VIDEO_ONLY,
+    IMAGE_ONLY
+}

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CaptureMode.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.jetpackcamera.settings.model
 
 enum class CaptureMode {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -128,7 +128,7 @@ class PreviewViewModel @AssistedInject constructor(
      */
     private fun CameraAppSettings.applyPreviewMode(previewMode: PreviewMode): CameraAppSettings {
         val captureMode = previewMode.toCaptureMode()
-        return if (captureMode == CaptureMode.STANDARD) {
+        return if (captureMode == this.captureMode) {
             this
         } else {
             this.copy(captureMode = captureMode)

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -41,6 +41,7 @@ import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
+import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.ConcurrentCameraMode
 import com.google.jetpackcamera.settings.model.DeviceRotation
 import com.google.jetpackcamera.settings.model.DynamicRange
@@ -116,10 +117,22 @@ class PreviewViewModel @AssistedInject constructor(
     // used to ensure we don't start the camera before initialization is complete.
     private var initializationDeferred: Deferred<Unit> = viewModelScope.async {
         cameraUseCase.initialize(
-            cameraAppSettings = settingsRepository.defaultCameraAppSettings.first(),
-            previewMode.toUseCaseMode(),
-            isDebugMode
+            cameraAppSettings = settingsRepository.defaultCameraAppSettings.first()
+                .applyPreviewMode(previewMode),
+            isDebugMode = isDebugMode
         ) { cameraPropertiesJSON = it }
+    }
+
+    /**
+     * updates the capture mode based on the preview mode
+     */
+    private fun CameraAppSettings.applyPreviewMode(previewMode: PreviewMode): CameraAppSettings {
+        val captureMode = previewMode.toCaptureMode()
+        return if (captureMode == CaptureMode.DEFAULT) {
+            this
+        } else {
+            this.copy(captureMode = captureMode)
+        }
     }
 
     init {
@@ -307,11 +320,11 @@ class PreviewViewModel @AssistedInject constructor(
         }
     }
 
-    private fun PreviewMode.toUseCaseMode() = when (this) {
-        is PreviewMode.ExternalImageCaptureMode -> CameraUseCase.UseCaseMode.IMAGE_ONLY
-        is PreviewMode.ExternalMultipleImageCaptureMode -> CameraUseCase.UseCaseMode.IMAGE_ONLY
-        is PreviewMode.ExternalVideoCaptureMode -> CameraUseCase.UseCaseMode.VIDEO_ONLY
-        is PreviewMode.StandardMode -> CameraUseCase.UseCaseMode.STANDARD
+    private fun PreviewMode.toCaptureMode() = when (this) {
+        is PreviewMode.ExternalImageCaptureMode -> CaptureMode.IMAGE_ONLY
+        is PreviewMode.ExternalMultipleImageCaptureMode -> CaptureMode.IMAGE_ONLY
+        is PreviewMode.ExternalVideoCaptureMode -> CaptureMode.VIDEO_ONLY
+        is PreviewMode.StandardMode -> CaptureMode.DEFAULT
     }
 
     /**

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -128,7 +128,7 @@ class PreviewViewModel @AssistedInject constructor(
      */
     private fun CameraAppSettings.applyPreviewMode(previewMode: PreviewMode): CameraAppSettings {
         val captureMode = previewMode.toCaptureMode()
-        return if (captureMode == CaptureMode.DEFAULT) {
+        return if (captureMode == CaptureMode.STANDARD) {
             this
         } else {
             this.copy(captureMode = captureMode)
@@ -279,16 +279,14 @@ class PreviewViewModel @AssistedInject constructor(
     private fun getAudioUiState(
         isAudioEnabled: Boolean,
         videoRecordingState: VideoRecordingState
-    ): AudioUiState {
-        return if (isAudioEnabled) {
-            if (videoRecordingState is VideoRecordingState.Active) {
-                AudioUiState.Enabled.On(videoRecordingState.audioAmplitude)
-            } else {
-                AudioUiState.Enabled.On(0.0)
-            }
+    ): AudioUiState = if (isAudioEnabled) {
+        if (videoRecordingState is VideoRecordingState.Active) {
+            AudioUiState.Enabled.On(videoRecordingState.audioAmplitude)
         } else {
-            AudioUiState.Enabled.Mute
+            AudioUiState.Enabled.On(0.0)
         }
+    } else {
+        AudioUiState.Enabled.Mute
     }
 
     private fun stabilizationUiStateFrom(
@@ -324,7 +322,7 @@ class PreviewViewModel @AssistedInject constructor(
         is PreviewMode.ExternalImageCaptureMode -> CaptureMode.IMAGE_ONLY
         is PreviewMode.ExternalMultipleImageCaptureMode -> CaptureMode.IMAGE_ONLY
         is PreviewMode.ExternalVideoCaptureMode -> CaptureMode.VIDEO_ONLY
-        is PreviewMode.StandardMode -> CaptureMode.DEFAULT
+        is PreviewMode.StandardMode -> CaptureMode.STANDARD
     }
 
     /**

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -732,6 +732,53 @@ fun CurrentCameraIdText(physicalCameraId: String?, logicalCameraId: String?) {
 }
 
 @Composable
+private fun CaptureModeDropDown() {
+    var isExpanded by remember { mutableStateOf(false) }
+    var selectedOption by remember { mutableStateOf("Default") }
+
+    Column {
+        Box(
+            modifier = Modifier
+                .clickable { isExpanded = !isExpanded }
+                .padding(8.dp)
+        ) {
+            Text(text = selectedOption, modifier = Modifier.padding(16.dp))
+        }
+        AnimatedVisibility(visible = isExpanded) {
+            Column {
+                Text(
+                    text = "Default",
+                    modifier = Modifier
+                        .clickable {
+                            selectedOption = "Default"
+                            isExpanded = false
+                        }
+                        .padding(16.dp)
+                )
+                Text(
+                    text = "Image Only",
+                    modifier = Modifier
+                        .clickable {
+                            selectedOption = "Image Only"
+                            isExpanded = false
+                        }
+                        .padding(16.dp)
+                )
+                Text(
+                    text = "Video Only",
+                    modifier = Modifier
+                        .clickable {
+                            selectedOption = "Video Only"
+                            isExpanded = false
+                        }
+                        .padding(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
 fun CaptureButton(
     onClick: () -> Unit,
     onLongPress: () -> Unit,

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -732,53 +732,6 @@ fun CurrentCameraIdText(physicalCameraId: String?, logicalCameraId: String?) {
 }
 
 @Composable
-private fun CaptureModeDropDown() {
-    var isExpanded by remember { mutableStateOf(false) }
-    var selectedOption by remember { mutableStateOf("Default") }
-
-    Column {
-        Box(
-            modifier = Modifier
-                .clickable { isExpanded = !isExpanded }
-                .padding(8.dp)
-        ) {
-            Text(text = selectedOption, modifier = Modifier.padding(16.dp))
-        }
-        AnimatedVisibility(visible = isExpanded) {
-            Column {
-                Text(
-                    text = "Default",
-                    modifier = Modifier
-                        .clickable {
-                            selectedOption = "Default"
-                            isExpanded = false
-                        }
-                        .padding(16.dp)
-                )
-                Text(
-                    text = "Image Only",
-                    modifier = Modifier
-                        .clickable {
-                            selectedOption = "Image Only"
-                            isExpanded = false
-                        }
-                        .padding(16.dp)
-                )
-                Text(
-                    text = "Video Only",
-                    modifier = Modifier
-                        .clickable {
-                            selectedOption = "Video Only"
-                            isExpanded = false
-                        }
-                        .padding(16.dp)
-                )
-            }
-        }
-    }
-}
-
-@Composable
 fun CaptureButton(
     onClick: () -> Unit,
     onLongPress: () -> Unit,

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/ScreenFlashTest.kt
@@ -114,8 +114,7 @@ class ScreenFlashTest {
     private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             cameraUseCase.initialize(
-                DEFAULT_CAMERA_APP_SETTINGS,
-                CameraUseCase.UseCaseMode.STANDARD
+                DEFAULT_CAMERA_APP_SETTINGS
             ) {}
             cameraUseCase.runCamera()
         }


### PR DESCRIPTION
effectively convert `UseCaseMode` to `CaptureMode`, and move into `CameraAppSettings`.
Update references to UseCaseMode account for captureMode now residing in `CameraAppSettings`.

`CameraAppSettings.applyPreviewMode()` in viewModel to initialize the CameraAppSettings captureMode to `VIDEO_ONLY` or `IMAGE_ONLY` if the PreviewMode doesn't support `STANDARD`