### PR TITLE
Fix double tap lens flipping bug

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -370,13 +369,13 @@ private fun ContentScreen(
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) {
-        val flipLensState by rememberUpdatedState(
-            captureUiState.flipLensUiState
-        )
         val onFlipCamera = {
-            if (flipLensState is FlipLensUiState.Available) {
+            if (captureUiState.flipLensUiState is FlipLensUiState.Available) {
                 onSetLensFacing(
-                    (flipLensState as FlipLensUiState.Available).selectedLensFacing.flip()
+                    (
+                        captureUiState.flipLensUiState as FlipLensUiState.Available
+                        )
+                        .selectedLensFacing.flip()
                 )
             }
         }

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -369,13 +370,13 @@ private fun ContentScreen(
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) {
+        val flipLensState by rememberUpdatedState(
+            captureUiState.flipLensUiState
+        )
         val onFlipCamera = {
-            if (captureUiState.flipLensUiState is FlipLensUiState.Available) {
+            if (flipLensState is FlipLensUiState.Available) {
                 onSetLensFacing(
-                    (
-                        captureUiState.flipLensUiState as FlipLensUiState.Available
-                        )
-                        .selectedLensFacing.flip()
+                    (flipLensState as FlipLensUiState.Available).selectedLensFacing.flip()
                 )
             }
         }

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureScreenComponents.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureScreenComponents.kt
@@ -453,7 +453,7 @@ fun PreviewDisplay(
                 CameraXViewfinder(
                     modifier = Modifier
                         .fillMaxSize()
-                        .pointerInput(Unit) {
+                        .pointerInput(onFlipCamera) {
                             detectTapGestures(
                                 onDoubleTap = { offset ->
                                     // double tap to flip camera


### PR DESCRIPTION
In #363, the rememberUpdatedState() was removed. This cause the flipLensUiState used here being not updated. Use rememberUpdatedState() to track the updated uiState.

#381 shows the debugging process