### PR TITLE
fixes crashing bug between image HDR and concurrent quicksettings

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
@@ -64,6 +64,8 @@ import com.google.jetpackcamera.settings.model.AspectRatio
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import com.google.jetpackcamera.settings.model.ConcurrentCameraMode
+import com.google.jetpackcamera.settings.model.DEFAULT_HDR_DYNAMIC_RANGE
+import com.google.jetpackcamera.settings.model.DEFAULT_HDR_IMAGE_OUTPUT
 import com.google.jetpackcamera.settings.model.DynamicRange
 import com.google.jetpackcamera.settings.model.FlashMode
 import com.google.jetpackcamera.settings.model.ImageOutputFormat
@@ -273,7 +275,13 @@ private fun ExpandedQuickSettingsUi(
                             enabled =
                             previewUiState.systemConstraints.concurrentCamerasSupported &&
                                 previewUiState.previewMode
-                                    !is PreviewMode.ExternalImageCaptureMode
+                                    !is PreviewMode.ExternalImageCaptureMode &&
+                                (
+                                    currentCameraSettings.dynamicRange !=
+                                        DEFAULT_HDR_DYNAMIC_RANGE &&
+                                        currentCameraSettings.imageFormat !=
+                                        DEFAULT_HDR_IMAGE_OUTPUT
+                                    )
                         )
                     }
                 }


### PR DESCRIPTION
concurrent camera setting is still enabled while HDR quick setting is active. 

🐛  the app will crash when attempting to enable concurrent camera while HDR image capture is enabled.

✅ this change simply disables the concurrent camera quick setting while HDR image or HDR video is enabled