### PR TITLE
ci: disable instrumentation tests in presubmit

### DIFF
--- a/.github/workflows/PullRequestWorkflow.yaml
+++ b/.github/workflows/PullRequestWorkflow.yaml
@@ -92,59 +92,6 @@ jobs:
           name: test-reports
           path: "*/build/reports/tests"
 
-  android-test:
-    name: Instrumentation Tests (${{ matrix.device.name }})
-    needs: choose_runner
-    runs-on: ${{ needs.choose_runner.outputs.chosen_runner }}
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        device:
-          - { name: pixel2Api28, img: 'system-images;android-28;google_apis;x86' }
-          - { name: pixel8Api34, img: 'system-images;android-34;aosp_atd;x86_64' }
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: ${{ env.DISTRIBUTION }}
-          java-version: ${{ env.JDK_VERSION }}
-
-      - name: Install Emulator
-        run: |
-          yes | "$ANDROID_HOME"/cmdline-tools/latest/bin/sdkmanager --install "${{ matrix.device.img }}"
-            
-
-      - name: Accept licenses
-        run: yes | "$ANDROID_HOME"/cmdline-tools/latest/bin/sdkmanager --licenses || true
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-      - name: Run instrumentation tests
-        run: ./gradlew ${{ matrix.device.name }}StableDebugAndroidTest
-
-      - name: Upload instrumentation test reports and logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: instrumentation-test-reports-${{ matrix.device.name }}
-          path: |
-            */build/reports/androidTests/**/${{ matrix.device.name }}
-            */build/outputs/androidTest-results/**/${{ matrix.device.name }}
-
   spotless:
     name: Spotless Check
     needs: choose_runner


### PR DESCRIPTION
Removes the android-test job from GitHub Actions to save resources. The Gradle Managed Devices configurations remain intact for occasional local use.
