### PR TITLE
Add storage permission screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,6 @@ android {
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
     }
 
-
     buildTypes {
         getByName("debug") {
             signingConfig = signingConfigs.getByName("debug")
@@ -140,7 +139,6 @@ dependencies {
     androidTestImplementation(libs.androidx.uiautomator)
     androidTestImplementation(libs.truth)
     androidTestUtil(libs.androidx.orchestrator)
-
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/androidTest/java/com/google/jetpackcamera/ImageCaptureDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ImageCaptureDeviceTest.kt
@@ -20,7 +20,6 @@ import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
 import android.view.KeyEvent
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
@@ -48,6 +47,7 @@ import com.google.jetpackcamera.utils.VIDEO_PREFIX
 import com.google.jetpackcamera.utils.deleteFilesInDirAfterTimestamp
 import com.google.jetpackcamera.utils.doesFileExist
 import com.google.jetpackcamera.utils.doesMediaExist
+import com.google.jetpackcamera.utils.ensureTagNotAppears
 import com.google.jetpackcamera.utils.getMultipleImageCaptureIntent
 import com.google.jetpackcamera.utils.getSingleImageCaptureIntent
 import com.google.jetpackcamera.utils.getTestUri
@@ -190,18 +190,11 @@ internal class ImageCaptureDeviceTest {
                     .assertExists()
                     .performTouchInput { longClick(durationMillis = 3_000) }
 
-                try {
-                    composeTestRule.waitUntil(timeoutMillis = VIDEO_CAPTURE_TIMEOUT_MILLIS) {
-                        // image_only capture UI does not display the video unsupported snackbar
-                        composeTestRule.onNodeWithTag(VIDEO_CAPTURE_EXTERNAL_UNSUPPORTED_TAG)
-                            .isDisplayed()
-                    }
-                    throw AssertionError(
-                        "$VIDEO_CAPTURE_EXTERNAL_UNSUPPORTED_TAG should not be present"
-                    )
-                } catch (e: ComposeTimeoutException) {
-                    /*do nothing. we want to time out */
-                }
+                composeTestRule.ensureTagNotAppears(
+                    VIDEO_CAPTURE_EXTERNAL_UNSUPPORTED_TAG,
+                    VIDEO_CAPTURE_TIMEOUT_MILLIS
+                )
+
                 uiDevice.pressBack()
             }
         Truth.assertThat(result.resultCode).isEqualTo(Activity.RESULT_CANCELED)

--- a/app/src/androidTest/java/com/google/jetpackcamera/PermissionsTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/PermissionsTest.kt
@@ -261,10 +261,6 @@ class PermissionsTest {
             // If we are on preview screen, then read permission was automatically granted
             composeTestRule.waitForStartup()
 
-            // check for imagewell
-            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
-                composeTestRule.onNodeWithTag(IMAGE_WELL_TAG).isDisplayed()
-            }
             // check for image capture success
             composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()
 
@@ -273,6 +269,10 @@ class PermissionsTest {
                 .performClick()
             composeTestRule.waitUntil(timeoutMillis = IMAGE_CAPTURE_TIMEOUT_MILLIS) {
                 composeTestRule.onNodeWithTag(IMAGE_CAPTURE_SUCCESS_TAG).isDisplayed()
+            }
+            // check for imagewell
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_WELL_TAG).isDisplayed()
             }
         }
     }
@@ -316,9 +316,11 @@ class PermissionsTest {
         }
     }
 
+    // @Test
     @SdkSuppress(maxSdkVersion = 28)
