### PR TITLE
add constraints to flash setting

### DIFF
--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -15,8 +15,6 @@
  */
 package com.google.jetpackcamera.settings.model
 
-import kotlin.reflect.KProperty1
-
 const val TARGET_FPS_AUTO = 0
 const val UNLIMITED_VIDEO_DURATION = 0L
 val DEFAULT_HDR_DYNAMIC_RANGE = DynamicRange.HLG10
@@ -47,14 +45,4 @@ data class CameraAppSettings(
 fun SystemConstraints.forCurrentLens(cameraAppSettings: CameraAppSettings): CameraConstraints? =
     perLensConstraints[cameraAppSettings.cameraLensFacing]
 
-inline fun <reified T> SystemConstraints.forDevice(
-    property: KProperty1<CameraConstraints, Any>
-): Set<T> = perLensConstraints.values.asSequence().flatMap {
-    val someting = when (val value = property.get(it)) {
-        is Iterable<*> -> value.filterIsInstance<T>().asSequence() // Convert to Sequence
-        is Sequence<*> -> value.filterIsInstance<T>()
-        else -> emptySequence()
-    }
-    someting
-}.toSet()
 val DEFAULT_CAMERA_APP_SETTINGS = CameraAppSettings()

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -15,6 +15,8 @@
  */
 package com.google.jetpackcamera.settings.model
 
+import kotlin.reflect.KProperty1
+
 const val TARGET_FPS_AUTO = 0
 const val UNLIMITED_VIDEO_DURATION = 0L
 val DEFAULT_HDR_DYNAMIC_RANGE = DynamicRange.HLG10
@@ -45,4 +47,14 @@ data class CameraAppSettings(
 fun SystemConstraints.forCurrentLens(cameraAppSettings: CameraAppSettings): CameraConstraints? =
     perLensConstraints[cameraAppSettings.cameraLensFacing]
 
+inline fun <reified T> SystemConstraints.forDevice(
+    property: KProperty1<CameraConstraints, Any>
+): Set<T> = perLensConstraints.values.asSequence().flatMap {
+    val someting = when (val value = property.get(it)) {
+        is Iterable<*> -> value.filterIsInstance<T>().asSequence() // Convert to Sequence
+        is Sequence<*> -> value.filterIsInstance<T>()
+        else -> emptySequence()
+    }
+    someting
+}.toSet()
 val DEFAULT_CAMERA_APP_SETTINGS = CameraAppSettings()

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
@@ -15,24 +15,15 @@
  */
 package com.google.jetpackcamera.settings.model
 
-import kotlin.reflect.KProperty1
-
 data class SystemConstraints(
     val availableLenses: List<LensFacing> = emptyList(),
     val concurrentCamerasSupported: Boolean = false,
     val perLensConstraints: Map<LensFacing, CameraConstraints> = emptyMap()
-) {
+)
 
-    inline fun <reified R> forDevice(property: KProperty1<CameraConstraints, Any>): R =
-        perLensConstraints.values.asSequence()
-            .flatMap {
-                when (val value = property.get(it)) {
-                    is Iterable<*> -> value.asSequence()
-                    is Sequence<*> -> value
-                    else -> sequenceOf(value)
-                }
-            }.toSet() as R
-}
+inline fun <reified T> SystemConstraints.forDevice(
+    crossinline constraintSelector: (CameraConstraints) -> Iterable<T>
+) = perLensConstraints.values.asSequence().flatMap { constraintSelector(it) }.toSet()
 
 data class CameraConstraints(
     val supportedStabilizationModes: Set<StabilizationMode>,

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
@@ -15,11 +15,24 @@
  */
 package com.google.jetpackcamera.settings.model
 
+import kotlin.reflect.KProperty1
+
 data class SystemConstraints(
     val availableLenses: List<LensFacing> = emptyList(),
     val concurrentCamerasSupported: Boolean = false,
     val perLensConstraints: Map<LensFacing, CameraConstraints> = emptyMap()
-)
+) {
+
+    inline fun <reified R> forDevice(property: KProperty1<CameraConstraints, Any>): R =
+        perLensConstraints.values.asSequence()
+            .flatMap {
+                when (val value = property.get(it)) {
+                    is Iterable<*> -> value.asSequence()
+                    is Sequence<*> -> value
+                    else -> sequenceOf(value)
+                }
+            }.toSet() as R
+}
 
 data class CameraConstraints(
     val supportedStabilizationModes: Set<StabilizationMode>,

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
@@ -104,8 +104,7 @@ sealed interface DisabledRationale {
     data class VideoQualityUnsupportedRationale(
         override val affectedSettingNameResId: Int,
         val currentDynamicRange: Int = R.string.video_quality_rationale_suffix_default
-    ) :
-        DisabledRationale {
+    ) : DisabledRationale {
         override val reasonTextResId = R.string.video_quality_unsupported
         override val testTag = VIDEO_QUALITY_UNSUPPORTED_TAG
     }
@@ -189,6 +188,7 @@ sealed interface AudioUiState {
 
     sealed interface Enabled : AudioUiState {
         val additionalContext: String
+
         data class On(override val additionalContext: String = "") : Enabled
         data class Mute(override val additionalContext: String = "") : Enabled
     }
@@ -196,17 +196,19 @@ sealed interface AudioUiState {
     data class Disabled(val disabledRationale: DisabledRationale) : AudioUiState
 }
 
+sealed interface FlashUiState {
+    data class Enabled(
+        val currentFlashMode: FlashMode,
+        val lowLightSelectableState: SingleSelectableState,
+        val additionalContext: String = ""
+    ) : FlashUiState
+}
+
 // ////////////////////////////////////////////////////////////
 //
 // Settings that DON'T currently depend on constraints
 //
 // ////////////////////////////////////////////////////////////
-
-// this could be constrained w/ a check to see if a torch is available?
-sealed interface FlashUiState {
-    data class Enabled(val currentFlashMode: FlashMode, val additionalContext: String = "") :
-        FlashUiState
-}
 
 sealed interface AspectRatioUiState {
     data class Enabled(val currentAspectRatio: AspectRatio, val additionalContext: String = "") :
@@ -255,7 +257,12 @@ val TYPICAL_SETTINGS_UISTATE = SettingsUiState.Enabled(
         AudioUiState.Enabled.Mute()
     },
     flashUiState =
-    FlashUiState.Enabled(currentFlashMode = DEFAULT_CAMERA_APP_SETTINGS.flashMode),
+    FlashUiState.Enabled(
+        currentFlashMode = DEFAULT_CAMERA_APP_SETTINGS.flashMode,
+        lowLightSelectableState = SingleSelectableState.Disabled(
+            DeviceUnsupportedRationale(R.string.llb_rationale_prefix)
+        )
+    ),
     fpsUiState = FpsUiState.Enabled(
         currentSelection = DEFAULT_CAMERA_APP_SETTINGS.targetFrameRate,
         fpsAutoState = SingleSelectableState.Selectable,

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
@@ -199,9 +199,13 @@ sealed interface AudioUiState {
 sealed interface FlashUiState {
     data class Enabled(
         val currentFlashMode: FlashMode,
+        val onSelectableState: SingleSelectableState,
+        val autoSelectableState: SingleSelectableState,
         val lowLightSelectableState: SingleSelectableState,
         val additionalContext: String = ""
     ) : FlashUiState
+
+    data class Disabled(val disabledRationale: DisabledRationale) : FlashUiState
 }
 
 // ////////////////////////////////////////////////////////////
@@ -259,8 +263,10 @@ val TYPICAL_SETTINGS_UISTATE = SettingsUiState.Enabled(
     flashUiState =
     FlashUiState.Enabled(
         currentFlashMode = DEFAULT_CAMERA_APP_SETTINGS.flashMode,
+        autoSelectableState = SingleSelectableState.Selectable,
+        onSelectableState = SingleSelectableState.Selectable,
         lowLightSelectableState = SingleSelectableState.Disabled(
-            DeviceUnsupportedRationale(R.string.llb_rationale_prefix)
+            DeviceUnsupportedRationale(R.string.flash_llb_rationale_prefix)
         )
     ),
     fpsUiState = FpsUiState.Enabled(

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -112,10 +112,10 @@ class SettingsViewModel @Inject constructor(
         check(currentSupportedFlashModes.isNotEmpty()) {
             "No flash modes supported. Should at least support OFF."
         }
-        val deviceSupportedFlashModes: Set<FlashMode> = constraints.forDevice {
-            it.supportedFlashModes
-        }
-        // disable entire setting when:
+        val deviceSupportedFlashModes: Set<FlashMode> = constraints.forDevice(
+            CameraConstraints::supportedFlashModes
+        )
+        // disable entire setting when:git status
         //  device only supports off... device unsupported rationale
         //  lens only supports off... lens unsupported rationale
         if (deviceSupportedFlashModes == setOf(FlashMode.OFF)) {

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -41,6 +41,7 @@ import com.google.jetpackcamera.settings.model.StreamConfig
 import com.google.jetpackcamera.settings.model.SystemConstraints
 import com.google.jetpackcamera.settings.model.VideoQuality
 import com.google.jetpackcamera.settings.model.forCurrentLens
+import com.google.jetpackcamera.settings.model.forDevice
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -111,9 +112,9 @@ class SettingsViewModel @Inject constructor(
         check(currentSupportedFlashModes.isNotEmpty()) {
             "No flash modes supported. Should at least support OFF."
         }
-        val deviceSupportedFlashModes: Set<FlashMode> = constraints.forDevice(
-            CameraConstraints::supportedFlashModes
-        )
+        val deviceSupportedFlashModes: Set<FlashMode> = constraints.forDevice {
+            it.supportedFlashModes
+        }
         // disable entire setting when:
         //  device only supports off... device unsupported rationale
         //  lens only supports off... lens unsupported rationale

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -118,11 +118,11 @@ class SettingsViewModel @Inject constructor(
         // disable entire setting when:
         //  device only supports off... device unsupported rationale
         //  lens only supports off... lens unsupported rationale
-        if (deviceSupportedFlashModes.size == 1) {
+        if (deviceSupportedFlashModes == setOf(FlashMode.OFF)) {
             return FlashUiState.Disabled(
                 DeviceUnsupportedRationale(R.string.flash_rationale_prefix)
             )
-        } else if (currentSupportedFlashModes.size == 1) {
+        } else if (deviceSupportedFlashModes == setOf(FlashMode.OFF)) {
             return FlashUiState.Disabled(
                 getLensUnsupportedRationale(
                     cameraAppSettings.cameraLensFacing,

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -41,7 +41,6 @@ import com.google.jetpackcamera.settings.model.StreamConfig
 import com.google.jetpackcamera.settings.model.SystemConstraints
 import com.google.jetpackcamera.settings.model.VideoQuality
 import com.google.jetpackcamera.settings.model.forCurrentLens
-import com.google.jetpackcamera.settings.model.forDevice
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -112,7 +111,7 @@ class SettingsViewModel @Inject constructor(
         check(currentSupportedFlashModes.isNotEmpty()) {
             "No flash modes supported. Should at least support OFF."
         }
-        val deviceSupportedFlashModes = constraints.forDevice<FlashMode>(
+        val deviceSupportedFlashModes: Set<FlashMode> = constraints.forDevice(
             CameraConstraints::supportedFlashModes
         )
         // disable entire setting when:

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -244,14 +244,16 @@ fun FlashModeSetting(
                         modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_AUTO_TAG),
                         text = stringResource(id = R.string.flash_mode_selector_auto),
                         selected = flashUiState.currentFlashMode == FlashMode.AUTO,
-                        enabled = flashUiState.autoSelectableState is SingleSelectableState.Selectable,
+                        enabled = flashUiState.autoSelectableState is
+                            SingleSelectableState.Selectable,
                         onClick = { setFlashMode(FlashMode.AUTO) }
                     )
                     SingleChoiceSelector(
                         modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_ON_TAG),
                         text = stringResource(id = R.string.flash_mode_selector_on),
                         selected = flashUiState.currentFlashMode == FlashMode.ON,
-                        enabled = flashUiState.onSelectableState is SingleSelectableState.Selectable,
+                        enabled = flashUiState.onSelectableState is
+                            SingleSelectableState.Selectable,
                         onClick = { setFlashMode(FlashMode.ON) }
                     )
                     SingleChoiceSelector(

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -248,6 +248,7 @@ fun FlashModeSetting(
                             SingleSelectableState.Selectable,
                         onClick = { setFlashMode(FlashMode.AUTO) }
                     )
+
                     SingleChoiceSelector(
                         modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_ON_TAG),
                         text = stringResource(id = R.string.flash_mode_selector_on),
@@ -256,14 +257,7 @@ fun FlashModeSetting(
                             SingleSelectableState.Selectable,
                         onClick = { setFlashMode(FlashMode.ON) }
                     )
-                    SingleChoiceSelector(
-                        modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_OFF_TAG),
-                        text = stringResource(id = R.string.flash_mode_selector_off),
-                        selected = flashUiState.currentFlashMode == FlashMode.OFF,
-                        enabled = true,
-                        onClick = { setFlashMode(FlashMode.OFF) }
-                    )
-                    // TODO(yasith): Add logic to only show LLB toggle if current lens supports LLB
+
                     SingleChoiceSelector(
                         modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_LLB_TAG),
                         text = stringResource(id = R.string.flash_mode_selector_llb),
@@ -271,6 +265,14 @@ fun FlashModeSetting(
                         enabled = flashUiState.lowLightSelectableState is
                             SingleSelectableState.Selectable,
                         onClick = { setFlashMode(FlashMode.LOW_LIGHT_BOOST) }
+                    )
+
+                    SingleChoiceSelector(
+                        modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_OFF_TAG),
+                        text = stringResource(id = R.string.flash_mode_selector_off),
+                        selected = flashUiState.currentFlashMode == FlashMode.OFF,
+                        enabled = true,
+                        onClick = { setFlashMode(FlashMode.OFF) }
                     )
                 }
             }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -263,7 +263,8 @@ fun FlashModeSetting(
                     modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_LLB_TAG),
                     text = stringResource(id = R.string.flash_mode_selector_llb),
                     selected = flashUiState.currentFlashMode == FlashMode.LOW_LIGHT_BOOST,
-                    enabled = true,
+                    enabled = flashUiState.lowLightSelectableState is
+                        SingleSelectableState.Selectable,
                     onClick = { setFlashMode(FlashMode.LOW_LIGHT_BOOST) }
                 )
             }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -221,10 +221,10 @@ fun FlashModeSetting(
         modifier = modifier.testTag(BTN_OPEN_DIALOG_SETTING_FLASH_TAG),
         title = stringResource(id = R.string.flash_mode_title),
         leadingIcon = null,
-        enabled = true,
+        enabled = flashUiState is FlashUiState.Enabled,
         description =
-        if (flashUiState is FlashUiState.Enabled) {
-            when (flashUiState.currentFlashMode) {
+        when (flashUiState) {
+            is FlashUiState.Enabled -> when (flashUiState.currentFlashMode) {
                 FlashMode.AUTO -> stringResource(id = R.string.flash_mode_description_auto)
                 FlashMode.ON -> stringResource(id = R.string.flash_mode_description_on)
                 FlashMode.OFF -> stringResource(id = R.string.flash_mode_description_off)
@@ -232,41 +232,45 @@ fun FlashModeSetting(
                     id = R.string.flash_mode_description_llb
                 )
             }
-        } else {
-            TODO("flash mode currently has no disabled criteria")
+            is FlashUiState.Disabled -> stringResource(
+                flashUiState.disabledRationale.reasonTextResId,
+                stringResource(flashUiState.disabledRationale.affectedSettingNameResId)
+            )
         },
         popupContents = {
-            Column(Modifier.selectableGroup()) {
-                SingleChoiceSelector(
-                    modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_AUTO_TAG),
-                    text = stringResource(id = R.string.flash_mode_selector_auto),
-                    selected = flashUiState.currentFlashMode == FlashMode.AUTO,
-                    enabled = true,
-                    onClick = { setFlashMode(FlashMode.AUTO) }
-                )
-                SingleChoiceSelector(
-                    modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_ON_TAG),
-                    text = stringResource(id = R.string.flash_mode_selector_on),
-                    selected = flashUiState.currentFlashMode == FlashMode.ON,
-                    enabled = true,
-                    onClick = { setFlashMode(FlashMode.ON) }
-                )
-                SingleChoiceSelector(
-                    modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_OFF_TAG),
-                    text = stringResource(id = R.string.flash_mode_selector_off),
-                    selected = flashUiState.currentFlashMode == FlashMode.OFF,
-                    enabled = true,
-                    onClick = { setFlashMode(FlashMode.OFF) }
-                )
-                // TODO(yasith): Add logic to only show LLB toggle if current lens supports LLB
-                SingleChoiceSelector(
-                    modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_LLB_TAG),
-                    text = stringResource(id = R.string.flash_mode_selector_llb),
-                    selected = flashUiState.currentFlashMode == FlashMode.LOW_LIGHT_BOOST,
-                    enabled = flashUiState.lowLightSelectableState is
-                        SingleSelectableState.Selectable,
-                    onClick = { setFlashMode(FlashMode.LOW_LIGHT_BOOST) }
-                )
+            if (flashUiState is FlashUiState.Enabled) {
+                Column(Modifier.selectableGroup()) {
+                    SingleChoiceSelector(
+                        modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_AUTO_TAG),
+                        text = stringResource(id = R.string.flash_mode_selector_auto),
+                        selected = flashUiState.currentFlashMode == FlashMode.AUTO,
+                        enabled = flashUiState.autoSelectableState is SingleSelectableState.Selectable,
+                        onClick = { setFlashMode(FlashMode.AUTO) }
+                    )
+                    SingleChoiceSelector(
+                        modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_ON_TAG),
+                        text = stringResource(id = R.string.flash_mode_selector_on),
+                        selected = flashUiState.currentFlashMode == FlashMode.ON,
+                        enabled = flashUiState.onSelectableState is SingleSelectableState.Selectable,
+                        onClick = { setFlashMode(FlashMode.ON) }
+                    )
+                    SingleChoiceSelector(
+                        modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_OFF_TAG),
+                        text = stringResource(id = R.string.flash_mode_selector_off),
+                        selected = flashUiState.currentFlashMode == FlashMode.OFF,
+                        enabled = true,
+                        onClick = { setFlashMode(FlashMode.OFF) }
+                    )
+                    // TODO(yasith): Add logic to only show LLB toggle if current lens supports LLB
+                    SingleChoiceSelector(
+                        modifier = Modifier.testTag(BTN_DIALOG_FLASH_OPTION_LLB_TAG),
+                        text = stringResource(id = R.string.flash_mode_selector_llb),
+                        selected = flashUiState.currentFlashMode == FlashMode.LOW_LIGHT_BOOST,
+                        enabled = flashUiState.lowLightSelectableState is
+                            SingleSelectableState.Selectable,
+                        onClick = { setFlashMode(FlashMode.LOW_LIGHT_BOOST) }
+                    )
+                }
             }
         }
     )

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -155,7 +155,10 @@
     <string name="stabilization_rationale_prefix">Stabilization</string>
     <string name="lens_rationale_prefix">Lens flip</string>
     <string name="fps_rationale_prefix">Fps</string>
-    <string name="llb_rationale_prefix">Low Light Boost</string>
+    <string name="flash_rationale_prefix">Flash</string>
+    <string name="flash_on_rationale_prefix">Flash On</string>
+    <string name="flash_auto_rationale_prefix">Flash Auto</string>
+    <string name="flash_llb_rationale_prefix">Low Light Boost</string>
 
     <string name="video_quality_rationale_prefix">Video quality</string>
     <string name="video_quality_rationale_suffix_default">the current dynamic range</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -155,6 +155,8 @@
     <string name="stabilization_rationale_prefix">Stabilization</string>
     <string name="lens_rationale_prefix">Lens flip</string>
     <string name="fps_rationale_prefix">Fps</string>
+    <string name="llb_rationale_prefix">Low Light Boost</string>
+
     <string name="video_quality_rationale_prefix">Video quality</string>
     <string name="video_quality_rationale_suffix_default">the current dynamic range</string>
     <string name="video_quality_rationale_suffix_sdr">SDR</string>


### PR DESCRIPTION
Default flash setting will now be disabled with an appropriate message when:
* device only supports `OFF`
* default lens only supports `OFF`

Default flash options will be disabled if the current lens doesnt support the particular mode.

important stuff to check is in `SettingsViewModel`