### PR TITLE
Add Spotless pre-push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,32 @@ OEMs looking to validate their camera feature implementations.
 
 This project uses the gradle build system, and can be imported directly into Android Studio.
 
-Currently, Jetpack Camera App is built using the Android Gradle Plugin 8.10.0, which is only compatible
-with Android Studio Meerkat or newer.
+Currently, Jetpack Camera App is built using the Android Gradle Plugin 8.10.0, which is only 
+compatible with Android Studio Meerkat or newer.
+
+## Pre-push Hook (Recommended)
+
+This repository includes a `pre-push` hook that automatically checks your code for correct 
+formatting using `spotless` before you push your changes. This helps prevent CI failures due to 
+formatting issues.
+
+To enable this hook, run the following command once from the root of the repository:
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+This command configures Git to use the hooks located in the `scripts/git-hooks/` directory for this 
+repository only. It will not affect your other Git projects.
+
+### Bypassing the Hook
+
+If you need to bypass the pre-push check for any reason, you can use the `--no-verify` flag with 
+your push command:
+
+```bash
+git push origin <your-branch-name> --no-verify
+```
 
 # Architecture 📐
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ To enable this hook, run the following command once from the root of the reposit
 git config core.hooksPath scripts/git-hooks
 ```
 
-This command configures Git to use the hooks located in the `scripts/git-hooks/` directory for this 
-repository only. It will not affect your other Git projects.
+This command tells Git to use the hooks located in the `scripts/git-hooks/` directory for this
+repository only. It will not affect your other Git projects. After running the command, the hook
+will automatically run every time you push.
+
 
 ### Bypassing the Hook
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 ![Video Capture with Jetpack Camera App](docs/images/JCA-video-capture.gif "Video Capture with Jetpack Camera App")
 # Jetpack Camera App 📸
 
-Jetpack Camera App (JCA) is a camera app, focused on features used by app developers, and built 
-entirely with CameraX, Kotlin and Jetpack Compose. It follows Android 
+Jetpack Camera App (JCA) is a camera app, focused on features used by app developers, and built
+entirely with CameraX, Kotlin and Jetpack Compose. It follows Android
 design and development best practices and it's intended to be a useful reference for developers and
 OEMs looking to validate their camera feature implementations.
 
-# Development Environment ⚒️ 
+# Development Environment ⚒️
 
 This project uses the gradle build system, and can be imported directly into Android Studio.
 
-Currently, Jetpack Camera App is built using the Android Gradle Plugin 8.10.0, which is only 
+Currently, Jetpack Camera App is built using the Android Gradle Plugin 8.10.0, which is only
 compatible with Android Studio Meerkat or newer.
 
 ## Pre-push Hook (Recommended)
 
-This repository includes a `pre-push` hook that automatically checks your code for correct 
-formatting using `spotless` before you push your changes. This helps prevent CI failures due to 
+This repository includes a `pre-push` hook that automatically checks your code for correct
+formatting using `spotless` before you push your changes. This helps prevent CI failures due to
 formatting issues.
 
 To enable this hook, run the following command once from the root of the repository:
@@ -32,7 +32,7 @@ will automatically run every time you push.
 
 ### Bypassing the Hook
 
-If you need to bypass the pre-push check for any reason, you can use the `--no-verify` flag with 
+If you need to bypass the pre-push check for any reason, you can use the `--no-verify` flag with
 your push command:
 
 ```bash
@@ -61,7 +61,7 @@ Pixel 8 (API 34) emulators which can be used to run instrumentation tests with:
 
 # Features ✨🧰✨
 
-This section provides a detailed overview of the camera app's features, highlighting its 
+This section provides a detailed overview of the camera app's features, highlighting its
 capabilities and functionalities. Each feature is described with its purpose, usage, and any
 relevant considerations to help you understand and utilize the app effectively.
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -2,17 +2,21 @@
 
 echo "Running Spotless check before push..."
 
+GRADLE_BASE_CMD="./gradlew --init-script gradle/init.gradle.kts"
+
 # Run the spotlessCheck command. If it fails, print a helpful message and exit.
-if ! ./gradlew spotlessCheck --init-script gradle/init.gradle.kts; then
-    echo "--------------------------------------------------"
-    echo "ERROR: Spotless check failed."
-    echo "Your code is not formatted correctly."
-    echo ""
-    echo "Please run the following command to fix it:"
-    echo "  ./gradlew spotlessApply --init-script gradle/init.gradle.kts"
-    echo ""
-    echo "Then, stage the changes and amend your commit before pushing."
-    echo "--------------------------------------------------"
+if ! $GRADLE_BASE_CMD spotlessCheck; then
+    {
+        echo "--------------------------------------------------"
+        echo "ERROR: Spotless check failed."
+        echo "Your code is not formatted correctly."
+        echo ""
+        echo "Please run the following command to fix it:"
+        echo "  $GRADLE_BASE_CMD spotlessApply"
+        echo ""
+        echo "Then, stage the changes and amend your commit before pushing."
+        echo "--------------------------------------------------"
+    } >&2
     # Exit with a non-zero status to abort the push
     exit 1
 fi

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -2,16 +2,8 @@
 
 echo "Running Spotless check before push..."
 
-# Run the spotlessCheck command.
-# If it fails, it will exit with a non-zero status code,
-# which will automatically cause the pre-push hook to fail and abort the push.
-./gradlew spotlessCheck --init-script gradle/init.gradle.kts
-
-# Capture the exit code of the last command
-EXIT_CODE=$?
-
-# Check if the command failed
-if [ $EXIT_CODE -ne 0 ]; then
+# Run the spotlessCheck command. If it fails, print a helpful message and exit.
+if ! ./gradlew spotlessCheck --init-script gradle/init.gradle.kts; then
     echo "--------------------------------------------------"
     echo "ERROR: Spotless check failed."
     echo "Your code is not formatted correctly."

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+echo "Running Spotless check before push..."
+
+# Run the spotlessCheck command.
+# If it fails, it will exit with a non-zero status code,
+# which will automatically cause the pre-push hook to fail and abort the push.
+./gradlew spotlessCheck --init-script gradle/init.gradle.kts
+
+# Capture the exit code of the last command
+EXIT_CODE=$?
+
+# Check if the command failed
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "--------------------------------------------------"
+    echo "ERROR: Spotless check failed."
+    echo "Your code is not formatted correctly."
+    echo ""
+    echo "Please run the following command to fix it:"
+    echo "  ./gradlew spotlessApply --init-script gradle/init.gradle.kts"
+    echo ""
+    echo "Then, stage the changes and amend your commit before pushing."
+    echo "--------------------------------------------------"
+    # Exit with a non-zero status to abort the push
+    exit 1
+fi
+
+echo "Spotless check passed. Proceeding with push."
+exit 0


### PR DESCRIPTION
Adds a `pre-push` Git hook to automatically verify code formatting
before code is pushed.

The hook runs `./gradlew spotlessCheck` to ensure code adheres to
project style guidelines. This prevents CI failures caused by
formatting errors and helps maintain a consistent codebase.

To enable this, developers must run this command once:
`git config core.hooksPath scripts/git-hooks`

The check can be bypassed for a single push using the `--no-verify`
flag. Setup instructions have been added to README.md.
