### PR TITLE
Preview Cosmetic Animations

### DIFF
--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -123,18 +123,15 @@ private fun JetpackCameraNavHost(
             route = SETTINGS_ROUTE,
             enterTransition = {
                 fadeIn(
-                    animationSpec = tween(
-                        300,
-                        easing = LinearEasing
-                    )
+                    animationSpec = tween(easing = LinearEasing)
                 ) + slideIntoContainer(
-                    animationSpec = tween(300, easing = EaseIn),
+                    animationSpec = tween(easing = EaseIn),
                     towards = AnimatedContentTransitionScope.SlideDirection.Start
                 )
             },
             exitTransition = {
                 slideOutOfContainer(
-                    animationSpec = tween(300, easing = EaseOut),
+                    animationSpec = tween(easing = EaseOut),
                     towards = AnimatedContentTransitionScope.SlideDirection.End
                 )
             }

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -16,6 +16,12 @@
 package com.google.jetpackcamera.ui
 
 import android.Manifest
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.EaseIn
+import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -87,7 +93,7 @@ private fun JetpackCameraNavHost(
             )
         }
 
-        composable(PREVIEW_ROUTE) {
+        composable(route = PREVIEW_ROUTE, enterTransition = { fadeIn() }) {
             val permissionStates = rememberMultiplePermissionsState(
                 permissions = listOf(
                     Manifest.permission.CAMERA,
@@ -113,7 +119,26 @@ private fun JetpackCameraNavHost(
                 isDebugMode = isDebugMode
             )
         }
-        composable(SETTINGS_ROUTE) {
+        composable(
+            route = SETTINGS_ROUTE,
+            enterTransition = {
+                fadeIn(
+                    animationSpec = tween(
+                        300,
+                        easing = LinearEasing
+                    )
+                ) + slideIntoContainer(
+                    animationSpec = tween(300, easing = EaseIn),
+                    towards = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+            },
+            exitTransition = {
+                slideOutOfContainer(
+                    animationSpec = tween(300, easing = EaseOut),
+                    towards = AnimatedContentTransitionScope.SlideDirection.End
+                )
+            }
+        ) {
             SettingsScreen(
                 versionInfo = VersionInfoHolder(
                     versionName = BuildConfig.VERSION_NAME,

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
@@ -16,11 +16,14 @@
 package com.google.jetpackcamera.feature.preview.quicksettings
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -33,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
@@ -44,7 +46,7 @@ import com.google.jetpackcamera.feature.preview.FlashModeUiState
 import com.google.jetpackcamera.feature.preview.PreviewMode
 import com.google.jetpackcamera.feature.preview.PreviewUiState
 import com.google.jetpackcamera.feature.preview.R
-import com.google.jetpackcamera.feature.preview.quicksettings.ui.ExpandedQuickSetRatio
+import com.google.jetpackcamera.feature.preview.quicksettings.ui.FocusedQuickSetRatio
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_FLASH_BUTTON
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
@@ -88,47 +90,48 @@ fun QuickSettingsScreenOverlay(
     modifier: Modifier = Modifier,
     isOpen: Boolean = false
 ) {
-    var shouldShowQuickSetting by remember {
-        mutableStateOf(IsExpandedQuickSetting.NONE)
+    var focusedQuickSetting by remember {
+        mutableStateOf(FocusedQuickSetting.NONE)
     }
 
-    val backgroundColor =
-        animateColorAsState(
-            targetValue = Color.Black.copy(alpha = if (isOpen) 0.7f else 0f),
-            label = "backgroundColorAnimation"
-        )
-
-    val contentAlpha =
-        animateFloatAsState(
-            targetValue = if (isOpen) 1f else 0f,
-            label = "contentAlphaAnimation",
-            animationSpec = tween()
-        )
-
-    if (isOpen) {
+    AnimatedVisibility(
+        visible = isOpen,
+        enter = slideInVertically(initialOffsetY = { -it / 8 }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { -it / 16 }) + fadeOut()
+    ) {
         val onBack = {
-            when (shouldShowQuickSetting) {
-                IsExpandedQuickSetting.NONE -> toggleIsOpen()
-                else -> shouldShowQuickSetting = IsExpandedQuickSetting.NONE
+            when (focusedQuickSetting) {
+                FocusedQuickSetting.NONE -> toggleIsOpen()
+                else -> focusedQuickSetting = FocusedQuickSetting.NONE
             }
         }
+        // close out of focused quick setting
+        if (!isOpen) {
+            focusedQuickSetting = FocusedQuickSetting.NONE
+        }
+
         BackHandler(onBack = onBack)
         Column(
             modifier =
             modifier
                 .fillMaxSize()
-                .background(color = backgroundColor.value)
-                .alpha(alpha = contentAlpha.value)
-                .clickable(onClick = onBack),
+                .background(color = Color.Black.copy(alpha = 0.7f))
+                .clickable(
+                    onClick = onBack,
+                    indication = null,
+                    interactionSource = remember {
+                        MutableInteractionSource()
+                    }
+                ),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             ExpandedQuickSettingsUi(
                 previewUiState = previewUiState,
                 currentCameraSettings = currentCameraSettings,
-                shouldShowQuickSetting = shouldShowQuickSetting,
-                setVisibleQuickSetting = { enum: IsExpandedQuickSetting ->
-                    shouldShowQuickSetting = enum
+                focusedQuickSetting = focusedQuickSetting,
+                setFocusedQuickSetting = { enum: FocusedQuickSetting ->
+                    focusedQuickSetting = enum
                 },
                 onLensFaceClick = onLensFaceClick,
                 onFlashModeClick = onFlashModeClick,
@@ -139,37 +142,36 @@ fun QuickSettingsScreenOverlay(
                 onConcurrentCameraModeClick = onConcurrentCameraModeClick
             )
         }
-    } else {
-        shouldShowQuickSetting = IsExpandedQuickSetting.NONE
     }
 }
 
-// enum representing which individual quick setting is currently expanded
-private enum class IsExpandedQuickSetting {
+// enum representing which individual quick setting is currently focused
+private enum class FocusedQuickSetting {
     NONE,
     ASPECT_RATIO
 }
 
 /**
- * The UI component for quick settings when it is expanded.
+ * The UI component for quick settings when it is focused.
  */
 @Composable
 private fun ExpandedQuickSettingsUi(
+    modifier: Modifier = Modifier,
     previewUiState: PreviewUiState.Ready,
     currentCameraSettings: CameraAppSettings,
     onLensFaceClick: (newLensFace: LensFacing) -> Unit,
     onFlashModeClick: (flashMode: FlashMode) -> Unit,
     onAspectRatioClick: (aspectRation: AspectRatio) -> Unit,
     onStreamConfigClick: (streamConfig: StreamConfig) -> Unit,
-    shouldShowQuickSetting: IsExpandedQuickSetting,
-    setVisibleQuickSetting: (IsExpandedQuickSetting) -> Unit,
+    focusedQuickSetting: FocusedQuickSetting,
+    setFocusedQuickSetting: (FocusedQuickSetting) -> Unit,
     onDynamicRangeClick: (dynamicRange: DynamicRange) -> Unit,
     onImageOutputFormatClick: (imageOutputFormat: ImageOutputFormat) -> Unit,
     onConcurrentCameraModeClick: (concurrentCameraMode: ConcurrentCameraMode) -> Unit
 ) {
     Column(
         modifier =
-        Modifier
+        modifier
             .padding(
                 horizontal = dimensionResource(
                     id = R.dimen.quick_settings_ui_horizontal_padding
@@ -178,111 +180,111 @@ private fun ExpandedQuickSettingsUi(
     ) {
         // if no setting is chosen, display the grid of settings
         // to change the order of display just move these lines of code above or below each other
-        when (shouldShowQuickSetting) {
-            IsExpandedQuickSetting.NONE -> {
-                val displayedQuickSettings: List<@Composable () -> Unit> =
-                    buildList {
-                        add {
-                            QuickSetFlash(
-                                modifier = Modifier.testTag(QUICK_SETTINGS_FLASH_BUTTON),
-                                onClick = { f: FlashMode -> onFlashModeClick(f) },
-                                flashModeUiState = previewUiState.flashModeUiState
-                            )
-                        }
-
-                        add {
-                            QuickFlipCamera(
-                                modifier = Modifier.testTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON),
-                                setLensFacing = { l: LensFacing -> onLensFaceClick(l) },
-                                currentLensFacing = currentCameraSettings.cameraLensFacing
-                            )
-                        }
-
-                        add {
-                            QuickSetRatio(
-                                modifier = Modifier.testTag(QUICK_SETTINGS_RATIO_BUTTON),
-                                onClick = {
-                                    setVisibleQuickSetting(
-                                        IsExpandedQuickSetting.ASPECT_RATIO
-                                    )
-                                },
-                                ratio = currentCameraSettings.aspectRatio,
-                                currentRatio = currentCameraSettings.aspectRatio
-                            )
-                        }
-
-                        add {
-                            QuickSetStreamConfig(
-                                modifier = Modifier.testTag(QUICK_SETTINGS_STREAM_CONFIG_BUTTON),
-                                setStreamConfig = { c: StreamConfig -> onStreamConfigClick(c) },
-                                currentStreamConfig = currentCameraSettings.streamConfig,
-                                enabled = currentCameraSettings.concurrentCameraMode ==
-                                    ConcurrentCameraMode.OFF
-                            )
-                        }
-
-                        val cameraConstraints = previewUiState.systemConstraints.forCurrentLens(
-                            currentCameraSettings
+        AnimatedVisibility(visible = focusedQuickSetting == FocusedQuickSetting.NONE) {
+            val displayedQuickSettings: List<@Composable () -> Unit> =
+                buildList {
+                    add {
+                        QuickSetFlash(
+                            modifier = Modifier.testTag(QUICK_SETTINGS_FLASH_BUTTON),
+                            onClick = { f: FlashMode -> onFlashModeClick(f) },
+                            flashModeUiState = previewUiState.flashModeUiState
                         )
-                        add {
-                            fun CameraConstraints.hdrDynamicRangeSupported(): Boolean =
-                                this.supportedDynamicRanges.size > 1
-
-                            fun CameraConstraints.hdrImageFormatSupported(): Boolean =
-                                supportedImageFormatsMap[currentCameraSettings.streamConfig]
-                                    ?.let { it.size > 1 } == true
-
-                            // TODO(tm): Move this to PreviewUiState
-                            fun shouldEnable(): Boolean = when {
-                                currentCameraSettings.concurrentCameraMode !=
-                                    ConcurrentCameraMode.OFF -> false
-                                else -> (
-                                    cameraConstraints?.hdrDynamicRangeSupported() == true &&
-                                        previewUiState.previewMode is PreviewMode.StandardMode
-                                    ) ||
-                                    cameraConstraints?.hdrImageFormatSupported() == true
-                            }
-
-                            QuickSetHdr(
-                                modifier = Modifier.testTag(QUICK_SETTINGS_HDR_BUTTON),
-                                onClick = { d: DynamicRange, i: ImageOutputFormat ->
-                                    onDynamicRangeClick(d)
-                                    onImageOutputFormatClick(i)
-                                },
-                                selectedDynamicRange = currentCameraSettings.dynamicRange,
-                                selectedImageOutputFormat = currentCameraSettings.imageFormat,
-                                hdrDynamicRangeSupported =
-                                cameraConstraints?.hdrDynamicRangeSupported() ?: false,
-                                previewMode = previewUiState.previewMode,
-                                enabled = shouldEnable()
-                            )
-                        }
-
-                        add {
-                            QuickSetConcurrentCamera(
-                                modifier =
-                                Modifier.testTag(QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON),
-                                setConcurrentCameraMode = { c: ConcurrentCameraMode ->
-                                    onConcurrentCameraModeClick(c)
-                                },
-                                currentConcurrentCameraMode =
-                                currentCameraSettings.concurrentCameraMode,
-                                enabled =
-                                previewUiState.systemConstraints.concurrentCamerasSupported &&
-                                    previewUiState.previewMode
-                                        !is PreviewMode.ExternalImageCaptureMode
-                            )
-                        }
                     }
-                QuickSettingsGrid(quickSettingsButtons = displayedQuickSettings)
-            }
-            // if a setting that can be expanded is selected, show it
-            IsExpandedQuickSetting.ASPECT_RATIO -> {
-                ExpandedQuickSetRatio(
-                    setRatio = onAspectRatioClick,
-                    currentRatio = currentCameraSettings.aspectRatio
-                )
-            }
+
+                    add {
+                        QuickFlipCamera(
+                            modifier = Modifier.testTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON),
+                            setLensFacing = { l: LensFacing -> onLensFaceClick(l) },
+                            currentLensFacing = currentCameraSettings.cameraLensFacing
+                        )
+                    }
+
+                    add {
+                        QuickSetRatio(
+                            modifier = Modifier.testTag(QUICK_SETTINGS_RATIO_BUTTON),
+                            onClick = {
+                                setFocusedQuickSetting(
+                                    FocusedQuickSetting.ASPECT_RATIO
+                                )
+                            },
+                            ratio = currentCameraSettings.aspectRatio,
+                            currentRatio = currentCameraSettings.aspectRatio
+                        )
+                    }
+
+                    add {
+                        QuickSetStreamConfig(
+                            modifier = Modifier.testTag(
+                                QUICK_SETTINGS_STREAM_CONFIG_BUTTON
+                            ),
+                            setStreamConfig = { c: StreamConfig -> onStreamConfigClick(c) },
+                            currentStreamConfig = currentCameraSettings.streamConfig,
+                            enabled = currentCameraSettings.concurrentCameraMode ==
+                                ConcurrentCameraMode.OFF
+                        )
+                    }
+
+                    val cameraConstraints = previewUiState.systemConstraints.forCurrentLens(
+                        currentCameraSettings
+                    )
+                    add {
+                        fun CameraConstraints.hdrDynamicRangeSupported(): Boolean =
+                            this.supportedDynamicRanges.size > 1
+
+                        fun CameraConstraints.hdrImageFormatSupported(): Boolean =
+                            supportedImageFormatsMap[currentCameraSettings.streamConfig]
+                                ?.let { it.size > 1 } == true
+
+                        // TODO(tm): Move this to PreviewUiState
+                        fun shouldEnable(): Boolean = when {
+                            currentCameraSettings.concurrentCameraMode !=
+                                ConcurrentCameraMode.OFF -> false
+                            else -> (
+                                cameraConstraints?.hdrDynamicRangeSupported() == true &&
+                                    previewUiState.previewMode is PreviewMode.StandardMode
+                                ) ||
+                                cameraConstraints?.hdrImageFormatSupported() == true
+                        }
+
+                        QuickSetHdr(
+                            modifier = Modifier.testTag(QUICK_SETTINGS_HDR_BUTTON),
+                            onClick = { d: DynamicRange, i: ImageOutputFormat ->
+                                onDynamicRangeClick(d)
+                                onImageOutputFormatClick(i)
+                            },
+                            selectedDynamicRange = currentCameraSettings.dynamicRange,
+                            selectedImageOutputFormat = currentCameraSettings.imageFormat,
+                            hdrDynamicRangeSupported =
+                            cameraConstraints?.hdrDynamicRangeSupported() ?: false,
+                            previewMode = previewUiState.previewMode,
+                            enabled = shouldEnable()
+                        )
+                    }
+
+                    add {
+                        QuickSetConcurrentCamera(
+                            modifier =
+                            Modifier.testTag(QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON),
+                            setConcurrentCameraMode = { c: ConcurrentCameraMode ->
+                                onConcurrentCameraModeClick(c)
+                            },
+                            currentConcurrentCameraMode =
+                            currentCameraSettings.concurrentCameraMode,
+                            enabled =
+                            previewUiState.systemConstraints.concurrentCamerasSupported &&
+                                previewUiState.previewMode
+                                    !is PreviewMode.ExternalImageCaptureMode
+                        )
+                    }
+                }
+            QuickSettingsGrid(quickSettingsButtons = displayedQuickSettings)
+        }
+        // if a setting that can be focused is selected, show it
+        AnimatedVisibility(visible = focusedQuickSetting == FocusedQuickSetting.ASPECT_RATIO) {
+            FocusedQuickSetRatio(
+                setRatio = onAspectRatioClick,
+                currentRatio = currentCameraSettings.aspectRatio
+            )
         }
     }
 }
@@ -307,8 +309,8 @@ fun ExpandedQuickSettingsUiPreview() {
             currentCameraSettings = CameraAppSettings(),
             onLensFaceClick = { },
             onFlashModeClick = { },
-            shouldShowQuickSetting = IsExpandedQuickSetting.NONE,
-            setVisibleQuickSetting = { },
+            focusedQuickSetting = FocusedQuickSetting.NONE,
+            setFocusedQuickSetting = { },
             onAspectRatioClick = { },
             onStreamConfigClick = { },
             onDynamicRangeClick = { },
@@ -333,8 +335,8 @@ fun ExpandedQuickSettingsUiPreview_WithHdr() {
             currentCameraSettings = CameraAppSettings(dynamicRange = DynamicRange.HLG10),
             onLensFaceClick = { },
             onFlashModeClick = { },
-            shouldShowQuickSetting = IsExpandedQuickSetting.NONE,
-            setVisibleQuickSetting = { },
+            focusedQuickSetting = FocusedQuickSetting.NONE,
+            setFocusedQuickSetting = { },
             onAspectRatioClick = { },
             onStreamConfigClick = { },
             onDynamicRangeClick = { },

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/ui/QuickSettingsComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/ui/QuickSettingsComponents.kt
@@ -15,7 +15,10 @@
  */
 package com.google.jetpackcamera.feature.preview.quicksettings.ui
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,9 +35,11 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalConfiguration
@@ -277,10 +282,14 @@ fun ToggleQuickSettingsButton(
     isOpen: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val rotationAngle by animateFloatAsState(
+        targetValue = if (isOpen) 180f else 0f,
+        animationSpec = tween(durationMillis = 300) // Adjust duration as needed
+    )
     Row(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = modifier.rotate(rotationAngle)
     ) {
         // dropdown icon
         Icon(
@@ -293,10 +302,13 @@ fun ToggleQuickSettingsButton(
             modifier = Modifier
                 .testTag(QUICK_SETTINGS_DROP_DOWN)
                 .size(72.dp)
-                .clickable {
-                    toggleDropDown()
-                }
-                .scale(1f, if (isOpen) -1f else 1f)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    // removes the greyish background animation that appears when clicking on a clickable
+                    indication = null,
+                    onClick = toggleDropDown
+                )
+            // .scale(1f, if (isOpen) -1f else 1f)
         )
     }
 }
@@ -454,7 +466,12 @@ fun TopBarSettingIndicator(
             contentDescription = stringResource(id = enum.getDescriptionResId()),
             modifier = modifier
                 .size(dimensionResource(id = R.dimen.quick_settings_indicator_size))
-                .clickable(onClick = onClick, enabled = enabled)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onClick,
+                    enabled = enabled
+                )
         )
     }
 }
@@ -484,11 +501,11 @@ fun FlashModeIndicator(
 
 @Composable
 fun QuickSettingsIndicators(
+    modifier: Modifier = Modifier,
     flashModeUiState: FlashModeUiState,
-    onFlashModeClick: (flashMode: FlashMode) -> Unit,
-    modifier: Modifier = Modifier
+    onFlashModeClick: (flashMode: FlashMode) -> Unit
 ) {
-    Row(modifier) {
+    Row(modifier = modifier) {
         FlashModeIndicator(
             flashModeUiState,
             onFlashModeClick

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/CameraControlsOverlay.kt
@@ -151,6 +151,8 @@ fun CameraControlsOverlay(
 
             ControlsBottom(
                 modifier = Modifier
+                    // padding to avoid snackbar
+                    .padding(bottom = 60.dp)
                     .fillMaxWidth()
                     .align(Alignment.BottomCenter),
                 previewUiState = previewUiState,
@@ -198,7 +200,11 @@ private fun ControlsTop(
                         .testTag(SETTINGS_BUTTON),
                     onNavigateToSettings = onNavigateToSettings
                 )
-                if (!isQuickSettingsOpen) {
+                AnimatedVisibility(
+                    visible = !isQuickSettingsOpen,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
                     QuickSettingsIndicators(
                         flashModeUiState = flashModeUiState,
                         onFlashModeClick = onChangeFlash
@@ -272,7 +278,10 @@ private fun ControlsBottom(
     ) -> Unit = { _, _, _ -> },
     onStopVideoRecording: () -> Unit = {}
 ) {
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
         CompositionLocalProvider(
             LocalTextStyle provides LocalTextStyle.current.copy(fontSize = 20.sp)
         ) {
@@ -307,20 +316,27 @@ private fun ControlsBottom(
         ) {
             // Row that holds flip camera, capture button, and audio
             Row(Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceEvenly) {
-                if (!isQuickSettingsOpen && videoRecordingState is VideoRecordingState.Inactive) {
-                    FlipCameraButton(
-                        modifier = Modifier.testTag(FLIP_CAMERA_BUTTON),
-                        onClick = onFlipCamera,
-                        // enable only when phone has front and rear camera
-                        enabledCondition = systemConstraints.availableLenses.size > 1
-                    )
-                } else if (!isQuickSettingsOpen &&
-                    videoRecordingState is VideoRecordingState.Active
+                // animation fades in/out this component based on quick settings
+                AnimatedVisibility(
+                    visible = !isQuickSettingsOpen,
+                    enter = fadeIn(),
+                    exit = fadeOut()
                 ) {
-                    PauseResumeToggleButton(
-                        onSetPause = onSetPause,
-                        currentRecordingState = videoRecordingState
-                    )
+                    if (videoRecordingState is VideoRecordingState.Inactive) {
+                        FlipCameraButton(
+                            modifier = Modifier.testTag(FLIP_CAMERA_BUTTON),
+                            onClick = onFlipCamera,
+                            lensFacing = previewUiState.currentCameraSettings.cameraLensFacing,
+                            // enable only when phone has front and rear camera
+                            enabledCondition = systemConstraints.availableLenses.size > 1
+                        )
+                    } else if (videoRecordingState is VideoRecordingState.Active
+                    ) {
+                        PauseResumeToggleButton(
+                            onSetPause = onSetPause,
+                            currentRecordingState = videoRecordingState
+                        )
+                    }
                 }
             }
             CaptureButton(

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/PreviewScreenComponents.kt
@@ -27,7 +27,6 @@ import androidx.camera.viewfinder.compose.MutableCoordinateTransformer
 import androidx.camera.viewfinder.core.ImplementationMode
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.EaseOutExpo
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -84,7 +83,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -93,6 +91,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -125,7 +124,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.launch
 
 private const val TAG = "PreviewScreen"
 private const val BLINK_TIME = 100L
@@ -155,7 +153,7 @@ fun ElapsedTimeText(
 fun PauseResumeToggleButton(
     modifier: Modifier = Modifier,
     onSetPause: (Boolean) -> Unit,
-    size: Float = 75f,
+    size: Float = 80f,
     currentRecordingState: VideoRecordingState.Active
 ) {
     Box(
@@ -199,21 +197,47 @@ fun AmplitudeVisualizer(
     onToggleAudio: () -> Unit
 ) {
     val currentUiState = rememberUpdatedState(audioUiState)
+    var buttonClicked by remember { mutableStateOf(false) }
+    // animation value for the toggle icon itself
+    val animatedToggleScale by animateFloatAsState(
+        targetValue = if (buttonClicked) 1.1f else 1f, // Scale up to 110%
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        finishedListener = {
+            buttonClicked = false // Reset the trigger
+        }
+    )
 
     // Tweak the multiplier to amplitude to adjust the visualizer sensitivity
-    val animatedScaling by animateFloatAsState(
-        targetValue = EaseOutExpo.transform(1 + (1.75f * currentUiState.value.amplitude.toFloat())),
+    val animatedAudioScale by animateFloatAsState(
+        targetValue = 1 + (1.75f * currentUiState.value.amplitude.toFloat()),
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
         label = "AudioAnimation"
     )
-    Box(modifier = modifier.clickable { onToggleAudio() }) {
-        // animated circle
+    Box(
+        modifier = modifier.clickable(
+            onClick = {
+                buttonClicked = true
+                onToggleAudio()
+            },
+            interactionSource = null,
+            // removes the greyish background animation that appears when clicking
+            indication = null
+        )
+    ) {
+        // animated audio circle
         Canvas(
             modifier = Modifier
                 .align(Alignment.Center),
             onDraw = {
                 drawCircle(
                     // tweak the multiplier to size to adjust the maximum size of the visualizer
-                    radius = (size * animatedScaling).coerceIn(size, size * 1.65f),
+                    radius = (size * animatedAudioScale).coerceIn(size, size * 1.65f),
                     alpha = .5f,
                     color = Color.White
                 )
@@ -226,7 +250,7 @@ fun AmplitudeVisualizer(
                 .align(Alignment.Center),
             onDraw = {
                 drawCircle(
-                    radius = (size),
+                    radius = (size * animatedToggleScale),
                     color = Color.White
                 )
             }
@@ -236,6 +260,7 @@ fun AmplitudeVisualizer(
             modifier = Modifier
                 .align(Alignment.Center)
                 .size((0.5 * size).dp)
+                .scale(animatedToggleScale)
                 .apply {
                     if (currentUiState.value is AudioUiState.Enabled.On) {
                         testTag(AMPLITUDE_HOT_TAG)
@@ -622,28 +647,37 @@ fun FlipCameraButton(
 ) {
     var rotation by remember { mutableFloatStateOf(0f) }
     val animatedRotation = remember { Animatable(0f) }
-    val coroutineScope = rememberCoroutineScope()
+    var initialLaunch by remember { mutableStateOf(false) }
+
+    // spin animate whenever lensfacing changes
+    LaunchedEffect(lensFacing) {
+        if (initialLaunch) {
+            // full 360
+            rotation -= 180f
+            animatedRotation.animateTo(
+                targetValue = rotation,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessVeryLow
+                )
+            )
+        }
+        // dont rotate on the initial launch
+        else {
+            initialLaunch = true
+        }
+    }
     IconButton(
         modifier = modifier.size(40.dp),
-        onClick = {
-            rotation -= 360f
-            coroutineScope.launch {
-                animatedRotation.animateTo(
-                    targetValue = rotation,
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioLowBouncy,
-                        stiffness = Spring.StiffnessVeryLow
-                    )
-                )
-            }
-            onClick()
-        },
+        onClick = onClick,
         enabled = enabledCondition
     ) {
         Icon(
             imageVector = Icons.Filled.FlipCameraAndroid,
             contentDescription = stringResource(id = R.string.flip_camera_content_description),
-            modifier = Modifier.size(72.dp).rotate(animatedRotation.value)
+            modifier = Modifier
+                .size(72.dp)
+                .rotate(animatedRotation.value)
         )
     }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -19,13 +19,19 @@ import android.Manifest
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -92,6 +98,7 @@ fun SettingsScreen(
     viewModel.setGrantedPermissions(permissionStates)
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsScreen(
     uiState: SettingsUiState,
@@ -108,30 +115,42 @@ private fun SettingsScreen(
     setDarkMode: (DarkMode) -> Unit = {},
     setVideoQuality: (VideoQuality) -> Unit = {}
 ) {
-    Column(
-        modifier = Modifier
-            .verticalScroll(rememberScrollState())
-            .background(color = MaterialTheme.colorScheme.background)
-    ) {
-        SettingsPageHeader(
-            title = stringResource(id = R.string.settings_title),
-            navBack = onNavigateBack
-        )
-        if (uiState is SettingsUiState.Enabled) {
-            SettingsList(
-                uiState = uiState,
-                versionInfo = versionInfo,
-                setDefaultLensFacing = setDefaultLensFacing,
-                setFlashMode = setFlashMode,
-                setTargetFrameRate = setTargetFrameRate,
-                setAspectRatio = setAspectRatio,
-                setCaptureMode = setCaptureMode,
-                setStabilizationMode = setStabilizationMode,
-                setAudio = setAudio,
-                setMaxVideoDuration = setMaxVideoDuration,
-                setDarkMode = setDarkMode,
-                setVideoQuality = setVideoQuality
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(
+        rememberTopAppBarState()
+    )
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            SettingsPageHeader(
+                title = stringResource(id = R.string.settings_title),
+                navBack = onNavigateBack,
+                scrollBehavior = scrollBehavior
             )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .background(color = MaterialTheme.colorScheme.background)
+        ) {
+            if (uiState is SettingsUiState.Enabled) {
+                SettingsList(
+                    uiState = uiState,
+                    versionInfo = versionInfo,
+                    setDefaultLensFacing = setDefaultLensFacing,
+                    setFlashMode = setFlashMode,
+                    setTargetFrameRate = setTargetFrameRate,
+                    setAspectRatio = setAspectRatio,
+                    setCaptureMode = setCaptureMode,
+                    setStabilizationMode = setStabilizationMode,
+                    setAudio = setAudio,
+                    setMaxVideoDuration = setMaxVideoDuration,
+                    setDarkMode = setDarkMode,
+                    setVideoQuality = setVideoQuality
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
@@ -94,7 +95,12 @@ import com.google.jetpackcamera.settings.ui.theme.SettingsPreviewTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsPageHeader(title: String, navBack: () -> Unit, modifier: Modifier = Modifier) {
+fun SettingsPageHeader(
+    title: String,
+    navBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior? = null
+) {
     TopAppBar(
         modifier = modifier,
         title = {
@@ -110,7 +116,8 @@ fun SettingsPageHeader(title: String, navBack: () -> Unit, modifier: Modifier = 
                     stringResource(id = R.string.nav_back_accessibility)
                 )
             }
-        }
+        },
+        scrollBehavior = scrollBehavior
     )
 }
 


### PR DESCRIPTION
Some cosmetic UI changes. summary:

_Minor changes to existing:_
* added padding to bottom capture controls to avoid snackbar overlap
* hide the square, grayish touch indicator present on some clickable components

 _new animations:_
 * slide transition when opening settings screen
* bouncy buttons 
* flip camera icon spins whenever lensfacing changes
* smoother animations for quick settings drop down
* animation for for focusing (expanding) a quick setting


_Mild non-cosmetic refactors:_
* renamed ExpandedQuickSetting to FocusedQuickSetting


**_Android Developers page on_** [**_Animation Modifiers and Composables_**](https://developer.android.com/develop/ui/compose/animation/composables-modifiers)

https://github.com/user-attachments/assets/f4c8818e-951a-4b7d-8d94-215d18227645

<img width="300" alt="image" src="https://github.com/user-attachments/assets/48165ce0-bafe-4d2d-9955-2b3ee06c8fcb" />