-    @Test
     fun writeStoragePermission_denied_ReadPermission_granted() {
+        // todo: imagewell won't be present unless an image has already been captured
+
         uiDevice.waitForIdle()
         runScenarioTest<MainActivity> {
             // Wait for the write permission screen to be displayed
@@ -356,9 +358,11 @@ class PermissionsTest {
             composeTestRule.waitForStartup()
 
             // check for imagewell
+            /*
             composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
                 composeTestRule.onNodeWithTag(IMAGE_WELL_TAG).isDisplayed()
             }
+             */
 
             // check for image capture failure
             composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()

--- a/app/src/androidTest/java/com/google/jetpackcamera/PermissionsTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/PermissionsTest.kt
@@ -25,17 +25,28 @@ import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.google.jetpackcamera.feature.preview.ui.CAPTURE_BUTTON
+import com.google.jetpackcamera.feature.preview.ui.IMAGE_CAPTURE_FAILURE_TAG
+import com.google.jetpackcamera.feature.preview.ui.IMAGE_CAPTURE_SUCCESS_TAG
+import com.google.jetpackcamera.feature.preview.ui.IMAGE_WELL_TAG
+import com.google.jetpackcamera.permissions.AUDIO_RECORD_PERMISSION
 import com.google.jetpackcamera.permissions.ui.CAMERA_PERMISSION_BUTTON
+import com.google.jetpackcamera.permissions.ui.READ_EXTERNAL_STORAGE_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.RECORD_AUDIO_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.REQUEST_PERMISSION_BUTTON
+import com.google.jetpackcamera.permissions.ui.WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
 import com.google.jetpackcamera.utils.APP_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.utils.APP_START_TIMEOUT_MILLIS
+import com.google.jetpackcamera.utils.DEFAULT_TIMEOUT_MILLIS
+import com.google.jetpackcamera.utils.IMAGE_CAPTURE_TIMEOUT_MILLIS
 import com.google.jetpackcamera.utils.IndividualTestGrantPermissionRule
 import com.google.jetpackcamera.utils.askEveryTimeDialog
 import com.google.jetpackcamera.utils.denyPermissionDialog
+import com.google.jetpackcamera.utils.ensureTagNotAppears
 import com.google.jetpackcamera.utils.grantPermissionDialog
 import com.google.jetpackcamera.utils.onNodeWithText
 import com.google.jetpackcamera.utils.runScenarioTest
+import com.google.jetpackcamera.utils.waitForStartup
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,8 +61,21 @@ class PermissionsTest {
     @get:Rule
     val allPermissionsRule = IndividualTestGrantPermissionRule(
         permissions = APP_REQUIRED_PERMISSIONS.toTypedArray(),
+        targetTestNames = arrayOf("allPermissions_alreadyGranted_screenNotShown")
+    )
+
+    @get:Rule
+    val cameraAudioPermissionRule = IndividualTestGrantPermissionRule(
+        permissions = arrayOf(CAMERA_PERMISSION, AUDIO_RECORD_PERMISSION),
         targetTestNames = arrayOf(
-            "allPermissions_alreadyGranted_screenNotShown"
+            "writeStoragePermission_granted_skipsReadPermission",
+            "writeStoragePermission_granted_ReadPermission_granted",
+            "writeStoragePermission_denied_ReadPermission_granted",
+            "writeStoragePermission_denied_skips_ReadPermission",
+            "writeStoragePermission_granted_ReadPermission_granted",
+            "writeStoragePermission_denied_ReadPermission_granted",
+            "writeStoragePermission_denied_ReadPermission_denied"
+
         )
     )
 
@@ -201,6 +225,257 @@ class PermissionsTest {
             // Assert we're on a different page
             composeTestRule.waitUntil(timeoutMillis = APP_START_TIMEOUT_MILLIS) {
                 composeTestRule.onNodeWithTag(RECORD_AUDIO_PERMISSION_BUTTON).isNotDisplayed()
+            }
+        }
+    }
+
+    @SdkSuppress(minSdkVersion = 28)
+    @Test
+    fun writeStoragePermission_granted_skipsReadPermission() {
+        uiDevice.waitForIdle()
+        runScenarioTest<MainActivity> {
+            // Wait for the camera permission screen to be displayed
+            composeTestRule.waitUntil(timeoutMillis = APP_START_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(
+                    WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
+                ).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            // grant permission
+            uiDevice.grantPermissionDialog()
+
+            composeTestRule
+                .onNodeWithTag(WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON)
+                .assertDoesNotExist()
+            try {
+                composeTestRule.ensureTagNotAppears(READ_EXTERNAL_STORAGE_PERMISSION_BUTTON)
+            } catch (e: AssertionError) {
+                assumeTrue("read external storage permission was not skipped", false)
+            }
+
+            // If we are on preview screen, then read permission was automatically granted
+            composeTestRule.waitForStartup()
+
+            // check for imagewell
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_WELL_TAG).isDisplayed()
+            }
+            // check for image capture success
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()
+
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON)
+                .assertExists()
+                .performClick()
+            composeTestRule.waitUntil(timeoutMillis = IMAGE_CAPTURE_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_CAPTURE_SUCCESS_TAG).isDisplayed()
+            }
+        }
+    }
+
+    @SdkSuppress(minSdkVersion = 28)
+    @Test
+    fun writeStoragePermission_granted_ReadPermission_granted() {
+        uiDevice.waitForIdle()
+        runScenarioTest<MainActivity> {
+            // Wait for the permission screen to be displayed
+            composeTestRule.waitUntil(timeoutMillis = APP_START_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(
+                    WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
+                ).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            // grant permission
+            uiDevice.grantPermissionDialog()
+
+            try {
+                composeTestRule.ensureTagNotAppears(CAPTURE_BUTTON, timeoutMillis = 5_000)
+            } catch (e: AssertionError) {
+                assumeTrue("read external storage permission was skipped", false)
+            }
+
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(READ_EXTERNAL_STORAGE_PERMISSION_BUTTON).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            composeTestRule.waitForStartup()
+        }
+    }
+
+    @SdkSuppress(minSdkVersion = 28)
+    @Test
+    fun writeStoragePermission_denied_ReadPermission_granted() {
+        uiDevice.waitForIdle()
+        runScenarioTest<MainActivity> {
+            // Wait for the write permission screen to be displayed
+            composeTestRule.waitUntil(timeoutMillis = APP_START_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(
+                    WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
+                ).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            // deny permission
+            uiDevice.denyPermissionDialog()
+
+            try {
+                composeTestRule.ensureTagNotAppears(CAPTURE_BUTTON, timeoutMillis = 5_000)
+            } catch (e: AssertionError) {
+                assumeTrue("read external storage permission was skipped", false)
+            }
+
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(READ_EXTERNAL_STORAGE_PERMISSION_BUTTON).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            uiDevice.grantPermissionDialog()
+
+            composeTestRule.waitForStartup()
+
+            // check for imagewell
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_WELL_TAG).isDisplayed()
+            }
+
+            // check for image capture failure
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()
+
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON)
+                .assertExists()
+                .performClick()
+            composeTestRule.waitUntil(timeoutMillis = IMAGE_CAPTURE_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_CAPTURE_FAILURE_TAG).isDisplayed()
+            }
+        }
+    }
+
+    @SdkSuppress(minSdkVersion = 28)
+    @Test
+    fun writeStoragePermission_denied_ReadPermission_denied() {
+        uiDevice.waitForIdle()
+        runScenarioTest<MainActivity> {
+            // Wait for the write permission screen to be displayed
+            composeTestRule.waitUntil(timeoutMillis = APP_START_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(
+                    WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
+                ).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            // deny permission
+            uiDevice.denyPermissionDialog()
+
+            try {
+                composeTestRule.ensureTagNotAppears(CAPTURE_BUTTON, 5_000)
+            } catch (e: AssertionError) {
+                assumeTrue("read external storage permission was skipped", false)
+            }
+
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(READ_EXTERNAL_STORAGE_PERMISSION_BUTTON).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            uiDevice.denyPermissionDialog()
+
+            composeTestRule.waitForStartup()
+
+            // check for imagewell
+            try {
+                composeTestRule.ensureTagNotAppears(IMAGE_WELL_TAG)
+            } catch (e: AssertionError) {
+                assumeTrue("image well should not be visible", false)
+            }
+
+            // check for image capture failure
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()
+
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON)
+                .assertExists()
+                .performClick()
+            composeTestRule.waitUntil(timeoutMillis = IMAGE_CAPTURE_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_CAPTURE_FAILURE_TAG).isDisplayed()
+            }
+        }
+    }
+
+    @SdkSuppress(minSdkVersion = 28)
+    @Test
+    fun writeStoragePermission_denied_skips_ReadPermission() {
+        uiDevice.waitForIdle()
+        runScenarioTest<MainActivity> {
+            // Wait for the write permission screen to be displayed
+            composeTestRule.waitUntil(timeoutMillis = APP_START_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(
+                    WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
+                ).isDisplayed()
+            }
+
+            // Click button to request permission
+            composeTestRule.onNodeWithTag(REQUEST_PERMISSION_BUTTON)
+                .assertExists()
+                .performClick()
+
+            // deny permission
+            uiDevice.denyPermissionDialog()
+
+            try {
+                composeTestRule.ensureTagNotAppears(
+                    READ_EXTERNAL_STORAGE_PERMISSION_BUTTON,
+                    timeoutMillis = 5_000
+                )
+            } catch (e: AssertionError) {
+                assumeTrue("read external storage permission is displayed", false)
+            }
+
+            composeTestRule.waitForStartup()
+
+            // check for imagewell
+            try {
+                composeTestRule.ensureTagNotAppears(IMAGE_WELL_TAG)
+            } catch (e: AssertionError) {
+                assumeTrue("image well should not be visible", false)
+            }
+
+            // check for image capture failure
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()
+
+            composeTestRule.onNodeWithTag(CAPTURE_BUTTON)
+                .assertExists()
+                .performClick()
+            composeTestRule.waitUntil(timeoutMillis = IMAGE_CAPTURE_TIMEOUT_MILLIS) {
+                composeTestRule.onNodeWithTag(IMAGE_CAPTURE_FAILURE_TAG).isDisplayed()
             }
         }
     }

--- a/app/src/androidTest/java/com/google/jetpackcamera/PermissionsTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/PermissionsTest.kt
@@ -229,7 +229,7 @@ class PermissionsTest {
         }
     }
 
-    @SdkSuppress(minSdkVersion = 28)
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun writeStoragePermission_granted_skipsReadPermission() {
         uiDevice.waitForIdle()
@@ -277,7 +277,7 @@ class PermissionsTest {
         }
     }
 
-    @SdkSuppress(minSdkVersion = 28)
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun writeStoragePermission_granted_ReadPermission_granted() {
         uiDevice.waitForIdle()
@@ -316,7 +316,7 @@ class PermissionsTest {
         }
     }
 
