### PR TITLE
Rename CameraUseCase to CameraSystem

### DIFF
--- a/benchmark/src/main/java/com/google/jetpackcamera/benchmark/ImageCaptureLatencyBenchmark.kt
+++ b/benchmark/src/main/java/com/google/jetpackcamera/benchmark/ImageCaptureLatencyBenchmark.kt
@@ -68,7 +68,7 @@ class ImageCaptureLatencyBenchmark {
     /**
      * Measures the time between an onClick event on the Capture Button and onImageCapture
      * callback being fired from
-     * [takePicture][com.google.jetpackcamera.domain.camera.CameraXCameraUseCase.takePicture].
+     * [com.google.jetpackcamera.camera.core.CameraXCameraSystem.takePicture].
      *
      *  @param shouldFaceFront the direction the camera should be facing.
      *  @param flashMode the designated [FlashMode] for the camera.

--- a/benchmark/src/main/java/com/google/jetpackcamera/benchmark/ImageCaptureLatencyBenchmark.kt
+++ b/benchmark/src/main/java/com/google/jetpackcamera/benchmark/ImageCaptureLatencyBenchmark.kt
@@ -68,7 +68,7 @@ class ImageCaptureLatencyBenchmark {
     /**
      * Measures the time between an onClick event on the Capture Button and onImageCapture
      * callback being fired from
-     * [com.google.jetpackcamera.camera.core.CameraXCameraSystem.takePicture].
+     * [takePicture][com.google.jetpackcamera.core.camera.CameraXCameraSystem.takePicture].
      *
      *  @param shouldFaceFront the direction the camera should be facing.
      *  @param flashMode the designated [FlashMode] for the camera.

--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
@@ -25,8 +25,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
-import com.google.jetpackcamera.core.camera.CameraSystem.OnVideoRecordEvent.OnVideoRecordError
-import com.google.jetpackcamera.core.camera.CameraSystem.OnVideoRecordEvent.OnVideoRecorded
+import com.google.jetpackcamera.core.camera.OnVideoRecordEvent.OnVideoRecordError
+import com.google.jetpackcamera.core.camera.OnVideoRecordEvent.OnVideoRecorded
 import com.google.jetpackcamera.core.camera.utils.APP_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.Illuminant
@@ -188,7 +188,7 @@ class CameraXCameraSystemTest {
     } ?: fail("Timeout while waiting for expected value: $expectedValue")
 
     private suspend fun CameraXCameraSystem.startRecording(
-        onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
+        onVideoRecord: (OnVideoRecordEvent) -> Unit
     ) {
         // Start recording
         startVideoRecording(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraModule.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraModule.kt
@@ -27,5 +27,5 @@ import dagger.hilt.android.components.ViewModelComponent
 @InstallIn(ViewModelComponent::class)
 interface CameraModule {
     @Binds
-    fun bindsCameraUseCase(cameraXCameraUseCase: CameraXCameraUseCase): CameraUseCase
+    fun bindsCameraSystem(cameraXCameraSystem: CameraXCameraSystem): CameraSystem
 }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -704,7 +704,7 @@ private fun setFlashModeInternal(
             ) {
                 Log.d(TAG, "ImageCapture.ScreenFlash: apply")
                 screenFlashEvents.trySend(
-                    CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.APPLY_UI) {
+                    CameraSystem.ScreenFlashEvent(CameraSystem.ScreenFlashEvent.Type.APPLY_UI) {
                         listener.onCompleted()
                     }
                 )
@@ -713,7 +713,7 @@ private fun setFlashModeInternal(
             override fun clear() {
                 Log.d(TAG, "ImageCapture.ScreenFlash: clear")
                 screenFlashEvents.trySend(
-                    CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) {}
+                    CameraSystem.ScreenFlashEvent(CameraSystem.ScreenFlashEvent.Type.CLEAR_UI) {}
                 )
             }
         }
@@ -746,7 +746,7 @@ private fun getPendingRecording(
     captureTypeSuffix: String,
     videoCaptureUri: Uri?,
     shouldUseUri: Boolean,
-    onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
+    onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
 ): PendingRecording? {
     Log.d(TAG, "getPendingRecording")
 
@@ -764,7 +764,7 @@ private fun getPendingRecording(
                 )
             } catch (e: Exception) {
                 onVideoRecord(
-                    CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(e)
+                    CameraSystem.OnVideoRecordEvent.OnVideoRecordError(e)
                 )
                 null
             }
@@ -776,7 +776,7 @@ private fun getPendingRecording(
                 videoCaptureUseCase.output.prepareRecording(context, fileOutputOptions)
             } else {
                 onVideoRecord(
-                    CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(
+                    CameraSystem.OnVideoRecordEvent.OnVideoRecordError(
                         RuntimeException("Uri scheme not supported.")
                     )
                 )
@@ -811,7 +811,7 @@ private suspend fun startVideoRecordingInternal(
     pendingRecord: PendingRecording,
     maxDurationMillis: Long,
     initialRecordingSettings: InitialRecordingSettings,
-    onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
+    onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
 ): Recording {
     // set the camerastate to starting
     currentCameraState.update { old ->
@@ -925,7 +925,7 @@ private suspend fun startVideoRecordingInternal(
                             )
                         }
                         onVideoRecord(
-                            CameraUseCase.OnVideoRecordEvent.OnVideoRecorded(
+                            CameraSystem.OnVideoRecordEvent.OnVideoRecorded(
                                 onVideoRecordEvent.outputResults.outputUri
                             )
                         )
@@ -942,7 +942,7 @@ private suspend fun startVideoRecordingInternal(
                         }
 
                         onVideoRecord(
-                            CameraUseCase.OnVideoRecordEvent.OnVideoRecorded(
+                            CameraSystem.OnVideoRecordEvent.OnVideoRecorded(
                                 onVideoRecordEvent.outputResults.outputUri
                             )
                         )
@@ -950,7 +950,7 @@ private suspend fun startVideoRecordingInternal(
 
                     else -> {
                         onVideoRecord(
-                            CameraUseCase.OnVideoRecordEvent.OnVideoRecordError(
+                            CameraSystem.OnVideoRecordEvent.OnVideoRecordError(
                                 RuntimeException(
                                     "Recording finished with error: ${onVideoRecordEvent.error}",
                                     onVideoRecordEvent.cause
@@ -984,7 +984,7 @@ private suspend fun runVideoRecording(
     videoCaptureUri: Uri?,
     videoControlEvents: Channel<VideoCaptureControlEvent>,
     shouldUseUri: Boolean,
-    onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
+    onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
 ) = coroutineScope {
     var currentSettings = transientSettings.filterNotNull().first()
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionContext.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSessionContext.kt
@@ -34,7 +34,7 @@ internal data class CameraSessionContext(
     val context: Context,
     val cameraProvider: ProcessCameraProvider,
     val backgroundDispatcher: CoroutineDispatcher,
-    val screenFlashEvents: SendChannel<CameraUseCase.ScreenFlashEvent>,
+    val screenFlashEvents: SendChannel<CameraSystem.ScreenFlashEvent>,
     val focusMeteringEvents: Channel<CameraEvent.FocusMeteringEvent>,
     val videoCaptureControlEvents: Channel<VideoCaptureControlEvent>,
     val currentCameraState: MutableStateFlow<CameraState>,

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraState.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraState.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import android.net.Uri
+import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.LowLightBoostState
+import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.VideoQuality
+
+data class CameraState(
+    val videoRecordingState: VideoRecordingState = VideoRecordingState.Inactive(),
+    val zoomRatios: Map<LensFacing, Float> = mapOf(),
+    val linearZoomScales: Map<LensFacing, Float> = mapOf(),
+    val sessionFirstFrameTimestamp: Long = 0L,
+    val torchEnabled: Boolean = false,
+    val stabilizationMode: StabilizationMode = StabilizationMode.OFF,
+    val lowLightBoostState: LowLightBoostState = LowLightBoostState.INACTIVE,
+    val debugInfo: DebugInfo = DebugInfo(null, null),
+    val videoQualityInfo: VideoQualityInfo = VideoQualityInfo(VideoQuality.UNSPECIFIED, 0, 0)
+)
+
+data class DebugInfo(val logicalCameraId: String?, val physicalCameraId: String?)
+
+data class VideoQualityInfo(val quality: VideoQuality, val width: Int, val height: Int)
+
+sealed interface VideoRecordingState {
+
+    /**
+     * Indicates that a [PendingRecording][androidx.camera.video.PendingRecording] is about to start.
+     * This state may be used as a signal to start processes just before the recording actually starts.
+     */
+    data class Starting(val initialRecordingSettings: InitialRecordingSettings? = null) :
+        VideoRecordingState
+
+    /**
+     * Camera is not currently recording a video
+     */
+    data class Inactive(val finalElapsedTimeNanos: Long = 0) : VideoRecordingState
+
+    /**
+     * Camera is currently active; paused, stopping, or recording a video
+     */
+    sealed interface Active : VideoRecordingState {
+        val maxDurationMillis: Long
+        val audioAmplitude: Double
+        val elapsedTimeNanos: Long
+
+        data class Recording(
+            override val maxDurationMillis: Long,
+            override val audioAmplitude: Double,
+            override val elapsedTimeNanos: Long
+        ) : Active
+
+        data class Paused(
+            override val maxDurationMillis: Long,
+            override val audioAmplitude: Double,
+            override val elapsedTimeNanos: Long
+        ) : Active
+    }
+}
+
+/**
+ * Represents the events for video recording.
+ */
+sealed interface OnVideoRecordEvent {
+    data class OnVideoRecorded(val savedUri: Uri) : OnVideoRecordEvent
+
+    data class OnVideoRecordError(val error: Throwable) : OnVideoRecordEvent
+}

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Data layer for camera.
  */
