### PR TITLE
Ignore returned values and remove context receiver in device tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,10 +95,6 @@ android {
             }
         }
     }
-
-    kotlinOptions {
-        freeCompilerArgs += "-Xcontext-receivers"
-    }
 }
 
 dependencies {

--- a/app/src/androidTest/java/com/google/jetpackcamera/ConcurrentCameraTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ConcurrentCameraTest.kt
@@ -18,7 +18,6 @@ import android.provider.MediaStore
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
@@ -333,7 +332,6 @@ class ConcurrentCameraTest {
         }
     }
 
-    context(SemanticsNodeInteractionsProvider)
     private fun SemanticsNode.fetchConcurrentCameraMode(): ConcurrentCameraMode {
         config[SemanticsProperties.ContentDescription].any { description ->
             when (description) {
@@ -349,7 +347,6 @@ class ConcurrentCameraTest {
         throw AssertionError("Unable to determine concurrent camera mode from quick settings")
     }
 
-    context(SemanticsNodeInteractionsProvider)
     private fun SemanticsNodeInteraction.assertConcurrentCameraMode(
         mode: ConcurrentCameraMode
     ): SemanticsNodeInteraction {

--- a/app/src/androidTest/java/com/google/jetpackcamera/SwitchCameraTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/SwitchCameraTest.kt
@@ -146,7 +146,7 @@ inline fun runFlipCameraTest(
     }
 
     // If flipping the camera is available, flip it. Otherwise skip test.
-    val unused = composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).assume(isEnabled()) {
+    composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).assume(isEnabled()) {
         "Device does not have multiple cameras to flip between."
     }
 

--- a/app/src/androidTest/java/com/google/jetpackcamera/SwitchCameraTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/SwitchCameraTest.kt
@@ -146,7 +146,7 @@ inline fun runFlipCameraTest(
     }
 
     // If flipping the camera is available, flip it. Otherwise skip test.
-    composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).assume(isEnabled()) {
+    val unused = composeTestRule.onNodeWithTag(FLIP_CAMERA_BUTTON).assume(isEnabled()) {
         "Device does not have multiple cameras to flip between."
     }
 

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
@@ -119,7 +119,7 @@ fun mediaStoreInsertedFlow(
             override fun onChange(selfChange: Boolean, uris: Collection<Uri>, flags: Int) {
                 uris.forEach { uri ->
                     queryWrittenFiles(uri).forEach {
-                        trySend(it)
+                        val unused = trySend(it)
                     }
                 }
             }

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.transform
 
-const val APP_TEST_UTIL_TAG = "AppTestUtil"
+private const val TAG = "AppTestUtil"
 
 internal val APP_REQUIRED_PERMISSIONS: List<String> = buildList {
     add(android.Manifest.permission.CAMERA)
@@ -124,7 +124,7 @@ fun mediaStoreInsertedFlow(
                     queryWrittenFiles(uri).forEach {
                         val result = trySend(it)
                         if (result.isFailure) {
-                            Log.d(APP_TEST_UTIL_TAG, "Media store change failed result: $result")
+                            Log.d(TAG, "Media store change failed result: $result")
                         }
                     }
                 }

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
@@ -22,6 +22,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.BaseColumns
 import android.provider.MediaStore
+import android.util.Log
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -119,7 +120,8 @@ fun mediaStoreInsertedFlow(
             override fun onChange(selfChange: Boolean, uris: Collection<Uri>, flags: Int) {
                 uris.forEach { uri ->
                     queryWrittenFiles(uri).forEach {
-                        val unused = trySend(it)
+                        val result = trySend(it)
+                        Log.d("AppTestUtil", "Media store change: $result")
                     }
                 }
             }

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
@@ -123,7 +123,9 @@ fun mediaStoreInsertedFlow(
                 uris.forEach { uri ->
                     queryWrittenFiles(uri).forEach {
                         val result = trySend(it)
-                        Log.d(TAG, "Media store change: $result")
+                        if (result.isFailure) {
+                            Log.d(TAG, "Media store change failed result: $result")
+                        }
                     }
                 }
             }

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.transform
 
-const val TAG = "AppTestUtil"
+const val APP_TEST_UTIL_TAG = "AppTestUtil"
 
 internal val APP_REQUIRED_PERMISSIONS: List<String> = buildList {
     add(android.Manifest.permission.CAMERA)
@@ -124,7 +124,7 @@ fun mediaStoreInsertedFlow(
                     queryWrittenFiles(uri).forEach {
                         val result = trySend(it)
                         if (result.isFailure) {
-                            Log.d(TAG, "Media store change failed result: $result")
+                            Log.d(APP_TEST_UTIL_TAG, "Media store change failed result: $result")
                         }
                     }
                 }

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/AppTestUtil.kt
@@ -28,6 +28,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.transform
 
+const val TAG = "AppTestUtil"
+
 internal val APP_REQUIRED_PERMISSIONS: List<String> = buildList {
     add(android.Manifest.permission.CAMERA)
     add(android.Manifest.permission.RECORD_AUDIO)
@@ -121,7 +123,7 @@ fun mediaStoreInsertedFlow(
                 uris.forEach { uri ->
                     queryWrittenFiles(uri).forEach {
                         val result = trySend(it)
-                        Log.d("AppTestUtil", "Media store change: $result")
+                        Log.d(TAG, "Media store change: $result")
                     }
                 }
             }

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.printToString
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.google.errorprone.annotations.CanIgnoreReturnValue
 import com.google.jetpackcamera.settings.R as SettingsR
 import com.google.jetpackcamera.settings.model.CaptureMode
 import com.google.jetpackcamera.settings.model.ConcurrentCameraMode
@@ -88,7 +89,7 @@ fun SemanticsNodeInteractionsProvider.onNodeWithContentDescription(
 /**
  * Fetch a string resources from a [SemanticsNodeInteractionsProvider] context.
  */
-fun SemanticsNodeInteractionsProvider.getResString(@StringRes strRes: Int): String =
+fun getResString(@StringRes strRes: Int): String =
     ApplicationProvider.getApplicationContext<Context>().getString(strRes)
 
 /**
@@ -269,7 +270,7 @@ inline fun <reified T> ComposeTestRule.checkComponentContentDescriptionState(
     waitForNodeWithTag(nodeTag)
     onNodeWithTag(nodeTag).assume(isEnabled())
         .fetchSemanticsNode().let { node ->
-            node.config[SemanticsProperties.ContentDescription].any { description ->
+            val unused = node.config[SemanticsProperties.ContentDescription].any { description ->
                 block(description)?.let { result ->
                     // Return the T value if block returns non-null.
                     return@checkComponentContentDescriptionState result
@@ -289,7 +290,7 @@ inline fun <reified T> ComposeTestRule.checkComponentStateDescriptionState(
             block(node.config[SemanticsProperties.StateDescription])?.let { result ->
                 // Return the T value if block returns non-null.
                 return@checkComponentStateDescriptionState result
-            } ?: false
+            }
             throw AssertionError("Unable to determine state from component")
         }
 }
@@ -313,7 +314,7 @@ fun ComposeTestRule.getCurrentLensFacing(): LensFacing = visitQuickSettings {
     onNodeWithTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON).fetchSemanticsNode(
         "Flip camera button is not visible when expected."
     ).let { node ->
-        node.config[SemanticsProperties.ContentDescription].any { description ->
+        val unused = node.config[SemanticsProperties.ContentDescription].any { description ->
             when (description) {
                 getResString(CaptureR.string.quick_settings_front_camera_description) ->
                     return@let LensFacing.FRONT
@@ -332,7 +333,7 @@ fun ComposeTestRule.getCurrentFlashMode(): FlashMode = visitQuickSettings {
     onNodeWithTag(QUICK_SETTINGS_FLASH_BUTTON).fetchSemanticsNode(
         "Flash button is not visible when expected."
     ).let { node ->
-        node.config[SemanticsProperties.ContentDescription].any { description ->
+        val unused = node.config[SemanticsProperties.ContentDescription].any { description ->
             when (description) {
                 getResString(CaptureR.string.quick_settings_flash_off_description) ->
                     return@let FlashMode.OFF
@@ -359,7 +360,7 @@ fun ComposeTestRule.getConcurrentState(): ConcurrentCameraMode = visitQuickSetti
         .fetchSemanticsNode(
             "Concurrent camera button is not visible when expected."
         ).let { node ->
-            node.config[SemanticsProperties.ContentDescription].any { description ->
+            val unused = node.config[SemanticsProperties.ContentDescription].any { description ->
                 when (description) {
                     getResString(
                         CaptureR.string.quick_settings_description_concurrent_camera_off
@@ -388,7 +389,7 @@ fun ComposeTestRule.getCurrentCaptureMode(): CaptureMode = visitQuickSettings {
     onNodeWithTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE).fetchSemanticsNode(
         "Capture mode button is not visible when expected."
     ).let { node ->
-        node.config[SemanticsProperties.ContentDescription].any { description ->
+        val unused = node.config[SemanticsProperties.ContentDescription].any { description ->
             // check description is one of the capture modes
             when (description) {
                 getResString(CaptureR.string.quick_settings_description_capture_mode_standard) ->
@@ -478,7 +479,7 @@ fun SettingsScreenScope.selectLensFacing(lensFacing: LensFacing) {
                 )
             }
             if (!hasStateDescription(expectedContentDescription).matches(fetchSemanticsNode())) {
-                assume(isEnabled()) { "$lensFacing is not selectable" }
+                val unused = assume(isEnabled()) { "$lensFacing is not selectable" }
                 performClick()
             }
 
@@ -508,7 +509,8 @@ inline fun <T> SettingsScreenScope.visitSettingDialog(
                 }
             }
 
-            assume(isEnabled()) { disabledMessage ?: "Setting $settingTestTag is not enabled" }
+            val unused =
+                assume(isEnabled()) { disabledMessage ?: "Setting $settingTestTag is not enabled" }
             performClick()
         }
 
@@ -539,6 +541,7 @@ inline fun <T> SettingsScreenScope.visitSettingDialog(
  * Navigates to quick settings if not already there and perform action from provided block.
  * This will return from quick settings if not already there, or remain on quick settings if there.
  */
+@CanIgnoreReturnValue
 inline fun <T> ComposeTestRule.visitQuickSettings(crossinline block: ComposeTestRule.() -> T): T {
     var needReturnFromQuickSettings = false
     onNodeWithContentDescription(CaptureR.string.quick_settings_dropdown_closed_description).apply {

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -271,13 +271,12 @@ inline fun <reified T> ComposeTestRule.checkComponentContentDescriptionState(
     waitForNodeWithTag(nodeTag)
     onNodeWithTag(nodeTag).assume(isEnabled())
         .fetchSemanticsNode().let { node ->
-            val unused =
-                node.config[SemanticsProperties.ContentDescription].forEach { description ->
-                    block(description)?.let { result ->
-                        // Return the T value if block returns non-null.
-                        return@checkComponentContentDescriptionState result
-                    }
+            node.config[SemanticsProperties.ContentDescription].forEach { description ->
+                block(description)?.let { result ->
+                    // Return the T value if block returns non-null.
+                    return@checkComponentContentDescriptionState result
                 }
+            }
             throw AssertionError("Unable to determine state from quick settingz")
         }
 }
@@ -317,7 +316,7 @@ fun ComposeTestRule.getCurrentLensFacing(): LensFacing = visitQuickSettings {
     onNodeWithTag(QUICK_SETTINGS_FLIP_CAMERA_BUTTON).fetchSemanticsNode(
         "Flip camera button is not visible when expected."
     ).let { node ->
-        val unused = node.config[SemanticsProperties.ContentDescription].forEach { description ->
+        node.config[SemanticsProperties.ContentDescription].forEach { description ->
             when (description) {
                 getResString(CaptureR.string.quick_settings_front_camera_description) ->
                     return@let LensFacing.FRONT
@@ -334,7 +333,7 @@ fun ComposeTestRule.getCurrentFlashMode(): FlashMode = visitQuickSettings {
     onNodeWithTag(QUICK_SETTINGS_FLASH_BUTTON).fetchSemanticsNode(
         "Flash button is not visible when expected."
     ).let { node ->
-        val unused = node.config[SemanticsProperties.ContentDescription].forEach { description ->
+        node.config[SemanticsProperties.ContentDescription].forEach { description ->
             when (description) {
                 getResString(CaptureR.string.quick_settings_flash_off_description) ->
                     return@let FlashMode.OFF
@@ -359,21 +358,20 @@ fun ComposeTestRule.getConcurrentState(): ConcurrentCameraMode = visitQuickSetti
         .fetchSemanticsNode(
             "Concurrent camera button is not visible when expected."
         ).let { node ->
-            val unused =
-                node.config[SemanticsProperties.ContentDescription].forEach { description ->
-                    when (description) {
-                        getResString(
-                            CaptureR.string.quick_settings_description_concurrent_camera_off
-                        ) -> {
-                            return@let ConcurrentCameraMode.OFF
-                        }
-
-                        getResString(
-                            CaptureR.string.quick_settings_description_concurrent_camera_dual
-                        ) ->
-                            return@let ConcurrentCameraMode.DUAL
+            node.config[SemanticsProperties.ContentDescription].forEach { description ->
+                when (description) {
+                    getResString(
+                        CaptureR.string.quick_settings_description_concurrent_camera_off
+                    ) -> {
+                        return@let ConcurrentCameraMode.OFF
                     }
+
+                    getResString(
+                        CaptureR.string.quick_settings_description_concurrent_camera_dual
+                    ) ->
+                        return@let ConcurrentCameraMode.DUAL
                 }
+            }
             throw AssertionError(
                 "Unable to determine concurrent camera mode from quick settings"
             )
@@ -387,7 +385,7 @@ fun ComposeTestRule.getCurrentCaptureMode(): CaptureMode = visitQuickSettings {
     onNodeWithTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE).fetchSemanticsNode(
         "Capture mode button is not visible when expected."
     ).let { node ->
-        val unused = node.config[SemanticsProperties.ContentDescription].forEach { description ->
+        node.config[SemanticsProperties.ContentDescription].forEach { description ->
             // check description is one of the capture modes
             when (description) {
                 getResString(CaptureR.string.quick_settings_description_capture_mode_standard) ->

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/UiTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/UiTestUtil.kt
@@ -37,6 +37,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
 import com.google.common.truth.Truth.assertWithMessage
+import com.google.errorprone.annotations.CanIgnoreReturnValue
 import com.google.jetpackcamera.MainActivity
 import java.io.File
 import java.net.URLConnection
@@ -220,6 +221,7 @@ fun getTestUri(directoryPath: String, timeStamp: Long, suffix: String): Uri = Ur
 /**
  * @return - true if all eligible files were successfully deleted. False otherwise
  */
+@CanIgnoreReturnValue
 fun deleteFilesInDirAfterTimestamp(
     directoryPath: String,
     instrumentation: Instrumentation,


### PR DESCRIPTION
Add @IgnoreReturnValue to visitQuickSettings() and set unused return values to "val unused".

Removed the context receiver usage in ConcurrentCameraTest.
