### PR TITLE
Fix SettingsDeviceTest

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/SettingsDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/SettingsDeviceTest.kt
@@ -93,8 +93,6 @@ class SettingsDeviceTest {
             assert(!uiDevice.findObject(By.res(componentTestTag)).isEnabled)
             // The settings component is disabled. Display componentDisabledMessage
             Log.d(TAG, componentDisabledMessage)
-        } finally {
-            uiDevice.pressBack()
         }
     }
 


### PR DESCRIPTION
This line is somehow causing waitUtil() to fail while waiting for the Capture Button in the beginning of a test.