### PR TITLE
Set exact parameter type

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -84,6 +84,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.LinkedList
+import kotlin.reflect.KProperty1
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
@@ -98,7 +99,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.reflect.KProperty1
 
 private const val TAG = "PreviewViewModel"
 private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"


### PR DESCRIPTION
Current in `CameraAppSettings.applyDiff` defined `settingExtractor` as CameraAppSettings.() -> R (edited in #346) , but it actual type is KProperty1 (e.g. `CameraAppSettings::cameraLensFacing`) so that I changed it to actual type.


https://github.com/google/jetpack-camera-app/blob/c99c8f40bf3a71a841e8ec7111bb229314b30258/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt#L349-L383


I'm not sure whether this change does any chance to occur #345 again.