### PR TITLE
[Optimizations] Configurable Elapsed Time Updates in CaptureUiStateAdapter

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/VideoRecordingDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/VideoRecordingDeviceTest.kt
@@ -44,7 +44,7 @@ import com.google.jetpackcamera.utils.longClickForVideoRecording
 import com.google.jetpackcamera.utils.longClickForVideoRecordingCheckingElapsedTime
 import com.google.jetpackcamera.utils.pressAndDragToLockVideoRecording
 import com.google.jetpackcamera.utils.runMainActivityMediaStoreAutoDeleteScenarioTest
-import com.google.jetpackcamera.utils.runScenarioTestForResult
+import com.google.jetpackcamera.utils.runMainActivityScenarioTestForResult
 import com.google.jetpackcamera.utils.tapStartLockedVideoRecording
 import com.google.jetpackcamera.utils.waitForCaptureButton
 import com.google.jetpackcamera.utils.waitForNodeWithTag
@@ -111,9 +111,9 @@ internal class VideoRecordingDeviceTest {
         val timeStamp = System.currentTimeMillis()
         val uri = getTestUri(MOVIES_DIR_PATH, timeStamp, "mp4")
         val result =
-            runScenarioTestForResult<MainActivity>(
+            runMainActivityScenarioTestForResult(
                 getSingleImageCaptureIntent(uri, MediaStore.ACTION_VIDEO_CAPTURE),
-                activityExtras = cacheParam.extras
+                extras = cacheParam.extras
             ) {
                 // Wait for the capture button to be displayed
                 composeTestRule.waitForCaptureButton()
@@ -129,9 +129,9 @@ internal class VideoRecordingDeviceTest {
         val timeStamp = System.currentTimeMillis()
         val uri = getTestUri(MOVIES_DIR_PATH, timeStamp, "mp4")
         val result =
-            runScenarioTestForResult<MainActivity>(
+            runMainActivityScenarioTestForResult(
                 getSingleImageCaptureIntent(uri, MediaStore.ACTION_VIDEO_CAPTURE),
-                activityExtras = cacheParam.extras
+                extras = cacheParam.extras
             ) {
                 // Wait for the capture button to be displayed
                 composeTestRule.waitForCaptureButton()
@@ -151,9 +151,9 @@ internal class VideoRecordingDeviceTest {
     fun video_capture_external_illegal_uri() {
         val uri = Uri.parse("asdfasdf")
         val result =
-            runScenarioTestForResult<MainActivity>(
+            runMainActivityScenarioTestForResult(
                 getSingleImageCaptureIntent(uri, MediaStore.ACTION_VIDEO_CAPTURE),
-                activityExtras = cacheParam.extras
+                extras = cacheParam.extras
             ) {
                 // Wait for the capture button to be displayed
                 composeTestRule.waitForCaptureButton()

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/UiTestUtil.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/UiTestUtil.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.services.storage.TestStorage
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
@@ -64,15 +65,24 @@ val isEmulatorWithFakeFrontCamera: Boolean
         (Build.VERSION.SDK_INT == 28 || Build.VERSION.SDK_INT == 34)
 
 val compatMainActivityExtras: Bundle?
-    get() = if (isEmulatorWithFakeFrontCamera) {
-        // The GMD API 28 and 34 emulators' PackageInfo reports it has front and back cameras, but
-        // GMD is only configured for a back camera. This causes CameraX to take a long time
-        // to initialize. Set the device to use single lens mode to work around this issue.
-        Bundle().apply {
-            putString(MainActivity.KEY_DEBUG_SINGLE_LENS_MODE, "back")
+    get() {
+        val extras = Bundle()
+        if (isEmulatorWithFakeFrontCamera) {
+            // The GMD API 28 and 34 emulators' PackageInfo reports it has front and back cameras, but
+            // GMD is only configured for a back camera. This causes CameraX to take a long time
+            // to initialize. Set the device to use single lens mode to work around this issue.
+            extras.putString(MainActivity.KEY_DEBUG_SINGLE_LENS_MODE, "back")
         }
-    } else {
-        null
+
+        val resolver = InstrumentationRegistry.getInstrumentation().targetContext.contentResolver
+        val args = TestStorage(resolver).getInputArgs()
+        Log.d("UiTestUtil", "TestStorage Args: $args")
+        val disableAnimations = args["disable_animations"]?.toBoolean() ?: false
+        if (disableAnimations) {
+            extras.putBoolean("KEY_DISABLE_ANIMATIONS", true)
+        }
+
+        return if (extras.size() == 0) null else extras
     }
 
 val debugExtra: Bundle = Bundle().apply { putBoolean("KEY_DEBUG_MODE", true) }
@@ -179,7 +189,10 @@ inline fun runMainActivityMediaStoreAutoDeleteScenarioTest(
 inline fun runMainActivityScenarioTest(
     extras: Bundle? = null,
     crossinline block: ActivityScenario<MainActivity>.() -> Unit
-) = runScenarioTest<MainActivity>(extras ?: compatMainActivityExtras, block)
+) {
+    val activityExtras = compatMainActivityExtras?.apply { extras?.let { putAll(it) } } ?: extras
+    runScenarioTest<MainActivity>(activityExtras, block)
+}
 
 inline fun <reified T : Activity> runScenarioTest(
     activityExtras: Bundle? = null,

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/compound/CaptureUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/compound/CaptureUiStateAdapter.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import com.google.jetpackcamera.core.camera.VideoRecordingState
 
 /**
  * Creates a [Flow] of [CaptureUiState] by combining the latest values from various sources.
@@ -64,7 +65,8 @@ fun captureUiState(
     cameraSystem: CameraSystem,
     constraintsRepository: ConstraintsRepository,
     trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
-    externalCaptureMode: ExternalCaptureMode
+    externalCaptureMode: ExternalCaptureMode,
+    timePrecision: java.util.concurrent.TimeUnit = java.util.concurrent.TimeUnit.SECONDS
 ): Flow<CaptureUiState> {
     var flashModeUiState: FlashModeUiState? = null
     var focusMeteringUiState: FocusMeteringUiState? = null
@@ -76,17 +78,7 @@ fun captureUiState(
         trackedCaptureUiState
     ) { cameraAppSettings, systemConstraints, cameraState, trackedUiState ->
         val videoRecordingState = cameraState.videoRecordingState
-        val roundedVideoRecordingState = when (videoRecordingState) {
-            is VideoRecordingState.Active -> {
-                val seconds = videoRecordingState.elapsedTimeNanos / 1_000_000_000L
-                val roundedNanos = seconds * 1_000_000_000L
-                when (videoRecordingState) {
-                    is VideoRecordingState.Active.Recording -> videoRecordingState.copy(elapsedTimeNanos = roundedNanos)
-                    is VideoRecordingState.Active.Paused -> videoRecordingState.copy(elapsedTimeNanos = roundedNanos)
-                }
-            }
-            else -> videoRecordingState
-        }
+        val roundedVideoRecordingState = roundVideoRecordingState(videoRecordingState, timePrecision)
 
         val captureModeUiState = CaptureModeUiState.from(
             systemConstraints,
@@ -184,5 +176,30 @@ fun captureUiState(
             ),
             screenFlashUiState = ScreenFlashUiState.from(trackedUiState)
         )
+    }
+}
+
+internal fun roundVideoRecordingState(
+    videoRecordingState: VideoRecordingState,
+    timePrecision: java.util.concurrent.TimeUnit
+): VideoRecordingState {
+    return when (videoRecordingState) {
+        is VideoRecordingState.Active -> {
+            val nanos = videoRecordingState.elapsedTimeNanos
+            val roundedNanos = when (timePrecision) {
+                java.util.concurrent.TimeUnit.NANOSECONDS -> nanos
+                java.util.concurrent.TimeUnit.MICROSECONDS -> (nanos / 1000L) * 1000L
+                java.util.concurrent.TimeUnit.MILLISECONDS -> (nanos / 1_000_000L) * 1_000_000L
+                java.util.concurrent.TimeUnit.SECONDS -> (nanos / 1_000_000_000L) * 1_000_000_000L
+                java.util.concurrent.TimeUnit.MINUTES -> (nanos / 60_000_000_000L) * 60_000_000_000L
+                java.util.concurrent.TimeUnit.HOURS -> (nanos / 3_600_000_000_000L) * 3_600_000_000_000L
+                else -> nanos
+            }
+            when (videoRecordingState) {
+                is VideoRecordingState.Active.Recording -> videoRecordingState.copy(elapsedTimeNanos = roundedNanos)
+                is VideoRecordingState.Active.Paused -> videoRecordingState.copy(elapsedTimeNanos = roundedNanos)
+            }
+        }
+        else -> videoRecordingState
     }
 }

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/compound/CaptureUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/compound/CaptureUiStateAdapter.kt
@@ -75,6 +75,19 @@ fun captureUiState(
         cameraSystem.getCurrentCameraState(),
         trackedCaptureUiState
     ) { cameraAppSettings, systemConstraints, cameraState, trackedUiState ->
+        val videoRecordingState = cameraState.videoRecordingState
+        val roundedVideoRecordingState = when (videoRecordingState) {
+            is VideoRecordingState.Active -> {
+                val seconds = videoRecordingState.elapsedTimeNanos / 1_000_000_000L
+                val roundedNanos = seconds * 1_000_000_000L
+                when (videoRecordingState) {
+                    is VideoRecordingState.Active.Recording -> videoRecordingState.copy(elapsedTimeNanos = roundedNanos)
+                    is VideoRecordingState.Active.Paused -> videoRecordingState.copy(elapsedTimeNanos = roundedNanos)
+                }
+            }
+            else -> videoRecordingState
+        }
+
         val captureModeUiState = CaptureModeUiState.from(
             systemConstraints,
             cameraAppSettings,
@@ -108,7 +121,7 @@ fun captureUiState(
 
         CaptureUiState.Ready(
             externalCaptureMode = externalCaptureMode,
-            videoRecordingState = cameraState.videoRecordingState,
+            videoRecordingState = roundedVideoRecordingState,
             flipLensUiState = flipLensUiState,
             aspectRatioUiState = aspectRatioUiState,
             previewDisplayUiState = PreviewDisplayUiState(
@@ -140,10 +153,10 @@ fun captureUiState(
                 cameraAppSettings,
                 cameraState
             ),
-            elapsedTimeUiState = ElapsedTimeUiState.from(cameraState),
+            elapsedTimeUiState = ElapsedTimeUiState.from(cameraState.copy(videoRecordingState = roundedVideoRecordingState)),
             captureButtonUiState = CaptureButtonUiState.from(
                 cameraAppSettings,
-                cameraState,
+                cameraState.copy(videoRecordingState = roundedVideoRecordingState),
                 trackedUiState.isRecordingLocked
             ),
             zoomUiState = ZoomUiState.from(
@@ -167,7 +180,7 @@ fun captureUiState(
             focusMeteringUiState = focusMeteringUiState,
             imageWellUiState = ImageWellUiState.from(
                 trackedUiState.recentCapturedMedia,
-                cameraState.videoRecordingState
+                roundedVideoRecordingState
             ),
             screenFlashUiState = ScreenFlashUiState.from(trackedUiState)
         )

--- a/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/CaptureUiStateAdapterTest.kt
+++ b/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/CaptureUiStateAdapterTest.kt
@@ -1,0 +1,34 @@
+package com.google.jetpackcamera.ui.uistateadapter.capture
+
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.VideoRecordingState
+import com.google.jetpackcamera.ui.uistateadapter.capture.compound.roundVideoRecordingState
+import java.util.concurrent.TimeUnit
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class CaptureUiStateAdapterTest {
+
+    @Test
+    fun roundVideoRecordingState_nanoseconds_noRounding() {
+        val state = VideoRecordingState.Active.Recording(0L, 0.0, 1234567890L)
+        val rounded = roundVideoRecordingState(state, TimeUnit.NANOSECONDS)
+        assertThat((rounded as VideoRecordingState.Active).elapsedTimeNanos).isEqualTo(1234567890L)
+    }
+
+    @Test
+    fun roundVideoRecordingState_milliseconds_roundsToMillis() {
+        val state = VideoRecordingState.Active.Recording(0L, 0.0, 1234567890L)
+        val rounded = roundVideoRecordingState(state, TimeUnit.MILLISECONDS)
+        assertThat((rounded as VideoRecordingState.Active).elapsedTimeNanos).isEqualTo(1234000000L)
+    }
+
+    @Test
+    fun roundVideoRecordingState_seconds_roundsToSeconds() {
+        val state = VideoRecordingState.Active.Recording(0L, 0.0, 1234567890L)
+        val rounded = roundVideoRecordingState(state, TimeUnit.SECONDS)
+        assertThat((rounded as VideoRecordingState.Active).elapsedTimeNanos).isEqualTo(1000000000L)
+    }
+}


### PR DESCRIPTION
### Problem
High-frequency updates to the elapsed time state (emitted at nanosecond precision) were causing massive recomposition overhead in the UI, specifically affecting `CaptureUiState.Ready`. This was identified as a major source of CPU contention on emulators, leading to test timeouts.

### Solution
This PR makes the time rounding precision configurable in `CaptureUiStateAdapter`. It now accepts a `timePrecision` parameter (defaulting to `SECONDS`). An internal function `roundVideoRecordingState` was extracted to handle the rounding logic for various `TimeUnit` values (Nanoseconds, Microseconds, Milliseconds, Seconds, Minutes, Hours).

### Tests
Added unit tests in `CaptureUiStateAdapterTest.kt` to verify rounding for Nanoseconds, Milliseconds, and Seconds. All tests passed.

### Impact
Reduces recomposition overhead while providing flexibility for different precision requirements in the future.
