### PR TITLE
Introduce SaveLocation to replace URI / boolean

### DIFF
--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCaseTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCaseTest.kt
@@ -31,6 +31,7 @@ import com.google.jetpackcamera.core.camera.utils.APP_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.Illuminant
 import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.settings.ConstraintsRepository
 import com.google.jetpackcamera.settings.SettableConstraintsRepository
 import com.google.jetpackcamera.settings.SettableConstraintsRepositoryImpl
@@ -172,12 +173,6 @@ class CameraXCameraUseCaseTest {
         providePreviewSurface()
     }
 
-    private suspend fun CompletableDeferred<*>.await(timeoutMs: Long = GENERAL_TIMEOUT_MS) =
-        withTimeoutOrNull(timeoutMs) {
-            await()
-            Unit
-        } ?: fail("Timeout while waiting for the Deferred to complete")
-
     private suspend fun <T> ReceiveChannel<T>.awaitValue(
         expectedValue: T,
         timeoutMs: Long = GENERAL_TIMEOUT_MS
@@ -191,10 +186,7 @@ class CameraXCameraUseCaseTest {
         onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
     ) {
         // Start recording
-        startVideoRecording(
-            videoCaptureUri = null,
-            shouldUseUri = false
-        ) { event ->
+        startVideoRecording(SaveLocation.Default) { event ->
             // Track files that need to be deleted
             if (event is OnVideoRecorded) {
                 val videoUri = event.savedUri
@@ -250,7 +242,7 @@ class CameraXCameraUseCaseTest {
                 ContentResolver.SCHEME_CONTENT -> {
                     try {
                         context.contentResolver.delete(uri, null, null)
-                    } catch (e: RuntimeException) {
+                    } catch (_: RuntimeException) {
                         // Ignore any exception.
                     }
                 }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -25,7 +25,6 @@ import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
-import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
 import android.provider.MediaStore
@@ -76,6 +75,7 @@ import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.LowLightBoostState
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.TestPattern
@@ -744,63 +744,64 @@ private fun getPendingRecording(
     videoCaptureUseCase: VideoCapture<Recorder>,
     maxDurationMillis: Long,
     captureTypeSuffix: String,
-    videoCaptureUri: Uri?,
-    shouldUseUri: Boolean,
+    saveLocation: SaveLocation,
     onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
 ): PendingRecording? {
     Log.d(TAG, "getPendingRecording")
-
-    return if (shouldUseUri) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            try {
-                videoCaptureUseCase.output.prepareRecording(
-                    context,
-                    FileDescriptorOutputOptions.Builder(
-                        context.applicationContext.contentResolver.openFileDescriptor(
-                            videoCaptureUri!!,
-                            "rw"
-                        )!!
-                    ).build()
-                )
-            } catch (e: Exception) {
-                onVideoRecord(
-                    CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(e)
-                )
-                null
-            }
-        } else {
-            if (videoCaptureUri?.scheme == "file") {
-                val fileOutputOptions = FileOutputOptions.Builder(
-                    File(videoCaptureUri.path!!)
-                ).build()
-                videoCaptureUseCase.output.prepareRecording(context, fileOutputOptions)
-            } else {
-                onVideoRecord(
-                    CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(
-                        RuntimeException("Uri scheme not supported.")
+    return when (saveLocation) {
+        is SaveLocation.Explicit ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                try {
+                    videoCaptureUseCase.output.prepareRecording(
+                        context,
+                        FileDescriptorOutputOptions.Builder(
+                            context.applicationContext.contentResolver.openFileDescriptor(
+                                saveLocation.locationUri,
+                                "rw"
+                            )!!
+                        ).build()
                     )
-                )
-                null
-            }
-        }
-    } else {
-        val name = "JCA-recording-${Date()}-$captureTypeSuffix.mp4"
-        val contentValues =
-            ContentValues().apply {
-                put(MediaStore.Video.Media.DISPLAY_NAME, name)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // Android 10+
-                    put(MediaStore.Video.Media.RELATIVE_PATH, getDefaultMediaSaveLocation())
+                } catch (e: Exception) {
+                    onVideoRecord(
+                        CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(e)
+                    )
+                    null
+                }
+            } else {
+                if (saveLocation.locationUri.scheme == "file") {
+                    val fileOutputOptions = FileOutputOptions.Builder(
+                        File(saveLocation.locationUri.path!!)
+                    ).build()
+                    videoCaptureUseCase.output.prepareRecording(context, fileOutputOptions)
+                } else {
+                    onVideoRecord(
+                        CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(
+                            RuntimeException("Uri scheme not supported.")
+                        )
+                    )
+                    null
                 }
             }
-        val mediaStoreOutput =
-            MediaStoreOutputOptions.Builder(
-                context.contentResolver,
-                MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-            )
-                .setDurationLimitMillis(maxDurationMillis)
-                .setContentValues(contentValues)
-                .build()
-        videoCaptureUseCase.output.prepareRecording(context, mediaStoreOutput)
+
+        is SaveLocation.Default -> {
+            val name = "JCA-recording-${Date()}-$captureTypeSuffix.mp4"
+            val contentValues =
+                ContentValues().apply {
+                    put(MediaStore.Video.Media.DISPLAY_NAME, name)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // Android 10+
+                        put(MediaStore.Video.Media.RELATIVE_PATH, getDefaultMediaSaveLocation())
+                    }
+                }
+            val mediaStoreOutput =
+                MediaStoreOutputOptions.Builder(
+                    context.contentResolver,
+                    MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+                )
+                    .setDurationLimitMillis(maxDurationMillis)
+                    .setContentValues(contentValues)
+                    .build()
+            videoCaptureUseCase.output.prepareRecording(context, mediaStoreOutput)
+        }
     }
 }
 
@@ -981,9 +982,8 @@ private suspend fun runVideoRecording(
     context: Context,
     maxDurationMillis: Long,
     transientSettings: StateFlow<TransientSessionSettings?>,
-    videoCaptureUri: Uri?,
+    saveLocation: SaveLocation,
     videoControlEvents: Channel<VideoCaptureControlEvent>,
-    shouldUseUri: Boolean,
     onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
 ) = coroutineScope {
     var currentSettings = transientSettings.filterNotNull().first()
@@ -993,8 +993,7 @@ private suspend fun runVideoRecording(
         videoCapture,
         maxDurationMillis,
         captureTypeSuffix,
-        videoCaptureUri,
-        shouldUseUri,
+        saveLocation,
         onVideoRecord
     )?.let {
         startVideoRecordingInternal(
@@ -1087,9 +1086,8 @@ internal suspend fun processVideoControlEvents(
                     context,
                     event.maxVideoDuration,
                     transientSettings,
-                    event.videoCaptureUri,
+                    event.saveLocation,
                     videoCaptureControlEvents,
-                    event.shouldUseUri,
                     event.onVideoRecord
                 )
             }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraUseCase.kt
@@ -29,6 +29,7 @@ import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.LowLightBoostState
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.TestPattern
@@ -69,15 +70,13 @@ interface CameraUseCase {
      * location if the uri is not null. If it is null, an error will be thrown.
      */
     suspend fun takePicture(
-        onCaptureStarted: (() -> Unit) = {},
         contentResolver: ContentResolver,
-        imageCaptureUri: Uri?,
-        ignoreUri: Boolean = false
+        saveLocation: SaveLocation,
+        onCaptureStarted: (() -> Unit) = {}
     ): ImageCapture.OutputFileResults
 
     suspend fun startVideoRecording(
-        videoCaptureUri: Uri?,
-        shouldUseUri: Boolean,
+        saveLocation: SaveLocation,
         onVideoRecord: (OnVideoRecordEvent) -> Unit
     )
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraUseCase.kt
@@ -19,9 +19,7 @@ import android.app.Application
 import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
-import android.net.Uri
 import android.os.Build
-import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import android.util.Range
@@ -32,7 +30,6 @@ import androidx.camera.core.CameraXConfig
 import androidx.camera.core.DynamicRange as CXDynamicRange
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCapture.OutputFileOptions
-import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.SurfaceRequest
 import androidx.camera.core.takePicture
 import androidx.camera.lifecycle.ExperimentalCameraProviderConfiguration
@@ -55,6 +52,7 @@ import com.google.jetpackcamera.model.Illuminant
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.LensToZoom
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.TestPattern
@@ -104,8 +102,8 @@ class CameraXCameraUseCase
 @Inject
 constructor(
     private val application: Application,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
-    @IODispatcher private val iODispatcher: CoroutineDispatcher,
+    @param:DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @param:IODispatcher private val iODispatcher: CoroutineDispatcher,
     private val constraintsRepository: SettableConstraintsRepository
 ) : CameraUseCase {
     private lateinit var cameraProvider: ProcessCameraProvider
@@ -465,109 +463,74 @@ constructor(
 
     // TODO(b/319733374): Return bitmap for external mediastore capture without URI
     override suspend fun takePicture(
-        onCaptureStarted: (() -> Unit),
         contentResolver: ContentResolver,
-        imageCaptureUri: Uri?,
-        ignoreUri: Boolean
-    ): ImageCapture.OutputFileResults {
-        if (imageCaptureUseCase == null) {
-            throw RuntimeException("Attempted take picture with null imageCapture use case")
-        }
-        val eligibleContentValues = getEligibleContentValues()
-        val outputFileOptions: OutputFileOptions
-        if (ignoreUri) {
-            val formatter = SimpleDateFormat(
-                "yyyy-MM-dd-HH-mm-ss-SSS",
-                Locale.US
-            )
-            val filename = "JCA-${formatter.format(Calendar.getInstance().time)}.jpg"
-            val contentValues = ContentValues()
-            contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
-            contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // Android 10+
-                contentValues.put(
-                    MediaStore.Images.Media.RELATIVE_PATH,
-                    getDefaultMediaSaveLocation()
+        saveLocation: SaveLocation,
+        onCaptureStarted: (() -> Unit)
+    ): ImageCapture.OutputFileResults = imageCaptureUseCase?.let { imageCaptureUseCase ->
+        when (saveLocation) {
+            is SaveLocation.Default -> {
+                val formatter = SimpleDateFormat(
+                    "yyyy-MM-dd-HH-mm-ss-SSS",
+                    Locale.US
+                )
+                val filename = "JCA-${formatter.format(Calendar.getInstance().time)}.jpg"
+                val contentValues = ContentValues()
+                contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
+                contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+                val relativePath = getDefaultMediaSaveLocation()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // Android 10+
+                    contentValues.put(
+                        MediaStore.Images.Media.RELATIVE_PATH,
+                        relativePath
+                    )
+                }
+                val outputFileOptions = OutputFileOptions.Builder(
+                    contentResolver,
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                    contentValues
+                ).build()
+                imageCaptureUseCase.takePicture(
+                    outputFileOptions,
+                    onCaptureStarted
                 )
             }
-            outputFileOptions = OutputFileOptions.Builder(
-                contentResolver,
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                contentValues
-            ).build()
-        } else if (imageCaptureUri == null) {
-            val e = RuntimeException("Null Uri is provided.")
-            Log.d(TAG, "takePicture onError: $e")
-            throw e
-        } else {
-            try {
-                val outputStream = contentResolver.openOutputStream(imageCaptureUri)
-                if (outputStream != null) {
-                    outputFileOptions =
-                        OutputFileOptions.Builder(
-                            contentResolver.openOutputStream(imageCaptureUri)!!
-                        ).build()
-                } else {
-                    val e = RuntimeException("Provider recently crashed.")
+
+            is SaveLocation.Explicit -> {
+                try {
+                    val imageCaptureUri = saveLocation.locationUri
+                    val outputStream = contentResolver.openOutputStream(imageCaptureUri)
+                    if (outputStream != null) {
+                        outputStream.use { stream ->
+                            val outputFileOptions = OutputFileOptions.Builder(stream).build()
+                            imageCaptureUseCase.takePicture(
+                                outputFileOptions,
+                                onCaptureStarted
+                            )
+                        }
+                    } else {
+                        val e = RuntimeException("Provider recently crashed.")
+                        Log.d(TAG, "takePicture onError: $e")
+                        throw e
+                    }
+                } catch (e: FileNotFoundException) {
                     Log.d(TAG, "takePicture onError: $e")
                     throw e
                 }
-            } catch (e: FileNotFoundException) {
-                Log.d(TAG, "takePicture onError: $e")
-                throw e
+            }
+        }.also { outputFileResults ->
+            outputFileResults.savedUri?.let {
+                Log.d(TAG, "Saved image to ${outputFileResults.savedUri}")
             }
         }
-        try {
-            val outputFileResults = imageCaptureUseCase!!.takePicture(
-                outputFileOptions,
-                onCaptureStarted
-            )
-            val relativePath =
-                eligibleContentValues.getAsString(MediaStore.Images.Media.RELATIVE_PATH)
-            val displayName = eligibleContentValues.getAsString(
-                MediaStore.Images.Media.DISPLAY_NAME
-            )
-            Log.d(TAG, "Saved image to $relativePath/$displayName")
-            return outputFileResults
-        } catch (exception: ImageCaptureException) {
-            Log.d(TAG, "takePicture onError: $exception")
-            throw exception
-        }
-    }
-
-    private fun getEligibleContentValues(): ContentValues {
-        val eligibleContentValues = ContentValues()
-        eligibleContentValues.put(
-            MediaStore.Images.Media.DISPLAY_NAME,
-            Calendar.getInstance().time.toString()
-        )
-        eligibleContentValues.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
-        val saveLocation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // Android 10+
-            getDefaultMediaSaveLocation()
-        } else {
-            Environment.DIRECTORY_PICTURES
-        }
-        eligibleContentValues.put(
-            MediaStore.Images.Media.RELATIVE_PATH,
-            saveLocation
-        )
-        return eligibleContentValues
-    }
+    } ?: throw RuntimeException("Attempted take picture with null imageCapture use case")
 
     override suspend fun startVideoRecording(
-        videoCaptureUri: Uri?,
-        shouldUseUri: Boolean,
+        saveLocation: SaveLocation,
         onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
     ) {
-        if (shouldUseUri && videoCaptureUri == null) {
-            val e = RuntimeException("Null Uri is provided.")
-            Log.d(TAG, "takePicture onError: $e")
-            throw e
-        }
         videoCaptureControlEvents.send(
             VideoCaptureControlEvent.StartRecordingEvent(
-                videoCaptureUri,
-                shouldUseUri,
+                saveLocation,
                 currentSettings.value?.maxVideoDurationMillis
                     ?: UNLIMITED_VIDEO_DURATION,
                 onVideoRecord = onVideoRecord

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/VideoCaptureControlEvent.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/VideoCaptureControlEvent.kt
@@ -15,7 +15,7 @@
  */
 package com.google.jetpackcamera.core.camera
 
-import android.net.Uri
+import com.google.jetpackcamera.model.SaveLocation
 
 /**
  * Represents events that control video capture operations.
@@ -28,8 +28,7 @@ sealed interface VideoCaptureControlEvent {
      * @param onVideoRecord Callback to handle video recording events.
      */
     class StartRecordingEvent(
-        val videoCaptureUri: Uri?,
-        val shouldUseUri: Boolean,
+        val saveLocation: SaveLocation,
         val maxVideoDuration: Long,
         val onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
     ) : VideoCaptureControlEvent

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraUseCase.kt
@@ -17,7 +17,6 @@ package com.google.jetpackcamera.core.camera.test
 
 import android.annotation.SuppressLint
 import android.content.ContentResolver
-import android.net.Uri
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.SurfaceRequest
 import com.google.jetpackcamera.core.camera.CameraState
@@ -31,6 +30,7 @@ import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.TestPattern
@@ -114,10 +114,9 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
 
     @SuppressLint("RestrictedApi")
     override suspend fun takePicture(
-        onCaptureStarted: (() -> Unit),
         contentResolver: ContentResolver,
-        imageCaptureUri: Uri?,
-        ignoreUri: Boolean
+        saveLocation: SaveLocation,
+        onCaptureStarted: () -> Unit
     ): ImageCapture.OutputFileResults {
         takePicture(onCaptureStarted)
         return ImageCapture.OutputFileResults(null)
@@ -128,8 +127,7 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
     }
 
     override suspend fun startVideoRecording(
-        videoCaptureUri: Uri?,
-        shouldUseUri: Boolean,
+        saveLocation: SaveLocation,
         onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
     ) {
         if (!useCasesBinded) {

--- a/core/model/src/main/java/com/google/jetpackcamera/model/SaveLocation.kt
+++ b/core/model/src/main/java/com/google/jetpackcamera/model/SaveLocation.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.model
+
+import android.net.Uri
+
+/**
+ * Represents the intended save location strategy for captured media.
+ */
+sealed interface SaveLocation {
+
+    /**
+     * Indicates that the application's default logic for capturing media
+     * should determine the save location and filename. The CameraUseCase typically
+     * creates a new entry in the MediaStore with a generated name.
+     */
+    object Default : SaveLocation
+
+    /**
+     * Specifies a fully-defined [Uri] where the captured media should be saved.
+     * The CameraUseCase will pass this Uri directly to the underlying camera API.
+     *
+     * @property locationUri The non-null, complete [Uri] for the output file.
+     */
+    data class Explicit(val locationUri: Uri) : SaveLocation
+}

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -39,6 +39,7 @@ import com.google.jetpackcamera.model.ExternalCaptureMode
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.TestPattern
 import com.google.jetpackcamera.settings.ConstraintsRepository
@@ -534,9 +535,14 @@ class PreviewViewModel @AssistedInject constructor(
                     }
                     Pair(externalUriIndex, uri)
                 } ?: Pair(-1, imageCaptureUri)
+            val saveLocation = if (finalImageUri == null) {
+                SaveLocation.Default
+            } else {
+                SaveLocation.Explicit(finalImageUri)
+            }
             captureImageInternal(
                 doTakePicture = {
-                    cameraUseCase.takePicture({
+                    cameraUseCase.takePicture(contentResolver, saveLocation) {
                         _captureUiState.update { old ->
                             (old as? CaptureUiState.Ready)?.copy(
                                 previewDisplayUiState = PreviewDisplayUiState(
@@ -545,7 +551,7 @@ class PreviewViewModel @AssistedInject constructor(
                                 )
                             ) ?: old
                         }
-                    }, contentResolver, finalImageUri, ignoreUri).savedUri
+                    }.savedUri
                 },
                 onSuccess = { savedUri ->
                     updateLastCapturedMedia()
@@ -642,7 +648,12 @@ class PreviewViewModel @AssistedInject constructor(
         recordingJob = viewModelScope.launch {
             val cookie = "Video-${videoCaptureStartedCount.incrementAndGet()}"
             try {
-                cameraUseCase.startVideoRecording(videoCaptureUri, shouldUseUri) {
+                val saveLocation = if (videoCaptureUri == null || !shouldUseUri) {
+                    SaveLocation.Default
+                } else {
+                    SaveLocation.Explicit(videoCaptureUri)
+                }
+                cameraUseCase.startVideoRecording(saveLocation) {
                     var snackbarToShow: SnackbarData?
                     when (it) {
                         is CameraUseCase.OnVideoRecordEvent.OnVideoRecorded -> {

--- a/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/capture/ScreenFlashTest.kt
+++ b/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/capture/ScreenFlashTest.kt
@@ -21,6 +21,7 @@ import com.google.jetpackcamera.core.camera.CameraUseCase
 import com.google.jetpackcamera.core.camera.test.FakeCameraUseCase
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.ui.components.capture.ScreenFlash
 import com.google.jetpackcamera.ui.components.capture.capture.rules.MainDispatcherRule
@@ -73,7 +74,7 @@ class ScreenFlashTest {
         cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
         cameraUseCase.setFlashMode(FlashMode.ON)
         val contentResolver: ContentResolver = Mockito.mock()
-        cameraUseCase.takePicture({}, contentResolver, null)
+        cameraUseCase.takePicture(contentResolver, SaveLocation.Default)
 
         advanceUntilIdle()
         assertThat(states.map { it.enabled }).containsExactlyElementsIn(


### PR DESCRIPTION
- **New `SaveLocation` Sealed Interface:**
  - `SaveLocation.Default`: Indicates that the CameraUseCase should use its default logic for determining the save location and filename (typically a new entry in the MediaStore).
  - `SaveLocation.Explicit(locationUri: Uri)`: Specifies a fully-defined `Uri` where the captured media should be saved.
   
- **`CameraUseCase` API Changes:**
  - `takePicture`: The signature now accepts `saveLocation: SaveLocation` instead of `imageCaptureUri: Uri?` and `ignoreUri: Boolean`.
  - `startVideoRecording`: The signature now accepts `saveLocation: SaveLocation` instead of `videoCaptureUri: Uri?` and `shouldUseUri: Boolean`.
  - Implementations (`CameraXCameraUseCase`, `FakeCameraUseCase`) have been updated to handle the new `SaveLocation` types.
    
- **Updated Call Sites:**
  - `PreviewViewModel` has been updated to construct and pass the appropriate `SaveLocation` type to `CameraUseCase` methods based on whether an explicit URI is provided for external capture.
  - `VideoCaptureControlEvent.StartRecordingEvent` now carries a `SaveLocation` object.
  - Test (`ScreenFlashTest`) updated to reflect the API change.
    
This refactoring improves the clarity and maintainability of the capture process by centralizing the save destination logic and making the intent more explicit at the call site. It also removes the need for boolean flags to control URI usage.