### PR TITLE
Fix log tag to use TAG constant

### DIFF
--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureScreenComponents.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureScreenComponents.kt
@@ -469,7 +469,7 @@ fun PreviewDisplay(
                                     with(coordinateTransformer) {
                                         val surfaceCoords = it.transform()
                                         Log.d(
-                                            "TAG",
+                                            TAG,
                                             "onTapToFocus: " +
                                                 "input{$it} -> surface{$surfaceCoords}"
                                         )


### PR DESCRIPTION
Changed hardcoded "TAG" string to TAG constant in tap-to-focus log statement

https://github.com/google/jetpack-camera-app/blob/6ba412b90febc88a39603e38dea99baa09fb2d1d/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureScreenComponents.kt#L468-L475

Please note: I understand that minor typo fixes might not be the priority for this project. If you prefer not to accept this type of contribution, I'm happy to close this PR. No hard feelings!