### PR TITLE
Fix flash mode adapter state logic

### DIFF
--- a/ui/uistate/src/main/java/com/google/jetpackcamera/ui/uistate/SingleSelectableUiState.kt
+++ b/ui/uistate/src/main/java/com/google/jetpackcamera/ui/uistate/SingleSelectableUiState.kt
@@ -27,11 +27,13 @@ import android.content.Context
  * @param T The type of the value that can be selected or is disabled.
  */
 sealed interface SingleSelectableUiState<T> {
+    val value: T
+
     /**
      * Represents an item that is currently available for selection.
      * @property value The underlying value of the selectable item.
      */
-    data class SelectableUi<T>(val value: T) : SingleSelectableUiState<T>
+    data class SelectableUi<T>(override val value: T) : SingleSelectableUiState<T>
 
     /**
      * Represents an item that is currently disabled and cannot be selected.
@@ -39,7 +41,7 @@ sealed interface SingleSelectableUiState<T> {
      * @property value The underlying value of the item, even though it's disabled.
      * @property disabledReason The rationale explaining why this item is disabled.
      */
-    data class Disabled<T>(val value: T, val disabledReason: DisableRationale) :
+    data class Disabled<T>(override val value: T, val disabledReason: DisableRationale) :
         SingleSelectableUiState<T>
 }
 

