### PR TITLE
Remove a duplicated extension function.

### DIFF
--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -273,7 +273,6 @@ constructor(
                 .tryApplyFlashModeConstraints()
                 .tryApplyCaptureModeConstraints()
                 .tryApplyVideoQualityConstraints()
-                .tryApplyCaptureModeConstraints()
         if (isDebugMode && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             withContext(iODispatcher) {
                 val cameraPropertiesJSON =


### PR DESCRIPTION
This `tryApplyVideoQualityConstraints` function was added in #324 and it was applied twice.
See line 274 and 276
https://github.com/google/jetpack-camera-app/blob/668eac5183f545eb8d2a94c60e76787d284e6c23/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt#L274

https://github.com/google/jetpack-camera-app/blob/668eac5183f545eb8d2a94c60e76787d284e6c23/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt#L276