### PR TITLE
ZoomScale persistence 

### DIFF
--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionContext.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionContext.kt
@@ -39,5 +39,6 @@ internal data class CameraSessionContext(
     val videoCaptureControlEvents: Channel<VideoCaptureControlEvent>,
     val currentCameraState: MutableStateFlow<CameraState>,
     val surfaceRequests: MutableStateFlow<SurfaceRequest?>,
-    val transientSettings: StateFlow<TransientSessionSettings?>
+    val transientSettings: StateFlow<TransientSessionSettings?>,
+    var zoomScale: MutableStateFlow<Float>
 )

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -117,7 +117,7 @@ constructor(
 
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
 
-    private val _cameraSessionZoomScale = MutableStateFlow(1f)
+    private val cameraSessionZoomScale = MutableStateFlow(1f)
     private var prevCameraSessionLensFacing: LensFacing? = null
 
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
@@ -355,7 +355,7 @@ constructor(
             }.distinctUntilChanged()
             .collectLatest { sessionSettings ->
                 if (transientSettings.value?.primaryLensFacing != prevCameraSessionLensFacing) {
-                    _cameraSessionZoomScale.update { 1f }
+                    cameraSessionZoomScale.update { 1f }
                 }
                 prevCameraSessionLensFacing = transientSettings.value?.primaryLensFacing
                 coroutineScope {
@@ -370,7 +370,7 @@ constructor(
                             currentCameraState = _currentCameraState,
                             surfaceRequests = _surfaceRequest,
                             transientSettings = transientSettings,
-                            zoomScale = _cameraSessionZoomScale
+                            zoomScale = cameraSessionZoomScale
                         )
                     ) {
                         try {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -117,9 +117,6 @@ constructor(
 
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
 
-    private val cameraSessionZoomScale = MutableStateFlow(1f)
-    private var prevCameraSessionLensFacing: LensFacing? = null
-
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
     override suspend fun initialize(
@@ -289,6 +286,8 @@ constructor(
         Log.d(TAG, "runCamera")
 
         val transientSettings = MutableStateFlow<TransientSessionSettings?>(null)
+        val cameraSessionZoomScale = MutableStateFlow(1f)
+        var prevCameraSessionLensFacing: LensFacing? = null
         currentSettings
             .filterNotNull()
             .map { currentCameraSettings ->

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -117,6 +117,9 @@ constructor(
 
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
 
+    private val _cameraSessionZoomScale = MutableStateFlow(1f)
+    private var prevCameraSessionLensFacing: LensFacing? = null
+
     override fun getSurfaceRequest(): StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
     override suspend fun initialize(
@@ -351,6 +354,10 @@ constructor(
                 }
             }.distinctUntilChanged()
             .collectLatest { sessionSettings ->
+                if (transientSettings.value?.primaryLensFacing != prevCameraSessionLensFacing) {
+                    _cameraSessionZoomScale.update { 1f }
+                }
+                prevCameraSessionLensFacing = transientSettings.value?.primaryLensFacing
                 coroutineScope {
                     with(
                         CameraSessionContext(
@@ -362,7 +369,8 @@ constructor(
                             videoCaptureControlEvents = videoCaptureControlEvents,
                             currentCameraState = _currentCameraState,
                             surfaceRequests = _surfaceRequest,
-                            transientSettings = transientSettings
+                            transientSettings = transientSettings,
+                            zoomScale = _cameraSessionZoomScale
                         )
                     ) {
                         try {


### PR DESCRIPTION
Added a private var to keep track of zoomScale of the cameras (mapped to lensFacing). This is needed because camera.cameraInfo.zoomState.zoomScale resets to 1 at some point after runSingleCameraSession. See the buggy video below:

https://github.com/user-attachments/assets/23a5128f-c86f-4b4a-b511-d65595053be8


So instead of using cameraInfo.zoomState to keep track of the current zoomScale, have our own var to do this bypass the bug. Below is the fixed behavior (I also verified lens flipping persistence but didn't include it in the video):


https://github.com/user-attachments/assets/137db24c-bd8d-4c54-9447-451a6b6ee6a0

