### PR TITLE
Add DefaultCoroutineScope annotation for jca's coroutine scope

### DIFF
--- a/core/common/src/main/java/com/google/jetpackcamera/core/common/CommonModule.kt
+++ b/core/common/src/main/java/com/google/jetpackcamera/core/common/CommonModule.kt
@@ -43,7 +43,8 @@ class CommonModule {
     @Singleton
     @DefaultCoroutineScope
     @Provides
-fun providesCoroutineScope(@DefaultDispatcher dispatcher: CoroutineDispatcher) = CoroutineScope(SupervisorJob() + dispatcher)
+    fun providesCoroutineScope(@DefaultDispatcher dispatcher: CoroutineDispatcher) =
+        CoroutineScope(SupervisorJob() + dispatcher)
 }
 
 @Qualifier


### PR DESCRIPTION
The coroutineScope obtained from this provider method is actually not used at all in JCA. However, if another app imports camera/core as a library and it already has a provider method for coroutine scope, this would cause a conflict. To avoid this, specify a custom annotation for this scope