### PR TITLE
fix pause while recording bug

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -420,18 +420,11 @@ class PreviewViewModel @AssistedInject constructor(
                 .Enabled.Idle(captureMode = cameraAppSettings.captureMode)
 
         // display different capture button UI depending on if recording is pressed or locked
-        is VideoRecordingState.Active.Recording -> if (lockedState) {
+        is VideoRecordingState.Active.Recording,  is VideoRecordingState.Active.Paused -> if (lockedState) {
             CaptureButtonUiState.Enabled.Recording.LockedRecording
         } else {
             CaptureButtonUiState.Enabled.Recording.PressedRecording
         }
-        is VideoRecordingState.Active.Paused ->
-            if (lockedState) {
-                CaptureButtonUiState
-                    .Enabled.Recording.LockedRecording
-            } else {
-                CaptureButtonUiState.Enabled.Recording.PressedRecording
-            }
 
         VideoRecordingState.Starting ->
             CaptureButtonUiState

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -425,12 +425,14 @@ class PreviewViewModel @AssistedInject constructor(
         } else {
             CaptureButtonUiState.Enabled.Recording.PressedRecording
         }
-        // todo: how to handle pause...
         is VideoRecordingState.Active.Paused ->
-            CaptureButtonUiState
-                .Enabled.Recording.LockedRecording
+            if (lockedState) {
+                CaptureButtonUiState
+                    .Enabled.Recording.LockedRecording
+            } else {
+                CaptureButtonUiState.Enabled.Recording.PressedRecording
+            }
 
-        // todo: how to handle starting...
         VideoRecordingState.Starting ->
             CaptureButtonUiState
                 .Enabled.Idle(captureMode = cameraAppSettings.captureMode)

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -420,11 +420,12 @@ class PreviewViewModel @AssistedInject constructor(
                 .Enabled.Idle(captureMode = cameraAppSettings.captureMode)
 
         // display different capture button UI depending on if recording is pressed or locked
-        is VideoRecordingState.Active.Recording,  is VideoRecordingState.Active.Paused -> if (lockedState) {
-            CaptureButtonUiState.Enabled.Recording.LockedRecording
-        } else {
-            CaptureButtonUiState.Enabled.Recording.PressedRecording
-        }
+        is VideoRecordingState.Active.Recording, is VideoRecordingState.Active.Paused ->
+            if (lockedState) {
+                CaptureButtonUiState.Enabled.Recording.LockedRecording
+            } else {
+                CaptureButtonUiState.Enabled.Recording.PressedRecording
+            }
 
         VideoRecordingState.Starting ->
             CaptureButtonUiState


### PR DESCRIPTION
pausing a pressed recording would cause the ui to treat it as a locked recording