-    @SdkSuppress(minSdkVersion = 28)
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun writeStoragePermission_denied_ReadPermission_granted() {
         uiDevice.waitForIdle()
@@ -362,7 +362,6 @@ class PermissionsTest {
 
             // check for image capture failure
             composeTestRule.onNodeWithTag(CAPTURE_BUTTON).assertExists().performClick()
-
             composeTestRule.onNodeWithTag(CAPTURE_BUTTON)
                 .assertExists()
                 .performClick()
@@ -372,7 +371,7 @@ class PermissionsTest {
         }
     }
 
-    @SdkSuppress(minSdkVersion = 28)
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun writeStoragePermission_denied_ReadPermission_denied() {
         uiDevice.waitForIdle()
@@ -430,7 +429,7 @@ class PermissionsTest {
         }
     }
 
-    @SdkSuppress(minSdkVersion = 28)
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun writeStoragePermission_denied_skips_ReadPermission() {
         uiDevice.waitForIdle()

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -125,9 +125,11 @@ fun ComposeTestRule.waitForStartup(timeoutMillis: Long = APP_START_TIMEOUT_MILLI
         onNodeWithTag(CAPTURE_BUTTON).isDisplayed()
     }
 }
+
 fun ComposeTestRule.waitForNodeWithTag(tag: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS) {
     waitUntil(timeoutMillis = timeoutMillis) { onNodeWithTag(tag).isDisplayed() }
 }
+
 private fun ComposeTestRule.idleForVideoDuration(
     durationMillis: Long = VIDEO_DURATION_MILLIS,
     earlyExitPredicate: () -> Boolean = {
@@ -141,6 +143,24 @@ private fun ComposeTestRule.idleForVideoDuration(
             earlyExitPredicate()
         }
     } catch (_: ComposeTimeoutException) {
+    }
+}
+
+fun ComposeTestRule.ensureTagNotAppears(
+    componentTag: String,
+    timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS
+) {
+    try {
+        waitUntil(timeoutMillis = timeoutMillis) {
+            // image_only capture UI does not display the video unsupported snackbar
+            onNodeWithTag(componentTag)
+                .isDisplayed()
+        }
+        throw AssertionError(
+            "$componentTag should not be present"
+        )
+    } catch (e: ComposeTimeoutException) {
+        /* Do nothing. we want to time out here. */
     }
 }
 
@@ -158,12 +178,7 @@ fun ComposeTestRule.pressAndDragToLockVideoRecording() {
             moveBy(delta = Offset(-400f, 0f), delayMillis = VIDEO_DURATION_MILLIS)
             up()
         }
-    try {
-        waitUntil(timeoutMillis = VIDEO_CAPTURE_TIMEOUT_MILLIS) {
-            onNodeWithTag(VIDEO_CAPTURE_SUCCESS_TAG).isDisplayed()
-        }
-        throw AssertionError("$VIDEO_CAPTURE_SUCCESS_TAG should not be displayed.")
-    } catch (e: ComposeTimeoutException) { /* do nothing. success tag should not have displayed*/ }
+    ensureTagNotAppears(VIDEO_CAPTURE_SUCCESS_TAG, VIDEO_CAPTURE_TIMEOUT_MILLIS)
 }
 
 fun ComposeTestRule.longClickForVideoRecording(durationMillis: Long = VIDEO_DURATION_MILLIS) {
@@ -225,11 +240,13 @@ fun ComposeTestRule.getHdrToggleState(): CaptureMode =
                 R.string.capture_mode_image_capture_content_description_disabled
             ) ->
                 CaptureMode.IMAGE_ONLY
+
             getResString(R.string.capture_mode_video_recording_content_description),
             getResString(
                 R.string.capture_mode_video_recording_content_description_disabled
             ) ->
                 CaptureMode.VIDEO_ONLY
+
             else -> null
         }
     }
@@ -270,16 +287,22 @@ inline fun <reified T> ComposeTestRule.checkComponentStateDescriptionState(
             throw AssertionError("Unable to determine state from component")
         }
 }
+
 fun ComposeTestRule.isHdrEnabled(): Boolean =
     checkComponentContentDescriptionState<Boolean>(QUICK_SETTINGS_HDR_BUTTON) { description ->
         when (description) {
             getResString(R.string.quick_settings_dynamic_range_hdr_description) -> {
                 return@checkComponentContentDescriptionState true
-            } getResString(R.string.quick_settings_dynamic_range_sdr_description) -> {
+            }
+
+            getResString(R.string.quick_settings_dynamic_range_sdr_description) -> {
                 return@checkComponentContentDescriptionState false
-            } else -> null
+            }
+
+            else -> null
         }
     }
+
 fun ComposeTestRule.getCurrentLensFacing(): LensFacing = visitQuickSettings {
     onNodeWithTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON).fetchSemanticsNode(
         "Flip camera button is not visible when expected."
@@ -288,8 +311,10 @@ fun ComposeTestRule.getCurrentLensFacing(): LensFacing = visitQuickSettings {
             when (description) {
                 getResString(R.string.quick_settings_front_camera_description) ->
                     return@let LensFacing.FRONT
+
                 getResString(R.string.quick_settings_back_camera_description) ->
                     return@let LensFacing.BACK
+
                 else -> false
             }
         }
@@ -305,18 +330,23 @@ fun ComposeTestRule.getCurrentFlashMode(): FlashMode = visitQuickSettings {
             when (description) {
                 getResString(R.string.quick_settings_flash_off_description) ->
                     return@let FlashMode.OFF
+
                 getResString(R.string.quick_settings_flash_on_description) ->
                     return@let FlashMode.ON
+
                 getResString(R.string.quick_settings_flash_auto_description) ->
                     return@let FlashMode.AUTO
+
                 getResString(R.string.quick_settings_flash_llb_description) ->
                     return@let FlashMode.LOW_LIGHT_BOOST
+
                 else -> false
             }
         }
         throw AssertionError("Unable to determine flash mode from quick settings")
     }
 }
+
 fun ComposeTestRule.getConcurrentState(): ConcurrentCameraMode = visitQuickSettings {
     onNodeWithTag(QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON)
         .assertExists()
@@ -327,10 +357,13 @@ fun ComposeTestRule.getConcurrentState(): ConcurrentCameraMode = visitQuickSetti
                 when (description) {
                     getResString(R.string.quick_settings_description_concurrent_camera_off) -> {
                         return@let ConcurrentCameraMode.OFF
-                    } getResString(
+                    }
+
+                    getResString(
                         R.string.quick_settings_description_concurrent_camera_dual
                     ) ->
                         return@let ConcurrentCameraMode.DUAL
+
                     else -> false
                 }
             }
@@ -339,6 +372,7 @@ fun ComposeTestRule.getConcurrentState(): ConcurrentCameraMode = visitQuickSetti
             )
         }
 }
