### PR TITLE
Add topStartButton parameter to PreviewLayout

### DIFF
--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureLayout.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureLayout.kt
@@ -76,7 +76,8 @@ fun PreviewLayout(
     debugOverlay: @Composable (Modifier) -> Unit,
     debugVisibilityWrapper: (@Composable (@Composable () -> Unit) -> Unit),
     screenFlashOverlay: @Composable (Modifier) -> Unit,
-    snackBar: @Composable (Modifier, snackbarHostState: SnackbarHostState) -> Unit
+    snackBar: @Composable (Modifier, snackbarHostState: SnackbarHostState) -> Unit,
+    topStartButton: @Composable (Modifier) -> Unit = {}
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
@@ -86,7 +87,10 @@ fun PreviewLayout(
         Box(modifier = modifier.background(Color.Black)) {
             Column {
                 indicatorRow(Modifier.statusBarsPadding())
-                viewfinder(Modifier)
+                Box {
+                    viewfinder(Modifier)
+                    topStartButton(Modifier.align(Alignment.TopStart).padding(paddingValues))
+                }
             }
 
             Box(

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureLayout.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureLayout.kt
@@ -89,7 +89,7 @@ fun PreviewLayout(
                 indicatorRow(Modifier.statusBarsPadding())
                 Box {
                     viewfinder(Modifier)
-                    topStartButton(Modifier.align(Alignment.TopStart).padding(paddingValues))
+                    topStartButton(Modifier.align(Alignment.TopStart))
                 }
             }
 


### PR DESCRIPTION
This PR adds the topStartButton parameter to PreviewLayout and places it stacked on top of the viewfinder.

Tested with an example button:
<img width="413" height="914" alt="Screenshot 2026-04-29 at 3 25 54 PM" src="https://github.com/user-attachments/assets/a9ab70ba-64c5-4e4d-93b9-769295f58d80" />

