### PR TITLE
disable single stream quick setting while Ultra HDR Image capture is active

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
@@ -154,6 +154,8 @@ private enum class FocusedQuickSetting {
     ASPECT_RATIO
 }
 
+// todo: Add UI states for Quick Settings buttons
+
 /**
  * The UI component for quick settings when it is focused.
  */
@@ -222,8 +224,12 @@ private fun ExpandedQuickSettingsUi(
                             ),
                             setStreamConfig = { c: StreamConfig -> onStreamConfigClick(c) },
                             currentStreamConfig = currentCameraSettings.streamConfig,
-                            enabled = currentCameraSettings.concurrentCameraMode ==
-                                ConcurrentCameraMode.OFF
+                            enabled = (
+                                currentCameraSettings.concurrentCameraMode ==
+                                    ConcurrentCameraMode.OFF &&
+                                    currentCameraSettings.imageFormat !=
+                                    ImageOutputFormat.JPEG_ULTRA_HDR
+                                )
                         )
                     }
 

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
@@ -224,10 +224,10 @@ private fun ExpandedQuickSettingsUi(
                             ),
                             setStreamConfig = { c: StreamConfig -> onStreamConfigClick(c) },
                             currentStreamConfig = currentCameraSettings.streamConfig,
-                            enabled = (
+                            enabled = !(
                                 currentCameraSettings.concurrentCameraMode ==
-                                    ConcurrentCameraMode.OFF &&
-                                    currentCameraSettings.imageFormat !=
+                                    ConcurrentCameraMode.DUAL ||
+                                    currentCameraSettings.imageFormat ==
                                     ImageOutputFormat.JPEG_ULTRA_HDR
                                 )
                         )


### PR DESCRIPTION
user will no longer be able to switch to single-stream capture while HDR image capture is on