### PR TITLE
Correctly apply semantics in QuickSettingsScreen

### DIFF
--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/quicksettings/QuickSettingsScreen.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/quicksettings/QuickSettingsScreen.kt
@@ -121,11 +121,7 @@ fun QuickSettingsBottomSheet(
                             ToggleFocusedQuickSetCaptureMode(
                                 modifier = Modifier
                                     .testTag(BTN_QUICK_SETTINGS_FOCUS_CAPTURE_MODE)
-                                    .semantics {
-                                        if (description != null) {
-                                            stateDescription = description
-                                        }
-                                    },
+                                    .semantics { description?.let { stateDescription = it } },
                                 setCaptureMode = {
                                     onSetFocusedSetting(FocusedQuickSetting.CAPTURE_MODE)
                                 },


### PR DESCRIPTION
The semantics modifier in QuickSettingsScreen was being called within an
`apply` block on the Modifier. This was incorrect because the `semantics`
function returns a new Modifier instance, which was being discarded as it
was not the return value of the `apply` block.

As a result, the `stateDescription` for the quick setting was never
actually applied to the composable.

This change moves the `semantics` call to be a direct part of the
Modifier chain. This ensures that the Modifier with the correct
semantics is used, and the `stateDescription` is properly set.

This fixes the
`ConcurrentCameraTest#concurrentCameraMode_whenEnabled_disablesOtherSettings`
test, which relies on checking the `stateDescription` to verify that
other settings are correctly disabled when concurrent camera mode is
enabled.