-interface CameraUseCase {
+interface CameraSystem {
     /**
      * Initializes the camera.
      *

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
@@ -28,7 +28,6 @@ import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
-import com.google.jetpackcamera.model.LowLightBoostState
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.TestPattern
@@ -140,66 +139,4 @@ interface CameraSystem {
             CLEAR_UI
         }
     }
-
-    /**
-     * Represents the events for video recording.
-     */
-
-    sealed interface OnVideoRecordEvent {
-        data class OnVideoRecorded(val savedUri: Uri) : OnVideoRecordEvent
-
-        data class OnVideoRecordError(val error: Throwable) : OnVideoRecordEvent
-    }
 }
-
-sealed interface VideoRecordingState {
-
-    /**
-     * Indicates that a [PendingRecording][androidx.camera.video.PendingRecording] is about to start.
-     * This state may be used as a signal to start processes just before the recording actually starts.
-     */
-    data class Starting(val initialRecordingSettings: InitialRecordingSettings? = null) :
-        VideoRecordingState
-
-    /**
-     * Camera is not currently recording a video
-     */
-    data class Inactive(val finalElapsedTimeNanos: Long = 0) : VideoRecordingState
-
-    /**
-     * Camera is currently active; paused, stopping, or recording a video
-     */
-    sealed interface Active : VideoRecordingState {
-        val maxDurationMillis: Long
-        val audioAmplitude: Double
-        val elapsedTimeNanos: Long
-
-        data class Recording(
-            override val maxDurationMillis: Long,
-            override val audioAmplitude: Double,
-            override val elapsedTimeNanos: Long
-        ) : Active
-
-        data class Paused(
-            override val maxDurationMillis: Long,
-            override val audioAmplitude: Double,
-            override val elapsedTimeNanos: Long
-        ) : Active
-    }
-}
-
-data class CameraState(
-    val videoRecordingState: VideoRecordingState = VideoRecordingState.Inactive(),
-    val zoomRatios: Map<LensFacing, Float> = mapOf(),
-    val linearZoomScales: Map<LensFacing, Float> = mapOf(),
-    val sessionFirstFrameTimestamp: Long = 0L,
-    val torchEnabled: Boolean = false,
-    val stabilizationMode: StabilizationMode = StabilizationMode.OFF,
-    val lowLightBoostState: LowLightBoostState = LowLightBoostState.INACTIVE,
-    val debugInfo: DebugInfo = DebugInfo(null, null),
-    val videoQualityInfo: VideoQualityInfo = VideoQualityInfo(VideoQuality.UNSPECIFIED, 0, 0)
-)
-
-data class DebugInfo(val logicalCameraId: String?, val physicalCameraId: String?)
-
-data class VideoQualityInfo(val quality: VideoQuality, val width: Int, val height: Int)

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -65,7 +65,7 @@ import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_15
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_60
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import dagger.hilt.android.scopes.ViewModelScoped
 import java.io.File
@@ -112,7 +112,7 @@ constructor(
 
     private var imageCaptureUseCase: ImageCapture? = null
 
-    private lateinit var systemConstraints: SystemConstraints
+    private lateinit var systemConstraints: CameraSystemConstraints
 
     private val screenFlashEvents: Channel<CameraSystem.ScreenFlashEvent> =
         Channel(capacity = Channel.UNLIMITED)
@@ -150,7 +150,7 @@ constructor(
             }
 
         // Build and update the system constraints
-        systemConstraints = SystemConstraints(
+        systemConstraints = CameraSystemConstraints(
             availableLenses = availableCameraLenses,
             concurrentCamerasSupported = cameraProvider.availableConcurrentCameraInfos.any {
                 it.map { cameraInfo -> cameraInfo.appLensFacing }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -88,7 +88,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
-private const val TAG = "CameraXCameraUseCase"
+private const val TAG = "CameraXCameraSystem"
 const val TARGET_FPS_AUTO = 0
 const val TARGET_FPS_15 = 15
 const val TARGET_FPS_30 = 30
@@ -97,24 +97,24 @@ const val TARGET_FPS_60 = 60
 const val UNLIMITED_VIDEO_DURATION = 0L
 
 /**
- * CameraX based implementation for [CameraUseCase]
+ * CameraX based implementation for [CameraSystem]
  */
 @ViewModelScoped
-class CameraXCameraUseCase
+class CameraXCameraSystem
 @Inject
 constructor(
     private val application: Application,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     @IODispatcher private val iODispatcher: CoroutineDispatcher,
     private val constraintsRepository: SettableConstraintsRepository
-) : CameraUseCase {
+) : CameraSystem {
     private lateinit var cameraProvider: ProcessCameraProvider
 
     private var imageCaptureUseCase: ImageCapture? = null
 
     private lateinit var systemConstraints: SystemConstraints
 
-    private val screenFlashEvents: Channel<CameraUseCase.ScreenFlashEvent> =
+    private val screenFlashEvents: Channel<CameraSystem.ScreenFlashEvent> =
         Channel(capacity = Channel.UNLIMITED)
     private val focusMeteringEvents =
         Channel<CameraEvent.FocusMeteringEvent>(capacity = Channel.CONFLATED)
@@ -557,7 +557,7 @@ constructor(
     override suspend fun startVideoRecording(
         videoCaptureUri: Uri?,
         shouldUseUri: Boolean,
-        onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
+        onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
     ) {
         if (shouldUseUri && videoCaptureUri == null) {
             val e = RuntimeException("Null Uri is provided.")

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/VideoCaptureControlEvent.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/VideoCaptureControlEvent.kt
@@ -31,7 +31,7 @@ sealed interface VideoCaptureControlEvent {
         val videoCaptureUri: Uri?,
         val shouldUseUri: Boolean,
         val maxVideoDuration: Long,
-        val onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
+        val onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
     ) : VideoCaptureControlEvent
 
     /**

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/VideoCaptureControlEvent.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/VideoCaptureControlEvent.kt
@@ -31,7 +31,7 @@ sealed interface VideoCaptureControlEvent {
         val videoCaptureUri: Uri?,
         val shouldUseUri: Boolean,
         val maxVideoDuration: Long,
-        val onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
+        val onVideoRecord: (OnVideoRecordEvent) -> Unit
     ) : VideoCaptureControlEvent
 
     /**

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/test/FakeCameraSystem.kt
@@ -21,7 +21,7 @@ import android.net.Uri
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.SurfaceRequest
 import com.google.jetpackcamera.core.camera.CameraState
-import com.google.jetpackcamera.core.camera.CameraUseCase
+import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.model.AspectRatio
 import com.google.jetpackcamera.model.CameraZoomRatio
 import com.google.jetpackcamera.model.CaptureMode
@@ -45,8 +45,8 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.update
 
-class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSettings()) :
-    CameraUseCase {
+class FakeCameraSystem(defaultCameraSettings: CameraAppSettings = CameraAppSettings()) :
+    CameraSystem {
     private val availableLenses = listOf(LensFacing.FRONT, LensFacing.BACK)
     private var initialized = false
     private var useCasesBinded = false
@@ -60,7 +60,7 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
     var isLensFacingFront = false
 
     private var isScreenFlash = true
-    private var screenFlashEvents = Channel<CameraUseCase.ScreenFlashEvent>(capacity = UNLIMITED)
+    private var screenFlashEvents = Channel<CameraSystem.ScreenFlashEvent>(capacity = UNLIMITED)
     private val zoomChanges = MutableStateFlow<CameraZoomRatio?>(null)
     private val currentSettings = MutableStateFlow(defaultCameraSettings)
 
@@ -103,10 +103,10 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
         }
         if (isScreenFlash) {
             screenFlashEvents.trySend(
-                CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.APPLY_UI) { }
+                CameraSystem.ScreenFlashEvent(CameraSystem.ScreenFlashEvent.Type.APPLY_UI) { }
             )
             screenFlashEvents.trySend(
-                CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
+                CameraSystem.ScreenFlashEvent(CameraSystem.ScreenFlashEvent.Type.CLEAR_UI) { }
             )
         }
         numPicturesTaken += 1
@@ -123,14 +123,14 @@ class FakeCameraUseCase(defaultCameraSettings: CameraAppSettings = CameraAppSett
         return ImageCapture.OutputFileResults(null)
     }
 
-    fun emitScreenFlashEvent(event: CameraUseCase.ScreenFlashEvent) {
+    fun emitScreenFlashEvent(event: CameraSystem.ScreenFlashEvent) {
         screenFlashEvents.trySend(event)
     }
 
     override suspend fun startVideoRecording(
         videoCaptureUri: Uri?,
         shouldUseUri: Boolean,
-        onVideoRecord: (CameraUseCase.OnVideoRecordEvent) -> Unit
+        onVideoRecord: (CameraSystem.OnVideoRecordEvent) -> Unit
     ) {
         if (!useCasesBinded) {
             throw IllegalStateException("Usecases not bound")

--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraSystemTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/test/FakeCameraSystemTest.kt
@@ -16,7 +16,7 @@
 package com.google.jetpackcamera.core.camera.test
 
 import com.google.common.truth.Truth
-import com.google.jetpackcamera.core.camera.CameraUseCase
+import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
@@ -37,11 +37,11 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class FakeCameraUseCaseTest {
+class FakeCameraSystemTest {
     private val testScope = TestScope()
     private val testDispatcher = StandardTestDispatcher(testScope.testScheduler)
 
-    private val cameraUseCase = FakeCameraUseCase()
+    private val cameraSystem = FakeCameraSystem()
 
     @Before
     fun setup() {
@@ -55,7 +55,7 @@ class FakeCameraUseCaseTest {
 
     @Test
     fun canInitialize() = runTest(testDispatcher) {
-        cameraUseCase.initialize(
+        cameraSystem.initialize(
             cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
         ) {}
     }
@@ -63,62 +63,62 @@ class FakeCameraUseCaseTest {
     @Test
     fun canRunCamera() = runTest(testDispatcher) {
         initAndRunCamera()
-        Truth.assertThat(cameraUseCase.isPreviewStarted())
+        Truth.assertThat(cameraSystem.isPreviewStarted())
     }
 
     @Test
     fun screenFlashDisabled_whenFlashModeOffAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
-        cameraUseCase.setFlashMode(flashMode = FlashMode.OFF)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.FRONT)
+        cameraSystem.setFlashMode(flashMode = FlashMode.OFF)
         advanceUntilIdle()
 
-        Truth.assertThat(cameraUseCase.isScreenFlashEnabled()).isFalse()
+        Truth.assertThat(cameraSystem.isScreenFlashEnabled()).isFalse()
     }
 
     @Test
     fun screenFlashDisabled_whenFlashModeOnAndNotFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.BACK)
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.BACK)
+        cameraSystem.setFlashMode(flashMode = FlashMode.ON)
         advanceUntilIdle()
 
-        Truth.assertThat(cameraUseCase.isScreenFlashEnabled()).isFalse()
+        Truth.assertThat(cameraSystem.isScreenFlashEnabled()).isFalse()
     }
 
     @Test
     fun screenFlashDisabled_whenFlashModeAutoAndNotFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.BACK)
-        cameraUseCase.setFlashMode(flashMode = FlashMode.AUTO)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.BACK)
+        cameraSystem.setFlashMode(flashMode = FlashMode.AUTO)
         advanceUntilIdle()
 
-        Truth.assertThat(cameraUseCase.isScreenFlashEnabled()).isFalse()
+        Truth.assertThat(cameraSystem.isScreenFlashEnabled()).isFalse()
     }
 
     @Test
     fun screenFlashEnabled_whenFlashModeOnAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
-        cameraUseCase.setFlashMode(flashMode = FlashMode.ON)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.FRONT)
+        cameraSystem.setFlashMode(flashMode = FlashMode.ON)
         advanceUntilIdle()
 
-        Truth.assertThat(cameraUseCase.isScreenFlashEnabled()).isTrue()
+        Truth.assertThat(cameraSystem.isScreenFlashEnabled()).isTrue()
     }
 
     @Test
     fun screenFlashEnabled_whenFlashModeAutoAndFrontCamera() = runTest(testDispatcher) {
         initAndRunCamera()
 
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
-        cameraUseCase.setFlashMode(flashMode = FlashMode.AUTO)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.FRONT)
+        cameraSystem.setFlashMode(flashMode = FlashMode.AUTO)
         advanceUntilIdle()
 
-        Truth.assertThat(cameraUseCase.isScreenFlashEnabled()).isTrue()
+        Truth.assertThat(cameraSystem.isScreenFlashEnabled()).isTrue()
     }
 
     @Test
@@ -126,32 +126,32 @@ class FakeCameraUseCaseTest {
         testDispatcher
     ) {
         initAndRunCamera()
-        val events = mutableListOf<CameraUseCase.ScreenFlashEvent>()
+        val events = mutableListOf<CameraSystem.ScreenFlashEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.getScreenFlashEvents().consumeAsFlow().toList(events)
+            cameraSystem.getScreenFlashEvents().consumeAsFlow().toList(events)
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
-        cameraUseCase.setFlashMode(FlashMode.ON)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.FRONT)
+        cameraSystem.setFlashMode(FlashMode.ON)
         advanceUntilIdle()
-        cameraUseCase.takePicture()
+        cameraSystem.takePicture()
 
         advanceUntilIdle()
         Truth.assertThat(events.map { it.type }).containsExactlyElementsIn(
             listOf(
-                CameraUseCase.ScreenFlashEvent.Type.APPLY_UI,
-                CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI
+                CameraSystem.ScreenFlashEvent.Type.APPLY_UI,
+                CameraSystem.ScreenFlashEvent.Type.CLEAR_UI
             )
         ).inOrder()
     }
 
     private fun TestScope.initAndRunCamera() {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.initialize(
+            cameraSystem.initialize(
                 cameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
             ) {}
-            cameraUseCase.runCamera()
+            cameraSystem.runCamera()
         }
     }
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/ConstraintsRepository.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/ConstraintsRepository.kt
@@ -15,27 +15,27 @@
  */
 package com.google.jetpackcamera.settings
 
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 interface ConstraintsRepository {
-    val systemConstraints: StateFlow<SystemConstraints?>
+    val systemConstraints: StateFlow<CameraSystemConstraints?>
 }
 
 interface SettableConstraintsRepository : ConstraintsRepository {
-    fun updateSystemConstraints(systemConstraints: SystemConstraints)
+    fun updateSystemConstraints(systemConstraints: CameraSystemConstraints)
 }
 
 class SettableConstraintsRepositoryImpl @Inject constructor() : SettableConstraintsRepository {
 
-    private val _systemConstraints = MutableStateFlow<SystemConstraints?>(null)
-    override val systemConstraints: StateFlow<SystemConstraints?>
+    private val _systemConstraints = MutableStateFlow<CameraSystemConstraints?>(null)
+    override val systemConstraints: StateFlow<CameraSystemConstraints?>
         get() = _systemConstraints.asStateFlow()
 
-    override fun updateSystemConstraints(systemConstraints: SystemConstraints) {
+    override fun updateSystemConstraints(systemConstraints: CameraSystemConstraints) {
         _systemConstraints.value = systemConstraints
     }
 }

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/CameraAppSettings.kt
@@ -55,7 +55,8 @@ data class CameraAppSettings(
     val debugSettings: DebugSettings = DebugSettings()
 )
 
-fun SystemConstraints.forCurrentLens(cameraAppSettings: CameraAppSettings): CameraConstraints? =
-    perLensConstraints[cameraAppSettings.cameraLensFacing]
+fun CameraSystemConstraints.forCurrentLens(
+    cameraAppSettings: CameraAppSettings
+): CameraConstraints? = perLensConstraints[cameraAppSettings.cameraLensFacing]
 
 val DEFAULT_CAMERA_APP_SETTINGS = CameraAppSettings()

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
@@ -42,13 +42,13 @@ import com.google.jetpackcamera.model.VideoQuality
  *                              corresponding value is a [CameraConstraints] object
  *                              detailing the specific capabilities and limitations of that lens.
  */
-data class SystemConstraints(
+data class CameraSystemConstraints(
     val availableLenses: List<LensFacing> = emptyList(),
     val concurrentCamerasSupported: Boolean = false,
     val perLensConstraints: Map<LensFacing, CameraConstraints> = emptyMap()
 )
 
-inline fun <reified T> SystemConstraints.forDevice(
+inline fun <reified T> CameraSystemConstraints.forDevice(
     crossinline constraintSelector: (CameraConstraints) -> Iterable<T>
 ) = perLensConstraints.values.asSequence().flatMap { constraintSelector(it) }.toSet()
 
@@ -113,7 +113,7 @@ data class CameraConstraints(
  * Useful set of constraints for testing
  */
 val TYPICAL_SYSTEM_CONSTRAINTS =
-    SystemConstraints(
+    CameraSystemConstraints(
         availableLenses = listOf(LensFacing.FRONT, LensFacing.BACK),
         concurrentCamerasSupported = false,
         perLensConstraints = buildMap {

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -44,7 +44,7 @@ import com.google.jetpackcamera.model.TestPattern
 import com.google.jetpackcamera.settings.ConstraintsRepository
 import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.ui.components.capture.IMAGE_CAPTURE_EXTERNAL_UNSUPPORTED_TAG
 import com.google.jetpackcamera.ui.components.capture.IMAGE_CAPTURE_FAILURE_TAG
 import com.google.jetpackcamera.ui.components.capture.IMAGE_CAPTURE_SUCCESS_TAG
@@ -280,7 +280,7 @@ class PreviewViewModel @AssistedInject constructor(
         flashModeUiState: FlashModeUiState,
         flipLensUiState: FlipLensUiState,
         cameraAppSettings: CameraAppSettings,
-        systemConstraints: SystemConstraints,
+        systemConstraints: CameraSystemConstraints,
         aspectRatioUiState: AspectRatioUiState,
         quickSettingsIsOpen: Boolean
     ): QuickSettingsUiState {
@@ -308,7 +308,7 @@ class PreviewViewModel @AssistedInject constructor(
     }
 
     private fun getDebugUiState(
-        systemConstraints: SystemConstraints,
+        systemConstraints: CameraSystemConstraints,
         cameraAppSettings: CameraAppSettings,
         cameraState: CameraState,
         isDebugOverlayOpen: Boolean

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -17,7 +17,7 @@ package com.google.jetpackcamera.feature.preview
 
 import android.content.ContentResolver
 import com.google.common.truth.Truth.assertThat
-import com.google.jetpackcamera.core.camera.test.FakeCameraUseCase
+import com.google.jetpackcamera.core.camera.test.FakeCameraSystem
 import com.google.jetpackcamera.data.media.FakeMediaRepository
 import com.google.jetpackcamera.model.DebugSettings
 import com.google.jetpackcamera.model.ExternalCaptureMode
@@ -46,7 +46,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PreviewViewModelTest {
 
-    private val cameraUseCase = FakeCameraUseCase()
+    private val cameraSystem = FakeCameraSystem()
     private val constraintsRepository = SettableConstraintsRepositoryImpl().apply {
         updateSystemConstraints(TYPICAL_SYSTEM_CONSTRAINTS)
     }
@@ -58,7 +58,7 @@ class PreviewViewModelTest {
         previewViewModel = PreviewViewModel(
             ExternalCaptureMode.StandardMode {},
             DebugSettings(isDebugModeEnabled = false),
-            cameraUseCase = cameraUseCase,
+            cameraSystem = cameraSystem,
             constraintsRepository = constraintsRepository,
             settingsRepository = FakeSettingsRepository,
             mediaRepository = FakeMediaRepository
@@ -77,7 +77,7 @@ class PreviewViewModelTest {
     fun runCamera() = runTest(StandardTestDispatcher()) {
         previewViewModel.startCameraUntilRunning()
 
-        assertThat(cameraUseCase.previewStarted).isTrue()
+        assertThat(cameraSystem.previewStarted).isTrue()
     }
 
     @Test
@@ -86,7 +86,7 @@ class PreviewViewModelTest {
         previewViewModel.startCameraUntilRunning()
         previewViewModel.captureImageWithUri(contentResolver, null) { _, _ -> }
         advanceUntilIdle()
-        assertThat(cameraUseCase.numPicturesTaken).isEqualTo(1)
+        assertThat(cameraSystem.numPicturesTaken).isEqualTo(1)
     }
 
     @Test
@@ -94,7 +94,7 @@ class PreviewViewModelTest {
         previewViewModel.startCameraUntilRunning()
         previewViewModel.startVideoRecording(null, false) {}
         advanceUntilIdle()
-        assertThat(cameraUseCase.recordingInProgress).isTrue()
+        assertThat(cameraSystem.recordingInProgress).isTrue()
     }
 
     @Test
@@ -104,7 +104,7 @@ class PreviewViewModelTest {
         advanceUntilIdle()
         previewViewModel.stopVideoRecording()
         advanceUntilIdle()
-        assertThat(cameraUseCase.recordingInProgress).isFalse()
+        assertThat(cameraSystem.recordingInProgress).isFalse()
     }
 
     @Test
@@ -144,7 +144,7 @@ class PreviewViewModelTest {
                     .selectedLensFacing
             ).isEqualTo(LensFacing.FRONT)
         }
-        assertThat(cameraUseCase.isLensFacingFront).isTrue()
+        assertThat(cameraSystem.isLensFacingFront).isTrue()
     }
 
     context(TestScope)

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsUiState.kt
@@ -258,7 +258,7 @@ sealed interface VideoQualityUiState {
 
 /**
  * Settings Ui State for testing, based on Typical System Constraints.
- * @see[com.google.jetpackcamera.settings.model.SystemConstraints]
+ * @see[com.google.jetpackcamera.settings.model.CameraSystemConstraints]
  */
 val TYPICAL_SETTINGS_UISTATE = SettingsUiState.Enabled(
     aspectRatioUiState = AspectRatioUiState.Enabled(DEFAULT_CAMERA_APP_SETTINGS.aspectRatio),

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsViewModel.kt
@@ -39,7 +39,7 @@ import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_1
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_30
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_60
 import com.google.jetpackcamera.settings.model.CameraConstraints.Companion.FPS_AUTO
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import com.google.jetpackcamera.settings.model.forDevice
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -104,7 +104,7 @@ class SettingsViewModel @Inject constructor(
 
     private fun getFlashUiState(
         cameraAppSettings: CameraAppSettings,
-        constraints: SystemConstraints
+        constraints: CameraSystemConstraints
     ): FlashUiState {
         val currentSupportedFlashModes =
             constraints.forCurrentLens(cameraAppSettings)?.supportedFlashModes ?: emptySet()
@@ -223,7 +223,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun getStabilizationUiState(
-        systemConstraints: SystemConstraints,
+        systemConstraints: CameraSystemConstraints,
         cameraAppSettings: CameraAppSettings
     ): StabilizationUiState {
         val deviceStabilizations: Set<StabilizationMode> =
@@ -366,7 +366,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun getVideoQualityUiState(
-        systemConstraints: SystemConstraints,
+        systemConstraints: CameraSystemConstraints,
         cameraAppSettings: CameraAppSettings
     ): VideoQualityUiState {
         val cameraConstraints = systemConstraints.forCurrentLens(cameraAppSettings)
@@ -425,7 +425,7 @@ class SettingsViewModel @Inject constructor(
      * support the other settings
      * */
     private fun getLensFlipUiState(
-        systemConstraints: SystemConstraints,
+        systemConstraints: CameraSystemConstraints,
         currentSettings: CameraAppSettings
     ): FlipLensUiState {
         // if there is only one lens, stop here
@@ -509,7 +509,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun getFpsUiState(
-        systemConstraints: SystemConstraints,
+        systemConstraints: CameraSystemConstraints,
         cameraAppSettings: CameraAppSettings
     ): FpsUiState {
         val optionConstraintRationale: MutableMap<Int, SingleSelectableState> = mutableMapOf()

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/ScreenFlash.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/ScreenFlash.kt
@@ -15,7 +15,7 @@
  */
 package com.google.jetpackcamera.ui.components.capture
 
-import com.google.jetpackcamera.core.camera.CameraUseCase
+import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.ui.uistate.capture.ScreenFlashUiState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,7 +30,7 @@ private const val TAG = "ScreenFlash"
 // TODO: Add this to ViewModelScoped so that it can be injected automatically. However, the current
 //  ViewModel and Hilt APIs probably don't support injecting the viewModelScope.
 class ScreenFlash(
-    private val cameraUseCase: CameraUseCase,
+    private val cameraSystem: CameraSystem,
     private val scope: CoroutineScope
 ) {
 
@@ -40,16 +40,16 @@ class ScreenFlash(
 
     init {
         scope.launch {
-            for (event in cameraUseCase.getScreenFlashEvents()) {
+            for (event in cameraSystem.getScreenFlashEvents()) {
                 _screenFlashUiState.emit(
                     when (event.type) {
-                        CameraUseCase.ScreenFlashEvent.Type.APPLY_UI ->
+                        CameraSystem.ScreenFlashEvent.Type.APPLY_UI ->
                             screenFlashUiState.value.copy(
                                 enabled = true,
                                 onChangeComplete = event.onComplete
                             )
 
-                        CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI ->
+                        CameraSystem.ScreenFlashEvent.Type.CLEAR_UI ->
                             screenFlashUiState.value.copy(
                                 enabled = false,
                                 onChangeComplete = {

--- a/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/capture/ScreenFlashTest.kt
+++ b/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/capture/ScreenFlashTest.kt
@@ -17,8 +17,8 @@ package com.google.jetpackcamera.ui.components.capture.capture
 
 import android.content.ContentResolver
 import com.google.common.truth.Truth.assertThat
-import com.google.jetpackcamera.core.camera.CameraUseCase
-import com.google.jetpackcamera.core.camera.test.FakeCameraUseCase
+import com.google.jetpackcamera.core.camera.CameraSystem
+import com.google.jetpackcamera.core.camera.test.FakeCameraSystem
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
@@ -49,12 +49,12 @@ class ScreenFlashTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
-    private val cameraUseCase = FakeCameraUseCase()
+    private val cameraSystem = FakeCameraSystem()
     private lateinit var screenFlash: ScreenFlash
 
     @Before
     fun setup() = runTest(testDispatcher) {
-        screenFlash = ScreenFlash(cameraUseCase, testScope)
+        screenFlash = ScreenFlash(cameraSystem, testScope)
     }
 
     @Test
@@ -70,10 +70,10 @@ class ScreenFlashTest {
         }
 
         // FlashMode.ON in front facing camera automatically enables screen flash
-        cameraUseCase.setLensFacing(lensFacing = LensFacing.FRONT)
-        cameraUseCase.setFlashMode(FlashMode.ON)
+        cameraSystem.setLensFacing(lensFacing = LensFacing.FRONT)
+        cameraSystem.setFlashMode(FlashMode.ON)
         val contentResolver: ContentResolver = Mockito.mock()
-        cameraUseCase.takePicture({}, contentResolver, null)
+        cameraSystem.takePicture({}, contentResolver, null)
 
         advanceUntilIdle()
         assertThat(states.map { it.enabled }).containsExactlyElementsIn(
@@ -88,8 +88,8 @@ class ScreenFlashTest {
     @Test
     fun emitClearUiEvent_screenFlashUiStateContainsClearUiScreenBrightness() = runCameraTest {
         screenFlash.setClearUiScreenBrightness(5.0f)
-        cameraUseCase.emitScreenFlashEvent(
-            CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
+        cameraSystem.emitScreenFlashEvent(
+            CameraSystem.ScreenFlashEvent(CameraSystem.ScreenFlashEvent.Type.CLEAR_UI) { }
         )
 
         advanceUntilIdle()
@@ -101,8 +101,8 @@ class ScreenFlashTest {
     @Test
     fun invokeOnChangeCompleteAfterClearUiEvent_screenFlashUiStateReset() = runCameraTest {
         screenFlash.setClearUiScreenBrightness(5.0f)
-        cameraUseCase.emitScreenFlashEvent(
-            CameraUseCase.ScreenFlashEvent(CameraUseCase.ScreenFlashEvent.Type.CLEAR_UI) { }
+        cameraSystem.emitScreenFlashEvent(
+            CameraSystem.ScreenFlashEvent(CameraSystem.ScreenFlashEvent.Type.CLEAR_UI) { }
         )
 
         advanceUntilIdle()
@@ -115,10 +115,10 @@ class ScreenFlashTest {
 
     private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            cameraUseCase.initialize(
+            cameraSystem.initialize(
                 DEFAULT_CAMERA_APP_SETTINGS
             ) {}
-            cameraUseCase.runCamera()
+            cameraSystem.runCamera()
         }
 
         testBody()

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/CaptureModeUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/CaptureModeUiStateAdapter.kt
@@ -26,7 +26,7 @@ import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import com.google.jetpackcamera.ui.components.capture.DisabledReason
 import com.google.jetpackcamera.ui.uistate.SingleSelectableUiState
@@ -40,7 +40,7 @@ private val ORDERED_UI_SUPPORTED_CAPTURE_MODES = listOf(
 )
 
 fun CaptureModeToggleUiState.Companion.from(
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     cameraAppSettings: CameraAppSettings,
     cameraState: CameraState,
     externalCaptureMode: ExternalCaptureMode
@@ -78,7 +78,7 @@ fun CaptureModeToggleUiState.Companion.from(
     }
 
 fun CaptureModeUiState.Companion.from(
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     cameraAppSettings: CameraAppSettings,
     externalCaptureMode: ExternalCaptureMode
 ): CaptureModeUiState {
@@ -123,7 +123,7 @@ private fun getSupportedCaptureModes(
 }
 
 private fun getAvailableCaptureModes(
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     cameraAppSettings: CameraAppSettings,
     externalCaptureMode: ExternalCaptureMode
 ): List<SingleSelectableUiState<CaptureMode>> {
@@ -228,7 +228,7 @@ private fun getCaptureModeDisabledReason(
     disabledCaptureMode: CaptureMode,
     hdrDynamicRangeSupported: Boolean,
     hdrImageFormatSupported: Boolean,
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     currentLensFacing: LensFacing,
     currentStreamConfig: StreamConfig,
     concurrentCameraMode: ConcurrentCameraMode,
@@ -300,7 +300,7 @@ private fun getCaptureModeDisabledReason(
     }
 }
 
-private fun SystemConstraints.anySupportsHdrDynamicRange(
+private fun CameraSystemConstraints.anySupportsHdrDynamicRange(
     lensFilter: (LensFacing) -> Boolean
 ): Boolean = perLensConstraints.asSequence().firstOrNull {
     lensFilter(it.key) && it.value.supportedDynamicRanges.size > 1
@@ -312,7 +312,7 @@ private fun Map<StreamConfig, Set<ImageOutputFormat>>.anySupportsUltraHdr(
     captureModeFilter(it.key) && it.value.contains(ImageOutputFormat.JPEG_ULTRA_HDR)
 } != null
 
-private fun SystemConstraints.anySupportsUltraHdr(
+private fun CameraSystemConstraints.anySupportsUltraHdr(
     captureModeFilter: (StreamConfig) -> Boolean = { true },
     lensFilter: (LensFacing) -> Boolean
 ): Boolean = perLensConstraints.asSequence().firstOrNull { lensConstraints ->

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/ConcurrentCameraUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/ConcurrentCameraUiStateAdapter.kt
@@ -21,14 +21,14 @@ import com.google.jetpackcamera.model.DEFAULT_HDR_IMAGE_OUTPUT
 import com.google.jetpackcamera.model.ExternalCaptureMode
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.ui.uistate.capture.CaptureModeUiState
 import com.google.jetpackcamera.ui.uistate.capture.ConcurrentCameraUiState
 import com.google.jetpackcamera.ui.uistate.capture.StreamConfigUiState
 
 fun ConcurrentCameraUiState.Companion.from(
     cameraAppSettings: CameraAppSettings,
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     externalCaptureMode: ExternalCaptureMode,
     captureModeUiState: CaptureModeUiState,
     streamConfigUiState: StreamConfigUiState

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/DebugUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/DebugUiStateAdapter.kt
@@ -19,12 +19,12 @@ import android.util.Size
 import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.model.TestPattern
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import com.google.jetpackcamera.ui.uistate.capture.DebugUiState
 
 fun DebugUiState.Open.Companion.from(
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     cameraAppSettings: CameraAppSettings,
     cameraState: CameraState,
     cameraPropertiesJSON: String

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
@@ -20,7 +20,7 @@ import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LowLightBoostState
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import com.google.jetpackcamera.ui.uistate.SingleSelectableUiState
 import com.google.jetpackcamera.ui.uistate.capture.FlashModeUiState
@@ -36,7 +36,7 @@ private val ORDERED_UI_SUPPORTED_FLASH_MODES = listOf(
 
 fun FlashModeUiState.Companion.from(
     cameraAppSettings: CameraAppSettings,
-    systemConstraints: SystemConstraints
+    systemConstraints: CameraSystemConstraints
 ): FlashModeUiState {
     val selectedFlashMode = cameraAppSettings.flashMode
     val supportedFlashModes = systemConstraints.forCurrentLens(cameraAppSettings)
@@ -70,7 +70,7 @@ fun FlashModeUiState.Companion.from(
 
 fun FlashModeUiState.updateFrom(
     cameraAppSettings: CameraAppSettings,
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     cameraState: CameraState
 ): FlashModeUiState {
     return when (this) {

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlipLensUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlipLensUiStateAdapter.kt
@@ -18,7 +18,7 @@ package com.google.jetpackcamera.ui.uistateadapter.capture
 import com.example.uistateadapter.Utils
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.ui.uistate.capture.FlipLensUiState
 
 private val ORDERED_UI_SUPPORTED_LENS_FACINGS = listOf(
@@ -29,7 +29,7 @@ private val ORDERED_UI_SUPPORTED_LENS_FACINGS = listOf(
 
 fun FlipLensUiState.Companion.from(
     cameraAppSettings: CameraAppSettings,
-    systemConstraints: SystemConstraints
+    systemConstraints: CameraSystemConstraints
 ): FlipLensUiState {
     val supportedLensFacings = systemConstraints.availableLenses.toSet()
     val availableLensFacings =

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/HdrUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/HdrUiStateAdapter.kt
@@ -21,13 +21,13 @@ import com.google.jetpackcamera.model.ExternalCaptureMode
 import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraConstraints
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import com.google.jetpackcamera.ui.uistate.capture.HdrUiState
 
 fun HdrUiState.Companion.from(
     cameraAppSettings: CameraAppSettings,
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     externalCaptureMode: ExternalCaptureMode
 ): HdrUiState {
     val cameraConstraints: CameraConstraints? = systemConstraints.forCurrentLens(

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/ZoomControlUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/ZoomControlUiStateAdapter.kt
@@ -18,12 +18,12 @@ package com.google.jetpackcamera.ui.uistateadapter.capture
 import android.util.Range
 import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.ui.uistate.capture.ZoomControlUiState
 
 fun ZoomControlUiState.Companion.from(
     animateZoomState: Float?,
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     cameraAppSettings: CameraAppSettings,
     cameraState: CameraState
 ): ZoomControlUiState {

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/ZoomUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/ZoomUiStateAdapter.kt
@@ -18,11 +18,11 @@ package com.google.jetpackcamera.ui.uistateadapter.capture
 import android.util.Range
 import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.model.LensFacing
-import com.google.jetpackcamera.settings.model.SystemConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.ui.uistate.capture.ZoomUiState
 
 fun ZoomUiState.Companion.from(
-    systemConstraints: SystemConstraints,
+    systemConstraints: CameraSystemConstraints,
     lensFacing: LensFacing,
     cameraState: CameraState
 ): ZoomUiState = ZoomUiState.Enabled(


### PR DESCRIPTION
This commit renames CameraUseCase to CameraSystem to avoid confusion with the "UseCase" pattern from Clean Architecture. The previous name was misleading, as the class did not follow that specific architectural pattern.

The new name, CameraSystem, more accurately reflects the class's role as the primary, high-level interface for interacting with the device's camera hardware and subsystems.