--- a/ui/uistateadapter/capture/build.gradle.kts
+++ b/ui/uistateadapter/capture/build.gradle.kts
@@ -75,6 +75,9 @@ dependencies {
     implementation(project(":ui:uistateadapter"))
     implementation(project(":ui:uistate:capture"))
     implementation(project(":ui:components:capture"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
 }
 
 // Allow references to generated code

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapter.kt
@@ -80,16 +80,19 @@ fun FlashModeUiState.updateFrom(
         }
 
         is Available -> {
-            val previousFlashMode = this.selectedFlashMode
-            val previousAvailableFlashModes = this.availableFlashModes
-            val currentAvailableFlashModes =
-                previousAvailableFlashModes.map { supportedFlashMode ->
-                    SingleSelectableUiState.SelectableUi(supportedFlashMode)
-                }
-            if (previousAvailableFlashModes != currentAvailableFlashModes) {
+            val supportedFlashModes =
+                systemConstraints.forCurrentLens(cameraAppSettings)?.supportedFlashModes
+                    ?: setOf(FlashMode.OFF)
+
+            // check if supported flash modes have changed without allocating a new list/set
+            val availableModesChanged =
+                this.availableFlashModes.size != supportedFlashModes.size ||
+                    this.availableFlashModes.any { !supportedFlashModes.contains(it.value) }
+
+            if (availableModesChanged) {
                 // Supported flash modes have changed, generate a new FlashModeUiState
                 FlashModeUiState.Companion.from(cameraAppSettings, systemConstraints)
-            } else if (previousFlashMode != cameraAppSettings.flashMode) {
+            } else if (this.selectedFlashMode != cameraAppSettings.flashMode) {
                 // Only the selected flash mode has changed, just update the flash mode
                 copy(selectedFlashMode = cameraAppSettings.flashMode)
             } else {

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlipLensUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlipLensUiStateAdapter.kt
@@ -43,24 +43,3 @@ fun FlipLensUiState.Companion.from(
         availableLensFacings = availableLensFacings
     )
 }
-
-private fun createFrom(
-    selectedLensFacing: LensFacing,
-    supportedLensFacings: Set<LensFacing>
-): FlipLensUiState {
-    // Ensure we at least support one flash mode
-    check(supportedLensFacings.isNotEmpty()) {
-        "No lens supported."
-    }
-
-    val availableLensFacings =
-        Utils.getSelectableListFromValues(
-            supportedLensFacings,
-            ORDERED_UI_SUPPORTED_LENS_FACINGS
-        )
-
-    return FlipLensUiState.Available(
-        selectedLensFacing = selectedLensFacing,
-        availableLensFacings = availableLensFacings
-    )
-}

--- a/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
+++ b/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.ui.uistateadapter.capture
+
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.CameraState
+import com.google.jetpackcamera.model.FlashMode
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
+import com.google.jetpackcamera.ui.uistate.capture.FlashModeUiState
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class FlashModeUiStateAdapterTest {
+
+    private val emptyCameraConstraints = CameraConstraints(
+        supportedStabilizationModes = emptySet(),
+        supportedFixedFrameRates = emptySet(),
+        supportedDynamicRanges = emptySet(),
+        supportedVideoQualitiesMap = emptyMap(),
+        supportedImageFormatsMap = emptyMap(),
+        supportedIlluminants = emptySet(),
+        supportedFlashModes = emptySet(),
+        supportedZoomRange = null,
+        unsupportedStabilizationFpsMap = emptyMap(),
+        supportedTestPatterns = emptySet()
+    )
+
+    private val defaultCameraAppSettings = CameraAppSettings()
+    private val defaultCameraState = CameraState()
+
+    @Test
+    fun from_noFlashModes_returnsUnavailable() {
+        // Given a system with no available flash modes
+        val systemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                defaultCameraAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF)
+                )
+            )
+        )
+
+        // When creating the UI state from these constraints
+        val flashModeUiState = FlashModeUiState.from(defaultCameraAppSettings, systemConstraints)
+
+        // Then the UI state is Unavailable
+        assertThat(flashModeUiState).isInstanceOf(FlashModeUiState.Unavailable::class.java)
+    }
+
+    @Test
+    fun updateFrom_sameAvailableFlashModes_noUpdate() {
+        // Given an initial UI state
+        val initialSystemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                defaultCameraAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.ON, FlashMode.AUTO)
+                )
+            )
+        )
+        val uiState = FlashModeUiState.from(defaultCameraAppSettings, initialSystemConstraints)
+
+        // When updating with the same constraints
+        val updatedUiState = uiState.updateFrom(
+            defaultCameraAppSettings,
+            initialSystemConstraints,
+            defaultCameraState
+        )
+
+        // Then the state does not change, and the same object is returned
+        assertThat(updatedUiState).isSameInstanceAs(uiState)
+    }
+
+    @Test
+    fun updateFrom_differentAvailableFlashModes_updatesSelectableValues() {
+        // Given an initial UI state
+        val initialSystemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                defaultCameraAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.ON)
+                )
+            )
+        )
+        val uiState = FlashModeUiState.from(defaultCameraAppSettings, initialSystemConstraints)
+
+        // When the available flash modes change
+        val newSystemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                defaultCameraAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.ON, FlashMode.AUTO)
+                )
+            )
+        )
+        val updatedUiState = uiState.updateFrom(
+            defaultCameraAppSettings,
+            newSystemConstraints,
+            defaultCameraState
+        )
+
+        // Then the selectable values are updated
+        assertThat(updatedUiState).isInstanceOf(FlashModeUiState.Available::class.java)
+        val availableUiState = updatedUiState as FlashModeUiState.Available
+        assertThat(availableUiState.availableFlashModes.map { it.value }).containsExactly(
+            FlashMode.OFF,
+            FlashMode.ON,
+            FlashMode.AUTO
+        )
+    }
+
+    @Test
+    fun updateFrom_unavailablePreviouslySelectedFlashMode_throwsException() {
+        // Given an initial UI state with ON selected
+        val initialAppSettings = defaultCameraAppSettings.copy(flashMode = FlashMode.ON)
+        val initialSystemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.ON)
+                )
+            )
+        )
+        val uiState = FlashModeUiState.from(initialAppSettings, initialSystemConstraints)
+
+        // When the selected flash mode (ON) is no longer available
+        val newSystemConstraints = CameraSystemConstraints(
+            perLensConstraints = mapOf(
+                initialAppSettings.cameraLensFacing to emptyCameraConstraints.copy(
+                    supportedFlashModes = setOf(FlashMode.OFF, FlashMode.AUTO)
+                )
+            )
+        )
+
+        // Then an IllegalStateException is thrown
+        assertThrows(IllegalStateException::class.java) {
+            uiState.updateFrom(
+                initialAppSettings,
+                newSystemConstraints,
+                defaultCameraState
+            )
+        }
+    }
+}


### PR DESCRIPTION
The `FlashModeUiStateAdapter` was not correctly updating its
state from `systemConstraints`. It was comparing against its
previous state, which could lead to stale UI when available
flash modes changed.

This has been corrected, and the adapter now properly derives
its state from the latest `systemConstraints`.

Tests have been added to verify the adapter's
logic.

The tests also check for referential equality to prevent
unnecessary object allocations.
