### PR TITLE
Fix ConcurrentCameraTest failure

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/ConcurrentCameraTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ConcurrentCameraTest.kt
@@ -34,6 +34,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.MainActivity
 import com.google.jetpackcamera.feature.preview.R
+import com.google.jetpackcamera.feature.preview.quicksettings.ui.BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_DROP_DOWN
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
@@ -42,9 +43,7 @@ import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_RATIO_BUTTON
 import com.google.jetpackcamera.feature.preview.quicksettings.ui.QUICK_SETTINGS_STREAM_CONFIG_BUTTON
 import com.google.jetpackcamera.feature.preview.ui.CAPTURE_BUTTON
-import com.google.jetpackcamera.feature.preview.ui.CAPTURE_MODE_TOGGLE_BUTTON
 import com.google.jetpackcamera.feature.preview.ui.FLIP_CAMERA_BUTTON
-import com.google.jetpackcamera.feature.preview.ui.IMAGE_CAPTURE_UNSUPPORTED_CONCURRENT_CAMERA_TAG
 import com.google.jetpackcamera.feature.preview.ui.VIDEO_CAPTURE_SUCCESS_TAG
 import com.google.jetpackcamera.settings.model.ConcurrentCameraMode
 import com.google.jetpackcamera.utils.APP_START_TIMEOUT_MILLIS
@@ -56,6 +55,7 @@ import com.google.jetpackcamera.utils.longClickForVideoRecording
 import com.google.jetpackcamera.utils.runMediaStoreAutoDeleteScenarioTest
 import com.google.jetpackcamera.utils.runScenarioTest
 import com.google.jetpackcamera.utils.stateDescriptionMatches
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -233,39 +233,36 @@ class ConcurrentCameraTest {
     @Test
     fun concurrentCameraMode_whenEnabled_disablesOtherSettings() =
         runConcurrentCameraScenarioTest<MainActivity> {
-            with(composeTestRule) {
-                onNodeWithTag(QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON)
-                    .assertExists()
-                    .assertConcurrentCameraMode(ConcurrentCameraMode.OFF)
-                    // Enable concurrent camera
-                    .performClick()
-                    .assertConcurrentCameraMode(ConcurrentCameraMode.DUAL)
+            runBlocking {
+                with(composeTestRule) {
+                    onNodeWithTag(QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON)
+                        .assertExists()
+                        .assertConcurrentCameraMode(ConcurrentCameraMode.OFF)
+                        // Enable concurrent camera
+                        .performClick()
+                        .assertConcurrentCameraMode(ConcurrentCameraMode.DUAL)
 
-                // Assert the capture mode button is disabled
-                onNodeWithTag(QUICK_SETTINGS_STREAM_CONFIG_BUTTON)
-                    .assertExists()
-                    .assert(isNotEnabled())
+                    // Assert the capture mode button is disabled
+                    onNodeWithTag(QUICK_SETTINGS_STREAM_CONFIG_BUTTON)
+                        .assertExists()
+                        .assert(isNotEnabled())
 
-                // Assert the HDR button is disabled
-                onNodeWithTag(QUICK_SETTINGS_HDR_BUTTON)
-                    .assertExists()
-                    .assert(isNotEnabled())
+                    // Assert the HDR button is disabled
+                    onNodeWithTag(QUICK_SETTINGS_HDR_BUTTON)
+                        .assertExists()
+                        .assert(isNotEnabled())
 
-                // Exit quick settings
-                onNodeWithTag(QUICK_SETTINGS_DROP_DOWN)
-                    .assertExists()
-                    .performClick()
-
-                onNodeWithTag(CAPTURE_MODE_TOGGLE_BUTTON)
-                    .assertExists()
-                    .assert(
-                        stateDescriptionMatches(
-                            getResString(R.string.capture_mode_video_recording_content_description)
+                    // Assert the capture mode is disabled and set to video-only
+                    onNodeWithTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE)
+                        .assertExists()
+                        .assert(isNotEnabled())
+                        .assert(
+                            stateDescriptionMatches(
+                                getResString(
+                                    R.string.quick_settings_description_capture_mode_video_only
+                                )
+                            )
                         )
-                    ).performClick()
-
-                waitUntil {
-                    onNodeWithTag(IMAGE_CAPTURE_UNSUPPORTED_CONCURRENT_CAMERA_TAG).isDisplayed()
                 }
             }
         }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/quicksettings/QuickSettingsScreen.kt
@@ -36,8 +36,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.jetpackcamera.core.camera.VideoRecordingState
 import com.google.jetpackcamera.feature.preview.CaptureModeUiState
@@ -311,8 +314,15 @@ private fun ExpandedQuickSettingsUi(
                     }
 
                     add {
+                        val context = LocalContext.current
                         QuickSetCaptureMode(
-                            modifier = Modifier.testTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE),
+                            modifier = Modifier
+                                .testTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE)
+                                .semantics {
+                                    previewUiState.captureModeUiState.stateDescription()?.let {
+                                        stateDescription = context.getString(it)
+                                    }
+                                },
                             onClick = {
                                 setFocusedQuickSetting(
                                     FocusedQuickSetting.CAPTURE_MODE
@@ -339,6 +349,14 @@ private fun ExpandedQuickSettingsUi(
                 captureModeUiState = previewUiState.captureModeUiState
             )
         }
+    }
+}
+
+private fun CaptureModeUiState.stateDescription() = (this as? CaptureModeUiState.Enabled)?.let {
+    when (currentSelection) {
+        CaptureMode.STANDARD -> R.string.quick_settings_description_capture_mode_standard
+        CaptureMode.VIDEO_ONLY -> R.string.quick_settings_description_capture_mode_video_only
+        CaptureMode.IMAGE_ONLY -> R.string.quick_settings_description_capture_mode_image_only
     }
 }
 


### PR DESCRIPTION
 The capture mode toggle switch was removed in #324 when concurrent
 camera mode is enabled.  We can now check the quick setting button
 for the capture mode.