+
 fun ComposeTestRule.getCurrentCaptureMode(): CaptureMode = visitQuickSettings {
     waitUntil(timeoutMillis = 1000) {
         onNodeWithTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE).isDisplayed()
@@ -351,10 +385,13 @@ fun ComposeTestRule.getCurrentCaptureMode(): CaptureMode = visitQuickSettings {
             when (description) {
                 getResString(R.string.quick_settings_description_capture_mode_standard) ->
                     return@let CaptureMode.STANDARD
+
                 getResString(R.string.quick_settings_description_capture_mode_image_only) ->
                     return@let CaptureMode.IMAGE_ONLY
+
                 getResString(R.string.quick_settings_description_capture_mode_video_only) ->
                     return@let CaptureMode.VIDEO_ONLY
+
                 else -> false
             }
         }
@@ -371,7 +408,7 @@ fun ComposeTestRule.getCurrentCaptureMode(): CaptureMode = visitQuickSettings {
 /**
  * Navigates to quick settings if not already there and perform action from provided block.
  * This will return from quick settings if not already there, or remain on quick settings if there.
-*/
+ */
 inline fun <T> ComposeTestRule.visitQuickSettings(crossinline block: ComposeTestRule.() -> T): T {
     var needReturnFromQuickSettings = false
     onNodeWithContentDescription(R.string.quick_settings_dropdown_closed_description).apply {
@@ -433,6 +470,7 @@ fun ComposeTestRule.setHdrEnabled(enabled: Boolean) {
         waitUntil(1000) { isHdrEnabled() == enabled }
     }
 }
+
 fun ComposeTestRule.setConcurrentCameraMode(concurrentMode: ConcurrentCameraMode) {
     visitQuickSettings {
         waitForNodeWithTag(tag = QUICK_SETTINGS_CONCURRENT_CAMERA_MODE_BUTTON)
@@ -446,6 +484,7 @@ fun ComposeTestRule.setConcurrentCameraMode(concurrentMode: ConcurrentCameraMode
         waitUntil(1_000) { getConcurrentState() == concurrentMode }
     }
 }
+
 fun ComposeTestRule.setCaptureMode(captureMode: CaptureMode) {
     visitQuickSettings {
         waitUntil(timeoutMillis = 1000) {

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -152,9 +152,7 @@ fun ComposeTestRule.ensureTagNotAppears(
 ) {
     try {
         waitUntil(timeoutMillis = timeoutMillis) {
-            // image_only capture UI does not display the video unsupported snackbar
-            onNodeWithTag(componentTag)
-                .isDisplayed()
+            onNodeWithTag(componentTag).isDisplayed()
         }
         throw AssertionError(
             "$componentTag should not be present"

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/UiTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/UiTestUtil.kt
@@ -177,25 +177,30 @@ fun getTestUri(directoryPath: String, timeStamp: Long, suffix: String): Uri = Ur
     )
 )
 
+/**
+ * @return - true if all eligible files were successfully deleted. False otherwise
+ */
 fun deleteFilesInDirAfterTimestamp(
     directoryPath: String,
     instrumentation: Instrumentation,
     timeStamp: Long
 ): Boolean {
-    var hasDeletedFile = false
+    val fileStatus = mutableMapOf<String, Boolean>()
     for (file in File(directoryPath).listFiles() ?: emptyArray()) {
         if (file.lastModified() >= timeStamp) {
-            file.delete()
+            fileStatus.put(file.name, file.delete())
             if (file.exists()) {
-                file.canonicalFile.delete()
+                fileStatus.put(file.name, file.canonicalFile.delete())
                 if (file.exists()) {
-                    instrumentation.targetContext.applicationContext.deleteFile(file.name)
+                    fileStatus.put(
+                        file.name,
+                        instrumentation.targetContext.applicationContext.deleteFile(file.name)
+                    )
                 }
             }
-            hasDeletedFile = true
         }
     }
-    return hasDeletedFile
+    return fileStatus.keys.all { fileStatus[it] ?: false }
 }
 
 fun doesFileExist(uri: Uri): Boolean = uri.path?.let { File(it) }?.exists() == true

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -83,7 +83,7 @@ private fun JetpackCameraNavHost(
     ) {
         composable(PERMISSIONS_ROUTE) {
             PermissionsScreen(
-                shouldRequestReadStoragePermission = previewMode is PreviewMode.StandardMode && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P,
+                shouldRequestReadWriteStoragePermission = previewMode is PreviewMode.StandardMode && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P,
                 shouldRequestAudioPermission = previewMode is PreviewMode.StandardMode,
                 onAllPermissionsGranted = {
                     // Pop off the permissions screen
@@ -99,10 +99,15 @@ private fun JetpackCameraNavHost(
 
         composable(route = PREVIEW_ROUTE, enterTransition = { fadeIn() }) {
             val permissionStates = rememberMultiplePermissionsState(
-                permissions = listOf(
-                    Manifest.permission.CAMERA,
-                    Manifest.permission.RECORD_AUDIO
-                )
+                permissions =
+                    buildList{
+                        add(Manifest.permission.CAMERA)
+                        add(Manifest.permission.RECORD_AUDIO)
+                        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                            add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                            add(Manifest.permission.READ_EXTERNAL_STORAGE)
+                        }
+                    }
             )
             // Automatically navigate to permissions screen when camera permission revoked
             LaunchedEffect(key1 = permissionStates.permissions[0].status) {

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -16,6 +16,7 @@
 package com.google.jetpackcamera.ui
 
 import android.Manifest
+import android.os.Build
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.EaseOut
@@ -82,6 +83,7 @@ private fun JetpackCameraNavHost(
     ) {
         composable(PERMISSIONS_ROUTE) {
             PermissionsScreen(
+                shouldRequestReadStoragePermission = previewMode is PreviewMode.StandardMode && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P,
                 shouldRequestAudioPermission = previewMode is PreviewMode.StandardMode,
                 onAllPermissionsGranted = {
                     // Pop off the permissions screen

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -83,7 +83,8 @@ private fun JetpackCameraNavHost(
     ) {
         composable(PERMISSIONS_ROUTE) {
             PermissionsScreen(
-                shouldRequestReadWriteStoragePermission = previewMode is PreviewMode.StandardMode && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P,
+                shouldRequestReadWriteStoragePermission = previewMode is PreviewMode.StandardMode &&
+                    Build.VERSION.SDK_INT <= Build.VERSION_CODES.P,
                 shouldRequestAudioPermission = previewMode is PreviewMode.StandardMode,
                 onAllPermissionsGranted = {
                     // Pop off the permissions screen
@@ -100,14 +101,14 @@ private fun JetpackCameraNavHost(
         composable(route = PREVIEW_ROUTE, enterTransition = { fadeIn() }) {
             val permissionStates = rememberMultiplePermissionsState(
                 permissions =
-                    buildList{
-                        add(Manifest.permission.CAMERA)
-                        add(Manifest.permission.RECORD_AUDIO)
-                        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-                            add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                            add(Manifest.permission.READ_EXTERNAL_STORAGE)
-                        }
+                buildList {
+                    add(Manifest.permission.CAMERA)
+                    add(Manifest.permission.RECORD_AUDIO)
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                        add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        add(Manifest.permission.READ_EXTERNAL_STORAGE)
                     }
+                }
             )
             // Automatically navigate to permissions screen when camera permission revoked
             LaunchedEffect(key1 = permissionStates.permissions[0].status) {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -760,7 +760,6 @@ private suspend fun startVideoRecordingInternal(
 
     pendingRecord.apply {
         if (isAudioGranted) {
-            Log.d(TAG, "INITIAL AUDIO $isInitialAudioEnabled")
             withAudioEnabled(isInitialAudioEnabled)
         }
     }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
@@ -19,7 +19,9 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CameraAlt
+import androidx.compose.material.icons.outlined.CreateNewFolder
 import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
@@ -29,11 +31,14 @@ import androidx.compose.ui.res.painterResource
 import com.google.jetpackcamera.permissions.ui.CAMERA_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.READ_EXTERNAL_STORAGE_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.RECORD_AUDIO_PERMISSION_BUTTON
+import com.google.jetpackcamera.permissions.ui.WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
 
 const val CAMERA_PERMISSION = "android.permission.CAMERA"
 const val AUDIO_RECORD_PERMISSION = "android.permission.RECORD_AUDIO"
 
 const val READ_EXTERNAL_STORAGE_PERMISSION = "android.permission.READ_EXTERNAL_STORAGE"
+const val WRITE_EXTERNAL_STORAGE_PERMISSION = "android.permission.WRITE_EXTERNAL_STORAGE"
+
 
 
 /**
@@ -133,6 +138,28 @@ enum class PermissionEnum : PermissionInfoProvider {
             R.string.microphone_permission_accessibility_text
     },
 
+    WRITE_STORAGE{
+        override fun getPermission(): String = WRITE_EXTERNAL_STORAGE_PERMISSION
+
+        override fun isOptional(): Boolean = true
+
+        override fun getTestTag(): String = WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
+
+        override fun getDrawableResId(): Int? = null
+
+        override fun getImageVector(): ImageVector = Icons.Outlined.CreateNewFolder
+
+        override fun getPermissionTitleResId(): Int = R.string.write_storage_permission_screen_title
+
+        override fun getPermissionBodyTextResId(): Int =
+            R.string.write_storage_permission_required_rationale
+
+        override fun getRationaleBodyTextResId(): Int? = null
+
+        override fun getIconAccessibilityTextResId(): Int =
+            R.string.write_storage_permission_accessibility_text
+    },
+
     READ_STORAGE{
         override fun getPermission(): String = READ_EXTERNAL_STORAGE_PERMISSION
 
@@ -142,7 +169,7 @@ enum class PermissionEnum : PermissionInfoProvider {
 
         override fun getDrawableResId(): Int? = null
 
-        override fun getImageVector(): ImageVector = Icons.Outlined.Folder
+        override fun getImageVector(): ImageVector = Icons.Outlined.FolderOpen
 
         override fun getPermissionTitleResId(): Int = R.string.read_storage_permission_screen_title
 

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
@@ -19,6 +19,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CameraAlt
+import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
@@ -26,10 +27,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import com.google.jetpackcamera.permissions.ui.CAMERA_PERMISSION_BUTTON
+import com.google.jetpackcamera.permissions.ui.READ_EXTERNAL_STORAGE_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.RECORD_AUDIO_PERMISSION_BUTTON
 
 const val CAMERA_PERMISSION = "android.permission.CAMERA"
 const val AUDIO_RECORD_PERMISSION = "android.permission.RECORD_AUDIO"
+
+const val READ_EXTERNAL_STORAGE_PERMISSION = "android.permission.READ_EXTERNAL_STORAGE"
+
 
 /**
  * Helper class storing a permission's relevant UI information
@@ -126,5 +131,28 @@ enum class PermissionEnum : PermissionInfoProvider {
 
         override fun getIconAccessibilityTextResId(): Int =
             R.string.microphone_permission_accessibility_text
+    },
+
+    READ_STORAGE{
+        override fun getPermission(): String = READ_EXTERNAL_STORAGE_PERMISSION
+
+        override fun isOptional(): Boolean = true
+
+        override fun getTestTag(): String = READ_EXTERNAL_STORAGE_PERMISSION_BUTTON
+
+        override fun getDrawableResId(): Int? = null
+
+        override fun getImageVector(): ImageVector = Icons.Outlined.Folder
+
+        override fun getPermissionTitleResId(): Int = R.string.read_storage_permission_screen_title
+
+        override fun getPermissionBodyTextResId(): Int =
+            R.string.read_storage_permission_required_rationale
+
+        override fun getRationaleBodyTextResId(): Int? = null
+
+        override fun getIconAccessibilityTextResId(): Int =
+            R.string.read_storage_permission_accessibility_text
+
     }
 }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
@@ -20,7 +20,6 @@ import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CameraAlt
 import androidx.compose.material.icons.outlined.CreateNewFolder
-import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.runtime.Composable
@@ -38,8 +37,6 @@ const val AUDIO_RECORD_PERMISSION = "android.permission.RECORD_AUDIO"
 
 const val READ_EXTERNAL_STORAGE_PERMISSION = "android.permission.READ_EXTERNAL_STORAGE"
 const val WRITE_EXTERNAL_STORAGE_PERMISSION = "android.permission.WRITE_EXTERNAL_STORAGE"
-
-
 
 /**
  * Helper class storing a permission's relevant UI information
@@ -138,7 +135,7 @@ enum class PermissionEnum : PermissionInfoProvider {
             R.string.microphone_permission_accessibility_text
     },
 
-    WRITE_STORAGE{
+    WRITE_STORAGE {
         override fun getPermission(): String = WRITE_EXTERNAL_STORAGE_PERMISSION
 
         override fun isOptional(): Boolean = true
@@ -160,7 +157,7 @@ enum class PermissionEnum : PermissionInfoProvider {
             R.string.write_storage_permission_accessibility_text
     },
 
-    READ_STORAGE{
+    READ_STORAGE {
         override fun getPermission(): String = READ_EXTERNAL_STORAGE_PERMISSION
 
         override fun isOptional(): Boolean = true
@@ -180,6 +177,5 @@ enum class PermissionEnum : PermissionInfoProvider {
 
         override fun getIconAccessibilityTextResId(): Int =
             R.string.read_storage_permission_accessibility_text
-
     }
 }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsEnums.kt
@@ -20,7 +20,6 @@ import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CameraAlt
 import androidx.compose.material.icons.outlined.CreateNewFolder
-import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
@@ -28,7 +27,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import com.google.jetpackcamera.permissions.ui.CAMERA_PERMISSION_BUTTON
-import com.google.jetpackcamera.permissions.ui.READ_EXTERNAL_STORAGE_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.RECORD_AUDIO_PERMISSION_BUTTON
 import com.google.jetpackcamera.permissions.ui.WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON
 
@@ -155,27 +153,5 @@ enum class PermissionEnum : PermissionInfoProvider {
 
         override fun getIconAccessibilityTextResId(): Int =
             R.string.write_storage_permission_accessibility_text
-    },
-
-    READ_STORAGE {
-        override fun getPermission(): String = READ_EXTERNAL_STORAGE_PERMISSION
-
-        override fun isOptional(): Boolean = true
-
-        override fun getTestTag(): String = READ_EXTERNAL_STORAGE_PERMISSION_BUTTON
-
-        override fun getDrawableResId(): Int? = null
-
-        override fun getImageVector(): ImageVector = Icons.Outlined.FolderOpen
-
-        override fun getPermissionTitleResId(): Int = R.string.read_storage_permission_screen_title
-
-        override fun getPermissionBodyTextResId(): Int =
-            R.string.read_storage_permission_required_rationale
-
-        override fun getRationaleBodyTextResId(): Int? = null
-
-        override fun getIconAccessibilityTextResId(): Int =
-            R.string.read_storage_permission_accessibility_text
     }
 }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
@@ -37,7 +37,7 @@ private const val TAG = "PermissionsScreen"
 @Composable
 fun PermissionsScreen(
     shouldRequestAudioPermission: Boolean,
-    shouldRequestReadStoragePermission:Boolean,
+    shouldRequestReadWriteStoragePermission:Boolean,
     onAllPermissionsGranted: () -> Unit,
     openAppSettings: () -> Unit
 ) {
@@ -47,8 +47,12 @@ fun PermissionsScreen(
                 add(Manifest.permission.CAMERA)
                 if(shouldRequestAudioPermission)
                     add(Manifest.permission.RECORD_AUDIO)
-                if(shouldRequestReadStoragePermission)
+
+                // sometimes, when the write storage permission is granted, it will automatically grant the read storage permission
+                if(shouldRequestReadWriteStoragePermission) {
+                    add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                     add(Manifest.permission.READ_EXTERNAL_STORAGE)
+                }
             }
     )
     PermissionsScreen(
@@ -107,6 +111,7 @@ fun PermissionsScreen(
             modifier = modifier,
             permissionEnum = permissionEnum,
             permissionState = currentPermissionState,
+            onDismissPermission = { viewModel.dismissPermission() },
             onSkipPermission = when (permissionEnum) {
                 PermissionEnum.CAMERA -> null
                 // todo: skip permission button functionality. currently need to go through the

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
@@ -37,20 +37,19 @@ private const val TAG = "PermissionsScreen"
 @Composable
 fun PermissionsScreen(
     shouldRequestAudioPermission: Boolean,
+    shouldRequestReadStoragePermission:Boolean,
     onAllPermissionsGranted: () -> Unit,
     openAppSettings: () -> Unit
 ) {
     val permissionStates = rememberMultiplePermissionsState(
-        permissions = if (shouldRequestAudioPermission) {
-            listOf(
-                Manifest.permission.CAMERA,
-                Manifest.permission.RECORD_AUDIO
-            )
-        } else {
-            listOf(
-                Manifest.permission.CAMERA
-            )
-        }
+        permissions =
+            buildList {
+                add(Manifest.permission.CAMERA)
+                if(shouldRequestAudioPermission)
+                    add(Manifest.permission.RECORD_AUDIO)
+                if(shouldRequestReadStoragePermission)
+                    add(Manifest.permission.READ_EXTERNAL_STORAGE)
+            }
     )
     PermissionsScreen(
         permissionStates = permissionStates,
@@ -109,7 +108,6 @@ fun PermissionsScreen(
             permissionEnum = permissionEnum,
             permissionState = currentPermissionState,
             onSkipPermission = when (permissionEnum) {
-                // todo: a prettier navigation to app settings.
                 PermissionEnum.CAMERA -> null
                 // todo: skip permission button functionality. currently need to go through the
                 // prompt to skip

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
@@ -17,8 +17,6 @@ package com.google.jetpackcamera.permissions
 
 import android.Manifest
 import android.util.Log
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -28,7 +26,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
-import com.google.accompanist.permissions.rememberPermissionState
 import com.google.jetpackcamera.permissions.ui.PermissionTemplate
 
 private const val TAG = "PermissionsScreen"
@@ -91,27 +88,10 @@ fun PermissionsScreen(
     if (permissionsUiState is PermissionsUiState.PermissionsNeeded) {
         val permissionEnum =
             (permissionsUiState as PermissionsUiState.PermissionsNeeded).currentPermission
-        val currentPermissionState =
-            rememberPermissionState(
-                permission = permissionEnum.getPermission()
-            )
-
-        val permissionLauncher = rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestPermission(),
-            onResult = { permissionGranted ->
-                if (permissionGranted) {
-                    // remove from list
-                    viewModel.dismissPermission()
-                } else if (permissionEnum.isOptional()) {
-                    viewModel.dismissPermission()
-                }
-            }
-        )
 
         PermissionTemplate(
             modifier = modifier,
             permissionEnum = permissionEnum,
-            permissionState = currentPermissionState,
             onDismissPermission = { viewModel.dismissPermission() },
             onSkipPermission = when (permissionEnum) {
                 PermissionEnum.CAMERA -> null
@@ -119,7 +99,6 @@ fun PermissionsScreen(
                 // prompt to skip
                 else -> null // permissionsViewModel::dismissPermission
             },
-            onRequestPermission = { permissionLauncher.launch(permissionEnum.getPermission()) },
             onOpenAppSettings = openAppSettings
         )
     }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsScreen.kt
@@ -37,23 +37,24 @@ private const val TAG = "PermissionsScreen"
 @Composable
 fun PermissionsScreen(
     shouldRequestAudioPermission: Boolean,
-    shouldRequestReadWriteStoragePermission:Boolean,
+    shouldRequestReadWriteStoragePermission: Boolean,
     onAllPermissionsGranted: () -> Unit,
     openAppSettings: () -> Unit
 ) {
     val permissionStates = rememberMultiplePermissionsState(
         permissions =
-            buildList {
-                add(Manifest.permission.CAMERA)
-                if(shouldRequestAudioPermission)
-                    add(Manifest.permission.RECORD_AUDIO)
-
-                // sometimes, when the write storage permission is granted, it will automatically grant the read storage permission
-                if(shouldRequestReadWriteStoragePermission) {
-                    add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    add(Manifest.permission.READ_EXTERNAL_STORAGE)
-                }
+        buildList {
+            add(Manifest.permission.CAMERA)
+            if (shouldRequestAudioPermission) {
+                add(Manifest.permission.RECORD_AUDIO)
             }
+
+            // sometimes, when the write storage permission is granted, it will automatically grant the read storage permission
+            if (shouldRequestReadWriteStoragePermission) {
+                add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                add(Manifest.permission.READ_EXTERNAL_STORAGE)
+            }
+        }
     )
     PermissionsScreen(
         permissionStates = permissionStates,

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsViewModel.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsViewModel.kt
@@ -45,7 +45,7 @@ class PermissionsViewModel @AssistedInject constructor(
         fun create(runtimeArg: MultiplePermissionsState): PermissionsViewModel
     }
 
-    private val permissionQueue = mutableListOf<PermissionEnum>()
+    private var permissionQueue = mutableListOf<PermissionEnum>()
 
     init {
         permissionQueue.addAll(getRequestablePermissions(permissionStates))
@@ -108,6 +108,15 @@ fun getRequestablePermissions(
                         Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
                     ){
                         add(PermissionEnum.READ_STORAGE)
+                    }
+                }
+
+                Manifest.permission.WRITE_EXTERNAL_STORAGE -> {
+                    if (!permissionState.status.shouldShowRationale &&
+                        !permissionState.status.isGranted &&
+                        Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
+                    ){
+                        add(PermissionEnum.WRITE_STORAGE)
                     }
                 }
             }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsViewModel.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsViewModel.kt
@@ -55,12 +55,10 @@ class PermissionsViewModel @AssistedInject constructor(
         MutableStateFlow(getCurrentPermission())
     val permissionsUiState: StateFlow<PermissionsUiState> = _permissionsUiState.asStateFlow()
 
-    private fun getCurrentPermission(): PermissionsUiState {
-        return if (permissionQueue.isEmpty()) {
-            PermissionsUiState.AllPermissionsGranted
-        } else {
-            PermissionsUiState.PermissionsNeeded(permissionQueue.first())
-        }
+    private fun getCurrentPermission(): PermissionsUiState = if (permissionQueue.isEmpty()) {
+        PermissionsUiState.AllPermissionsGranted
+    } else {
+        PermissionsUiState.PermissionsNeeded(permissionQueue.first())
     }
 
     fun dismissPermission() {
@@ -98,15 +96,6 @@ fun getRequestablePermissions(permissionStates: MultiplePermissionsState): Set<P
                         !permissionState.status.isGranted
                     ) {
                         add(PermissionEnum.RECORD_AUDIO)
-                    }
-                }
-
-                Manifest.permission.READ_EXTERNAL_STORAGE -> {
-                    if (!permissionState.status.shouldShowRationale &&
-                        !permissionState.status.isGranted &&
-                        Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
-                    ) {
-                        add(PermissionEnum.READ_STORAGE)
                     }
                 }
 

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsViewModel.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/PermissionsViewModel.kt
@@ -81,23 +81,22 @@ class PermissionsViewModel @AssistedInject constructor(
  * - optional permissions that have not yet been denied by the user
  */
 @OptIn(ExperimentalPermissionsApi::class)
-fun getRequestablePermissions(
-    permissionStates: MultiplePermissionsState
-): Set<PermissionEnum> {
+fun getRequestablePermissions(permissionStates: MultiplePermissionsState): Set<PermissionEnum> {
     val unGrantedPermissions = buildSet {
         permissionStates.permissions.forEach { permissionState ->
             when (permissionState.permission) {
-                //camera is always required
+                // camera is always required
                 Manifest.permission.CAMERA -> {
-                    if (!permissionState.status.isGranted)
+                    if (!permissionState.status.isGranted) {
                         add(PermissionEnum.CAMERA)
+                    }
                 }
 
-                //optional permissions
+                // optional permissions
                 Manifest.permission.RECORD_AUDIO -> {
                     if (!permissionState.status.shouldShowRationale &&
                         !permissionState.status.isGranted
-                    ){
+                    ) {
                         add(PermissionEnum.RECORD_AUDIO)
                     }
                 }
@@ -106,7 +105,7 @@ fun getRequestablePermissions(
                     if (!permissionState.status.shouldShowRationale &&
                         !permissionState.status.isGranted &&
                         Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
-                    ){
+                    ) {
                         add(PermissionEnum.READ_STORAGE)
                     }
                 }
@@ -115,7 +114,7 @@ fun getRequestablePermissions(
                     if (!permissionState.status.shouldShowRationale &&
                         !permissionState.status.isGranted &&
                         Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
-                    ){
+                    ) {
                         add(PermissionEnum.WRITE_STORAGE)
                     }
                 }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
@@ -65,19 +65,20 @@ fun PermissionTemplate(
     modifier: Modifier = Modifier,
     permissionEnum: PermissionEnum,
     onDismissPermission: () -> Unit,
-    permissionState: PermissionState,
-    onRequestPermission: () -> Unit,
     onSkipPermission: (() -> Unit)? = null,
     onOpenAppSettings: () -> Unit
 ) {
     val permissionState = rememberPermissionState(permissionEnum.getPermission())
 
     // LaunchedEffect will skip permission enum if already granted.
-    LaunchedEffect(permissionEnum) {
-        if (permissionState.status.isGranted || permissionState.status.shouldShowRationale) {
+    LaunchedEffect(permissionState.status) {
+        if (permissionState.status.isGranted ||
+            (permissionState.status.shouldShowRationale && permissionEnum.isOptional())
+        ) {
             onDismissPermission()
         }
     }
+
     PermissionTemplate(
         modifier = modifier,
         testTag = permissionEnum.getTestTag(),
@@ -85,7 +86,7 @@ fun PermissionTemplate(
             if (permissionState.status.shouldShowRationale) {
                 onOpenAppSettings()
             } else {
-                onRequestPermission()
+                permissionState.launchPermissionRequest()
             }
         },
         onSkipPermission = onSkipPermission,

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
@@ -74,7 +74,7 @@ fun PermissionTemplate(
 
     // LaunchedEffect will skip permission enum if already granted.
     LaunchedEffect(permissionEnum) {
-        if (permissionState.status.isGranted) {
+        if (permissionState.status.isGranted || permissionState.status.shouldShowRationale) {
             onDismissPermission()
         }
     }

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
@@ -15,7 +15,6 @@
  */
 package com.google.jetpackcamera.permissions.ui
 
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -40,7 +39,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -75,9 +73,10 @@ fun PermissionTemplate(
     val permissionState = rememberPermissionState(permissionEnum.getPermission())
 
     // LaunchedEffect will skip permission enum if already granted.
-    LaunchedEffect(permissionEnum){
-        if(permissionState.status.isGranted)
+    LaunchedEffect(permissionEnum) {
+        if (permissionState.status.isGranted) {
             onDismissPermission()
+        }
     }
     PermissionTemplate(
         modifier = modifier,

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/PermissionsScreenComponents.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.permissions.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -34,10 +35,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +49,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import com.google.jetpackcamera.permissions.PermissionEnum
 import com.google.jetpackcamera.permissions.R
@@ -61,11 +66,19 @@ import com.google.jetpackcamera.permissions.R
 fun PermissionTemplate(
     modifier: Modifier = Modifier,
     permissionEnum: PermissionEnum,
+    onDismissPermission: () -> Unit,
     permissionState: PermissionState,
     onRequestPermission: () -> Unit,
     onSkipPermission: (() -> Unit)? = null,
     onOpenAppSettings: () -> Unit
 ) {
+    val permissionState = rememberPermissionState(permissionEnum.getPermission())
+
+    // LaunchedEffect will skip permission enum if already granted.
+    LaunchedEffect(permissionEnum){
+        if(permissionState.status.isGranted)
+            onDismissPermission()
+    }
     PermissionTemplate(
         modifier = modifier,
         testTag = permissionEnum.getTestTag(),

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/TestTags.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/TestTags.kt
@@ -18,3 +18,5 @@ package com.google.jetpackcamera.permissions.ui
 const val REQUEST_PERMISSION_BUTTON = "RequestPermissionButton"
 const val CAMERA_PERMISSION_BUTTON = "CameraPermissionButton"
 const val RECORD_AUDIO_PERMISSION_BUTTON = "RecordAudioPermissionButton"
+
+const val READ_EXTERNAL_STORAGE_PERMISSION_BUTTON = "ReadExternalStoragePermissionButton"

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/TestTags.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/TestTags.kt
@@ -19,6 +19,4 @@ const val REQUEST_PERMISSION_BUTTON = "RequestPermissionButton"
 const val CAMERA_PERMISSION_BUTTON = "CameraPermissionButton"
 const val RECORD_AUDIO_PERMISSION_BUTTON = "RecordAudioPermissionButton"
 
-const val READ_EXTERNAL_STORAGE_PERMISSION_BUTTON = "ReadExternalStoragePermissionButton"
-
 const val WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON = "WriteExternalStoragePermissionButton"

--- a/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/TestTags.kt
+++ b/feature/permissions/src/main/java/com/google/jetpackcamera/permissions/ui/TestTags.kt
@@ -20,3 +20,5 @@ const val CAMERA_PERMISSION_BUTTON = "CameraPermissionButton"
 const val RECORD_AUDIO_PERMISSION_BUTTON = "RecordAudioPermissionButton"
 
 const val READ_EXTERNAL_STORAGE_PERMISSION_BUTTON = "ReadExternalStoragePermissionButton"
+
+const val WRITE_EXTERNAL_STORAGE_PERMISSION_BUTTON = "WriteExternalStoragePermissionButton"

--- a/feature/permissions/src/main/res/values/strings.xml
+++ b/feature/permissions/src/main/res/values/strings.xml
@@ -15,16 +15,22 @@
   ~ limitations under the License.
   -->
 <resources>
-    <string name="camera_permission_screen_title">Enable Camera</string>
-    <string name="camera_permission_required_rationale">Please provide permission to access to the camera. It is necessary for this app to function.</string>
-    <string name="camera_permission_declined_rationale">The app requires the camera to function. To use this app, go to the app\'s settings and grant the camera permission.</string>
-
-    <string name="camera_permission_accessibility_text">An icon representing a camera</string>
     <string name="request_permission">Allow Access</string>
     <string name="navigate_to_settings">Open App Settings</string>
 
+    <string name="camera_permission_screen_title">Enable Camera</string>
+    <string name="camera_permission_required_rationale">Please provide permission to access to the camera. It is necessary for this app to function.</string>
+    <string name="camera_permission_declined_rationale">The app requires the camera to function. To use this app, go to the app\'s settings and grant the camera permission.</string>
+    <string name="camera_permission_accessibility_text">An icon representing a camera</string>
 
     <string name="microphone_permission_screen_title">Enable Audio Recording</string>
-    <string name="microphone_permission_required_rationale">Please provide permission to enable audio in video recording. Videos will be mute if this permission is revoked.</string>
+    <string name="microphone_permission_required_rationale">Please provide permission to enable audio in video recording. Videos will be mute if this permission is denied.</string>
     <string name="microphone_permission_accessibility_text">An icon representing a microphone</string>
+
+
+    <string name="read_storage_permission_screen_title">Allow App to Read External Storage</string>
+    <string name="read_storage_permission_required_rationale">Please provide permission to read external storage. You will be unable to view previously captured images or videos if this permission is denied.</string>
+    <string name="read_storage_permission_accessibility_text">An icon representing a file folder</string>
+
+
 </resources>

--- a/feature/permissions/src/main/res/values/strings.xml
+++ b/feature/permissions/src/main/res/values/strings.xml
@@ -27,10 +27,13 @@
     <string name="microphone_permission_required_rationale">Please provide permission to enable audio in video recording. Videos will be mute if this permission is denied.</string>
     <string name="microphone_permission_accessibility_text">An icon representing a microphone</string>
 
-
     <string name="read_storage_permission_screen_title">Allow App to Read External Storage</string>
     <string name="read_storage_permission_required_rationale">Please provide permission to read external storage. You will be unable to view previously captured images or videos if this permission is denied.</string>
     <string name="read_storage_permission_accessibility_text">An icon representing a file folder</string>
+
+    <string name="write_storage_permission_screen_title">Allow App to Write External Storage</string>
+    <string name="write_storage_permission_required_rationale">Please provide permission to write to external storage. You will be unable to save captured mages or videos if this permission is denied.</string>
+    <string name="write_storage_permission_accessibility_text">An icon representing a file folder</string>
 
 
 </resources>

--- a/feature/permissions/src/main/res/values/strings.xml
+++ b/feature/permissions/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2024 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,10 +25,6 @@
     <string name="microphone_permission_screen_title">Enable Audio Recording</string>
     <string name="microphone_permission_required_rationale">Please provide permission to enable audio in video recording. Videos will be mute if this permission is denied.</string>
     <string name="microphone_permission_accessibility_text">An icon representing a microphone</string>
-
-    <string name="read_storage_permission_screen_title">Allow App to Read External Storage</string>
-    <string name="read_storage_permission_required_rationale">Please provide permission to read external storage. You will be unable to view previously captured images or videos if this permission is denied.</string>
-    <string name="read_storage_permission_accessibility_text">An icon representing a file folder</string>
 
     <string name="write_storage_permission_screen_title">Allow App to Write External Storage</string>
     <string name="write_storage_permission_required_rationale">Please provide permission to write to external storage. You will be unable to save captured mages or videos if this permission is denied.</string>

--- a/feature/permissions/src/main/res/values/strings.xml
+++ b/feature/permissions/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2024 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -86,6 +86,10 @@ android {
 dependencies {
     // Reflect
     implementation(libs.kotlin.reflect)
+
+    // Accompanist - Permissions
+    implementation(libs.accompanist.permissions)
+
     // Compose
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -176,7 +176,7 @@ fun PreviewScreen(
                 android.Manifest.permission.READ_EXTERNAL_STORAGE
             )
 
-            LaunchedEffect(Unit) {
+            LaunchedEffect(readStoragePermission.status) {
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P ||
                     readStoragePermission.status.isGranted
                 ) {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera.feature.preview
 import android.annotation.SuppressLint
 import android.content.ContentResolver
 import android.net.Uri
+import android.os.Build
 import android.util.Log
 import androidx.camera.core.SurfaceRequest
 import androidx.compose.foundation.background
@@ -51,6 +52,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.tracing.Trace
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.isGranted
 import com.google.jetpackcamera.core.camera.VideoRecordingState
 import com.google.jetpackcamera.feature.preview.quicksettings.QuickSettingsScreenOverlay
 import com.google.jetpackcamera.feature.preview.ui.CameraControlsOverlay
@@ -73,12 +77,15 @@ import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.StreamConfig
 import com.google.jetpackcamera.settings.model.TYPICAL_SYSTEM_CONSTRAINTS
 import kotlinx.coroutines.flow.transformWhile
+import com.google.accompanist.permissions.rememberPermissionState
+
 
 private const val TAG = "PreviewScreen"
 
 /**
  * Screen used for the Preview feature.
  */
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun PreviewScreen(
     onNavigateToSettings: () -> Unit,
@@ -166,8 +173,10 @@ fun PreviewScreen(
                 isDebugMode = isDebugMode,
                 onImageWellClick = onNavigateToPostCapture
             )
+            val readStoragePermission: PermissionState = rememberPermissionState(android.Manifest.permission.READ_EXTERNAL_STORAGE)
 
             LaunchedEffect(Unit) {
+                if(Build.VERSION.SDK_INT > Build.VERSION_CODES.P || readStoragePermission.status.isGranted)
                 viewModel.updateLastCapturedMedia()
             }
         }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -55,6 +55,7 @@ import androidx.tracing.Trace
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import com.google.jetpackcamera.core.camera.VideoRecordingState
 import com.google.jetpackcamera.feature.preview.quicksettings.QuickSettingsScreenOverlay
 import com.google.jetpackcamera.feature.preview.ui.CameraControlsOverlay
@@ -77,8 +78,6 @@ import com.google.jetpackcamera.settings.model.LensFacing
 import com.google.jetpackcamera.settings.model.StreamConfig
 import com.google.jetpackcamera.settings.model.TYPICAL_SYSTEM_CONSTRAINTS
 import kotlinx.coroutines.flow.transformWhile
-import com.google.accompanist.permissions.rememberPermissionState
-
 
 private const val TAG = "PreviewScreen"
 
@@ -173,11 +172,16 @@ fun PreviewScreen(
                 isDebugMode = isDebugMode,
                 onImageWellClick = onNavigateToPostCapture
             )
-            val readStoragePermission: PermissionState = rememberPermissionState(android.Manifest.permission.READ_EXTERNAL_STORAGE)
+            val readStoragePermission: PermissionState = rememberPermissionState(
+                android.Manifest.permission.READ_EXTERNAL_STORAGE
+            )
 
             LaunchedEffect(Unit) {
-                if(Build.VERSION.SDK_INT > Build.VERSION_CODES.P || readStoragePermission.status.isGranted)
-                viewModel.updateLastCapturedMedia()
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P ||
+                    readStoragePermission.status.isGranted
+                ) {
+                    viewModel.updateLastCapturedMedia()
+                }
             }
         }
     }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -256,7 +256,7 @@ class PreviewViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val lastCapturedMediaDescriptor = mediaRepository.getLastCapturedMedia()
             _previewUiState.update { old ->
-                (old as PreviewUiState.Ready).copy(
+                (old as? PreviewUiState.Ready)?.copy(
                     imageWellUiState = ImageWellUiState.LastCapture(
                         mediaDescriptor = lastCapturedMediaDescriptor
                     )

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ImageWell.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/ImageWell.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.google.jetpackcamera.data.media.MediaDescriptor
 import kotlin.math.min
@@ -51,6 +52,7 @@ fun ImageWell(
             bitmap?.let {
                 Box(
                     modifier = modifier
+                        .testTag(IMAGE_WELL_TAG)
                         .size(120.dp)
                         .padding(18.dp)
                         .border(2.dp, Color.White, RoundedCornerShape(16.dp))

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/TestTags.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/ui/TestTags.kt
@@ -36,6 +36,9 @@ const val IMAGE_CAPTURE_UNSUPPORTED_CONCURRENT_CAMERA_TAG =
 const val VIDEO_CAPTURE_EXTERNAL_UNSUPPORTED_TAG = "VideoCaptureExternalUnsupportedTag"
 const val VIDEO_CAPTURE_SUCCESS_TAG = "VideoCaptureSuccessTag"
 const val VIDEO_CAPTURE_FAILURE_TAG = "VideoCaptureFailureTag"
+
+const val IMAGE_WELL_TAG = "ImageWellTag"
+
 const val PREVIEW_DISPLAY = "PreviewDisplay"
 const val SCREEN_FLASH_OVERLAY = "ScreenFlashOverlay"
 const val SETTINGS_BUTTON = "SettingsButton"

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -91,7 +91,8 @@ fun SettingsScreen(
         permissions =
         listOf(
             Manifest.permission.CAMERA,
-            Manifest.permission.RECORD_AUDIO
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.READ_EXTERNAL_STORAGE
         )
     )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ accompanist = "0.37.2"
 # kotlinPlugin and composeCompiler are linked
 # See https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 kotlinPlugin = "2.1.20"
-androidGradlePlugin = "8.11.0-alpha03"
+androidGradlePlugin = "8.11.0-alpha07"
 protobufPlugin = "0.9.5"
 
 androidxActivityCompose = "1.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ accompanist = "0.37.2"
 # kotlinPlugin and composeCompiler are linked
 # See https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 kotlinPlugin = "2.1.20"
-androidGradlePlugin = "8.11.0-alpha08"
+androidGradlePlugin = "8.11.0-alpha09"
 protobufPlugin = "0.9.5"
 
 androidxActivityCompose = "1.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ accompanist = "0.37.2"
 # kotlinPlugin and composeCompiler are linked
 # See https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 kotlinPlugin = "2.1.20"
-androidGradlePlugin = "8.11.0-alpha07"
+androidGradlePlugin = "8.11.0-alpha08"
 protobufPlugin = "0.9.5"
 
 androidxActivityCompose = "1.10.1"


### PR DESCRIPTION
Fixes #348

adds read/write permission screens.
Sometimes, granting the write permission will automatically grant the read permission as well. if that is the case, the read permission screen will be skipped. If not, the read permission screen will still be displayed