### PR TITLE
scrollable setting dialog

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -50,8 +50,8 @@ import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.settings.R as SettingsR
 import com.google.jetpackcamera.settings.ui.BACK_BUTTON
-import com.google.jetpackcamera.settings.ui.BTN_CLOSE_POPUP
 import com.google.jetpackcamera.settings.ui.BTN_SWITCH_SETTING_LENS_FACING_TAG
+import com.google.jetpackcamera.settings.ui.CLOSE_BUTTON
 import com.google.jetpackcamera.settings.ui.SETTINGS_TITLE
 import com.google.jetpackcamera.ui.components.capture.BTN_QUICK_SETTINGS_FOCUSED_CAPTURE_MODE_IMAGE_ONLY
 import com.google.jetpackcamera.ui.components.capture.BTN_QUICK_SETTINGS_FOCUSED_CAPTURE_MODE_OPTION_STANDARD
@@ -623,7 +623,7 @@ inline fun <T> SettingsScreenScope.visitSettingDialog(
     try {
         return block()
     } finally {
-        onNodeWithTag(BTN_CLOSE_POPUP)
+        onNodeWithTag(CLOSE_BUTTON)
             .assertExists()
             .performClick()
 

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -50,8 +50,8 @@ import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.settings.R as SettingsR
 import com.google.jetpackcamera.settings.ui.BACK_BUTTON
+import com.google.jetpackcamera.settings.ui.BTN_CLOSE_POPUP
 import com.google.jetpackcamera.settings.ui.BTN_SWITCH_SETTING_LENS_FACING_TAG
-import com.google.jetpackcamera.settings.ui.CLOSE_BUTTON
 import com.google.jetpackcamera.settings.ui.SETTINGS_TITLE
 import com.google.jetpackcamera.ui.components.capture.BTN_QUICK_SETTINGS_FOCUSED_CAPTURE_MODE_IMAGE_ONLY
 import com.google.jetpackcamera.ui.components.capture.BTN_QUICK_SETTINGS_FOCUSED_CAPTURE_MODE_OPTION_STANDARD
@@ -623,7 +623,7 @@ inline fun <T> SettingsScreenScope.visitSettingDialog(
     try {
         return block()
     } finally {
-        onNodeWithTag(CLOSE_BUTTON)
+        onNodeWithTag(BTN_CLOSE_POPUP)
             .assertExists()
             .performClick()
 

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -914,16 +914,24 @@ fun BasicPopupSetting(
                 Text(
                     text = "Close",
                     modifier = Modifier
-                        .testTag(CLOSE_BUTTON)
+                        .testTag(BTN_CLOSE_POPUP)
                         .clickable { popupStatus.value = false }
                 )
             },
             title = { Text(text = title) },
             text = {
-                MaterialTheme(
-                    colorScheme = MaterialTheme.colorScheme.copy(surface = Color.Transparent),
-                    content = popupContents
-                )
+                // Apply a scroll state to ensure content is reachable
+                val scrollState = rememberScrollState()
+                Column(
+                    modifier = Modifier
+                        .testTag(CONTAINER_DIALOG_CONTENTS)
+                        .verticalScroll(scrollState)
+                ) {
+                    MaterialTheme(
+                        colorScheme = MaterialTheme.colorScheme.copy(surface = Color.Transparent),
+                        content = popupContents
+                    )
+                }
             }
         )
     }

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -910,7 +910,7 @@ fun BasicPopupSetting(
                 Text(
                     text = "Close",
                     modifier = Modifier
-                        .testTag(BTN_CLOSE_POPUP)
+                        .testTag(CLOSE_BUTTON)
                         .clickable { popupStatus.value = false }
                 )
             },

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -791,11 +791,7 @@ fun VideoQualitySetting(
             }
         },
         popupContents = {
-            Column(
-                Modifier
-                    .selectableGroup()
-                    .verticalScroll(rememberScrollState())
-            ) {
+            Column(Modifier.selectableGroup()) {
                 SingleChoiceSelector(
                     modifier = Modifier.testTag(
                         getVideoQualityOptionTestTag(VideoQuality.UNSPECIFIED)

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/TestTags.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/TestTags.kt
@@ -27,7 +27,8 @@ package com.google.jetpackcamera.settings.ui
 
 const val SETTINGS_TITLE = "SettingsTitle"
 const val BACK_BUTTON = "BackButton"
-const val CLOSE_BUTTON = "CloseButton"
+const val BTN_CLOSE_POPUP = "btn_close_popup"
+const val CONTAINER_DIALOG_CONTENTS = "container_dialog_contents"
 
 // unsupported rationale tags
 const val DEVICE_UNSUPPORTED_TAG = "DeviceUnsupportedTag"

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/TestTags.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/TestTags.kt
@@ -27,8 +27,8 @@ package com.google.jetpackcamera.settings.ui
 
 const val SETTINGS_TITLE = "SettingsTitle"
 const val BACK_BUTTON = "BackButton"
-const val BTN_CLOSE_POPUP = "btn_close_popup"
-const val CONTAINER_DIALOG_CONTENTS = "container_dialog_contents"
+const val CLOSE_BUTTON = "CloseButton"
+const val CONTAINER_DIALOG_CONTENTS = "dialog_contents_container"
 
 // unsupported rationale tags
 const val DEVICE_UNSUPPORTED_TAG = "DeviceUnsupportedTag"


### PR DESCRIPTION
Adds a scrollable  property to settings screen alert dialogs, such that overflowing text can still be accessible.

The id of the scrollable container is: `dialog_contents_container`