### PR TITLE
Add ContentResolver to ImagePostProcessor.processImage()

### DIFF
--- a/core/camera/postprocess/src/main/java/com/google/jetpackcamera/core/camera/postprocess/ImagePostProcessor.kt
+++ b/core/camera/postprocess/src/main/java/com/google/jetpackcamera/core/camera/postprocess/ImagePostProcessor.kt
@@ -15,6 +15,7 @@
  */
 package com.google.jetpackcamera.core.camera.postprocess
 
+import android.content.ContentResolver
 import android.net.Uri
 
 /**
@@ -30,5 +31,5 @@ interface ImagePostProcessor {
      *
      * @param uri The [Uri] of the saved image that needs to be processed.
      */
-    suspend fun postProcessImage(uri: Uri)
+    suspend fun postProcessImage(uri: Uri, contentResolver: ContentResolver)
 }

--- a/core/camera/postprocess/src/main/java/com/google/jetpackcamera/core/camera/postprocess/ImagePostProcessor.kt
+++ b/core/camera/postprocess/src/main/java/com/google/jetpackcamera/core/camera/postprocess/ImagePostProcessor.kt
@@ -30,6 +30,7 @@ interface ImagePostProcessor {
      * performing the post-processing.
      *
      * @param uri The [Uri] of the saved image that needs to be processed.
+     * @param contentResolver The [ContentResolver] used for post processing.
      */
     suspend fun postProcessImage(uri: Uri, contentResolver: ContentResolver)
 }

--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
@@ -140,6 +140,7 @@ class CameraXCameraSystemTest {
 
         // Assert.
         assertThat(imagePostProcessor.postProcessImageCalled).isTrue()
+        assertThat(imagePostProcessor.savedContentResolver).isEqualTo(contentResolver)
     }
 
     @Test
@@ -160,6 +161,7 @@ class CameraXCameraSystemTest {
 
         // Assert.
         assertThat(imagePostProcessor.postProcessImageCalled).isFalse()
+        assertThat(imagePostProcessor.savedContentResolver).isNull()
     }
 
     @Test
@@ -177,6 +179,7 @@ class CameraXCameraSystemTest {
         } catch (e: RuntimeException) {
             // Assert.
             assertThat(imagePostProcessor.postProcessImageCalled).isTrue()
+            assertThat(imagePostProcessor.savedContentResolver).isEqualTo(contentResolver)
 
             val savedUri = imagePostProcessor.savedUri
             assertThat(savedUri).isNotNull()
@@ -405,9 +408,11 @@ object FakeImagePostProcessorFeatureKey : ImagePostProcessorFeatureKey
 class FakeImagePostProcessor(val shouldError: Boolean = false) : ImagePostProcessor {
     var postProcessImageCalled = false
     var savedUri: Uri? = null
+    var savedContentResolver: ContentResolver? = null
     override suspend fun postProcessImage(uri: Uri, contentResolver: ContentResolver) {
         postProcessImageCalled = true
         savedUri = uri
+        savedContentResolver = contentResolver
         if (shouldError) throw RuntimeException("Post process failed")
     }
 }

--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
@@ -405,7 +405,7 @@ object FakeImagePostProcessorFeatureKey : ImagePostProcessorFeatureKey
 class FakeImagePostProcessor(val shouldError: Boolean = false) : ImagePostProcessor {
     var postProcessImageCalled = false
     var savedUri: Uri? = null
-    override suspend fun postProcessImage(uri: Uri) {
+    override suspend fun postProcessImage(uri: Uri, contentResolver: ContentResolver) {
         postProcessImageCalled = true
         savedUri = uri
         if (shouldError) throw RuntimeException("Post process failed")

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -620,7 +620,7 @@ constructor(
         }.also { outputFileResults ->
             outputFileResults.savedUri?.let {
                 for ((key, value) in imagePostProcessors) {
-                    value.get().postProcessImage(it)
+                    value.get().postProcessImage(it, contentResolver)
                     Log.d(TAG, "Post processed image with $key")
                 }
                 Log.d(TAG, "Saved image to $it")


### PR DESCRIPTION
As titled. Any implementations of such ImagePostProcessor likely needs access to the contentResolver that is used during the image capture process. Adding it as an input parameter to processImage()