### PR TITLE
Adopt CameraX Feature Group API

### DIFF
--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera.core.camera
 import android.app.Application
 import android.content.ContentResolver
 import android.net.Uri
+import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -37,11 +38,15 @@ import com.google.jetpackcamera.model.CaptureMode
 import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.Illuminant
+import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.model.VideoQuality
 import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import java.io.File
@@ -85,6 +90,7 @@ class CameraXCameraSystemTest {
         private const val GENERAL_TIMEOUT_MS = 3_000L
         private const val RECORDING_TIMEOUT_MS = 10_000L
         private const val RECORDING_START_DURATION_MS = 500L
+        private const val TAG = "CameraXCameraSystemTest"
     }
 
     @get:Rule
@@ -347,68 +353,205 @@ class CameraXCameraSystemTest {
     }
 
     @Test
-    fun setMultipleFeatures_systemConstraintsUpdatedAndFeaturesSettableIfSupported() = runBlocking {
-        // Arrange.
-        val cameraSystem = createAndInitCameraXCameraSystem()
-        val systemConstraintsFlow = cameraSystem.getSystemConstraints()
+    fun setMultipleFeatures_systemConstraintsUpdatedAndFeaturesSetIfSupported() = runBlocking {
+        // TODO: Add STREAM_CONFIG_SINGLE to the featuresToTest list. This currently leads to flaky
+        //  crashes due to some camera effect related surface not being cleaned up properly somehow.
+        //  This doesn't seem to be related to the primary purpose of this test, so simply excluding
+        //  it for now.
+        val featuresToTest = listOf(
+            Feature.DYNAMIC_RANGE_HLG10,
+            Feature.FPS_60,
+            Feature.VIDEO_QUALITY_UHD
+        )
 
-        // Each camera run/update should lead to a new systemConstraints update
-        var systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
-        cameraSystem.startCameraAndWaitUntilRunning()
+        // TODO: Run a subset of permutations instead of all when `featuresToTest` increases.
+        featuresToTest.permutations().forEach { orderedFeatures ->
+            Log.d(TAG, "Testing $orderedFeatures")
 
-        var currentConstraints = systemConstraintsUpdate.awaitUntil()
-        val lensFacing = cameraSystem.getCurrentSettings().value?.cameraLensFacing
+            // Setup
+            val cameraSystem = createAndInitCameraXCameraSystem()
 
-        // Act: For each of the features — HDR, 60 FPS, UHD recording, await previous constraints
-        //  update and set the feature if the constraints supports it.
+            // Initial run: each camera run/update should lead to a new systemConstraints update
+            var currentConstraints = cameraSystem.getSystemConstraints().observeNextUpdate(
+                this
+            ).let {
+                cameraSystem.startCameraAndWaitUntilRunning()
+                it.awaitUntil()
+            }
 
-        if (
-            currentConstraints
-                .perLensConstraints[lensFacing]
-                ?.supportedDynamicRanges
-                ?.contains(DynamicRange.HLG10) == true
-        ) {
-            systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
-            cameraSystem.setDynamicRange(DynamicRange.HLG10)
-            currentConstraints = systemConstraintsUpdate.awaitUntil()
+            val lensFacing =
+                requireNotNull(cameraSystem.getCurrentSettings().value?.cameraLensFacing)
+
+            orderedFeatures.forEach { feature ->
+                currentConstraints = when (feature) {
+                    Feature.DYNAMIC_RANGE_HLG10 -> feature.tryApplyFeature(
+                        scope = this,
+                        expectedValue = DynamicRange.HLG10,
+                        lensFacing = lensFacing,
+                        cameraSystemConstraints = currentConstraints,
+                        constraintsState = cameraSystem.getSystemConstraints(),
+                        cameraSystem = cameraSystem,
+                        setFeature = { cameraSystem.setDynamicRange(DynamicRange.HLG10) },
+                        getNewFeatureValue = { it?.dynamicRange }
+                    ) { constraints ->
+                        constraints
+                            ?.supportedDynamicRanges
+                            ?.contains(DynamicRange.HLG10) == true
+                    }
+
+                    Feature.FPS_60 -> feature.tryApplyFeature(
+                        scope = this,
+                        expectedValue = 60,
+                        lensFacing = lensFacing,
+                        cameraSystemConstraints = currentConstraints,
+                        constraintsState = cameraSystem.getSystemConstraints(),
+                        cameraSystem = cameraSystem,
+                        setFeature = { cameraSystem.setTargetFrameRate(60) },
+                        getNewFeatureValue = { it?.targetFrameRate }
+                    ) { constraints ->
+                        constraints
+                            ?.supportedFixedFrameRates
+                            ?.contains(60) == true
+                    }
+
+                    Feature.VIDEO_QUALITY_UHD -> feature.tryApplyFeature(
+                        scope = this,
+                        expectedValue = VideoQuality.UHD,
+                        lensFacing = lensFacing,
+                        cameraSystemConstraints = currentConstraints,
+                        constraintsState = cameraSystem.getSystemConstraints(),
+                        cameraSystem = cameraSystem,
+                        setFeature = { cameraSystem.setVideoQuality(VideoQuality.UHD) },
+                        getNewFeatureValue = { it?.videoQuality }
+                    ) { constraints ->
+                        constraints
+                            ?.supportedVideoQualitiesMap
+                            ?.get(cameraSystem.getCurrentSettings().value?.dynamicRange)
+                            ?.contains(VideoQuality.UHD) == true
+                    }
+
+                    Feature.STABILIZATION_MODE_ON -> feature.tryApplyFeature(
+                        scope = this,
+                        expectedValue = StabilizationMode.ON,
+                        lensFacing = lensFacing,
+                        cameraSystemConstraints = currentConstraints,
+                        constraintsState = cameraSystem.getSystemConstraints(),
+                        cameraSystem = cameraSystem,
+                        setFeature = { cameraSystem.setStabilizationMode(StabilizationMode.ON) },
+                        getNewFeatureValue = { it?.stabilizationMode }
+                    ) { constraints ->
+                        constraints
+                            ?.supportedStabilizationModes
+                            ?.contains(StabilizationMode.ON) == true
+                    }
+
+                    Feature.IMAGE_FORMAT_JPEG_ULTRA_HDR -> feature.tryApplyFeature(
+                        scope = this,
+                        expectedValue = ImageOutputFormat.JPEG_ULTRA_HDR,
+                        lensFacing = lensFacing,
+                        cameraSystemConstraints = currentConstraints,
+                        constraintsState = cameraSystem.getSystemConstraints(),
+                        cameraSystem = cameraSystem,
+                        setFeature = {
+                            cameraSystem.setImageFormat(
+                                ImageOutputFormat.JPEG_ULTRA_HDR
+                            )
+                        },
+                        getNewFeatureValue = { it?.imageFormat }
+                    ) { constraints ->
+                        constraints
+                            ?.supportedImageFormatsMap
+                            ?.get(cameraSystem.getCurrentSettings().value?.streamConfig)
+                            ?.contains(ImageOutputFormat.JPEG_ULTRA_HDR) == true
+                    }
+
+                    Feature.STREAM_CONFIG_SINGLE -> feature.tryApplyFeature(
+                        scope = this,
+                        expectedValue = StreamConfig.SINGLE_STREAM,
+                        lensFacing = lensFacing,
+                        cameraSystemConstraints = currentConstraints,
+                        constraintsState = cameraSystem.getSystemConstraints(),
+                        cameraSystem = cameraSystem,
+                        setFeature = { cameraSystem.setStreamConfig(StreamConfig.SINGLE_STREAM) },
+                        getNewFeatureValue = { it?.streamConfig }
+                    ) { constraints ->
+                        constraints
+                            ?.supportedStreamConfigs
+                            ?.contains(StreamConfig.SINGLE_STREAM) == true
+                    }
+                }
+            }
         }
-
-        if (
-            currentConstraints
-                .perLensConstraints[lensFacing]
-                ?.supportedFixedFrameRates
-                ?.contains(60) == true
-        ) {
-            systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
-            cameraSystem.setTargetFrameRate(60)
-            currentConstraints = systemConstraintsUpdate.awaitUntil()
-        }
-
-        if (
-            currentConstraints
-                .perLensConstraints[lensFacing]
-                ?.supportedVideoQualitiesMap
-                ?.get(cameraSystem.getCurrentSettings().value?.dynamicRange)
-                ?.contains(VideoQuality.UHD) == true
-        ) {
-            systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
-            cameraSystem.setVideoQuality(VideoQuality.UHD)
-            systemConstraintsUpdate.awaitUntil()
-        }
-
-        // Wait to ensure the async updateSystemConstraintsByFeatureGroups has time to run
-        // and potentially crash if there's an issue.
-        // As currentConstraints has already been updated, we just ensure we reach here without crash.
-
-        // Assert.
-        // If the test reaches here without crashing, it passes.
-        // This ensures that the feature group logic doesn't cause runtime exceptions
-        // even when high-end features are requested.
-        return@runBlocking
     }
 
     private fun <T> StateFlow<T?>.observeNextUpdate(scope: CoroutineScope): Deferred<T> {
         return scope.async { drop(1).filterNotNull().first() }
+    }
+
+    private suspend fun <T> Feature.tryApplyFeature(
+        scope: CoroutineScope,
+        expectedValue: T,
+        lensFacing: LensFacing,
+        cameraSystemConstraints: CameraSystemConstraints,
+        constraintsState: StateFlow<CameraSystemConstraints?>,
+        cameraSystem: CameraSystem,
+        setFeature: suspend () -> Unit,
+        getNewFeatureValue: (CameraAppSettings?) -> T?,
+        isSupported: (CameraConstraints?) -> Boolean
+    ): CameraSystemConstraints {
+        // Check support
+        if (!isSupported(cameraSystemConstraints.perLensConstraints[lensFacing])) {
+            Log.d(TAG, "Skipping $this: Not supported by current constraints.")
+            return cameraSystemConstraints
+        }
+
+        Log.d(TAG, "Applying $this...")
+
+        // Prepare observer
+        val nextUpdate = constraintsState.observeNextUpdate(scope)
+
+        setFeature()
+
+        // Wait to verify constraints is updated
+        val newConstraints = nextUpdate.awaitUntil()
+
+        // Verify feature is set according to current settings
+        assertThat(getNewFeatureValue(cameraSystem.getCurrentSettings().value)).isEqualTo(
+            expectedValue
+        )
+
+        return newConstraints
+    }
+
+    private fun <T> List<T>.permutations(): List<List<T>> {
+        if (isEmpty()) {
+            // Base case: an empty list has one permutation (the empty list itself)
+            return listOf(emptyList())
+        }
+
+        val result = mutableListOf<List<T>>()
+        val head = first() // Take the first element
+        val tail = drop(1) // Get the rest of the list
+
+        // Recursively get permutations of the tail
+        tail.permutations().forEach { permOfTail ->
+            // Insert the head element at all possible positions in each permutation of the tail
+            for (i in 0..permOfTail.size) {
+                val newPerm = permOfTail.toMutableList()
+                newPerm.add(i, head)
+                result.add(newPerm)
+            }
+        }
+        return result
+    }
+
+    private enum class Feature {
+        DYNAMIC_RANGE_HLG10,
+        FPS_60,
+        VIDEO_QUALITY_UHD,
+        STABILIZATION_MODE_ON,
+        IMAGE_FORMAT_JPEG_ULTRA_HDR,
+        STREAM_CONFIG_SINGLE
     }
 
     suspend fun <T> Deferred<T>.awaitUntil(timeout: Duration = 2.seconds): T {

--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
@@ -34,26 +34,33 @@ import com.google.jetpackcamera.core.camera.utils.APP_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.core.camera.utils.provideUpdatingSurface
 import com.google.jetpackcamera.core.common.testing.FakeFilePathGenerator
 import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.Illuminant
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.VideoQuality
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import java.io.File
 import java.util.AbstractMap
 import javax.inject.Provider
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -337,6 +344,77 @@ class CameraXCameraSystemTest {
         // Clean-up.
         recordingComplete.await()
         torchEnabled.cancel()
+    }
+
+    @Test
+    fun setMultipleFeatures_systemConstraintsUpdatedAndFeaturesSettableIfSupported() = runBlocking {
+        // Arrange.
+        val cameraSystem = createAndInitCameraXCameraSystem()
+        val systemConstraintsFlow = cameraSystem.getSystemConstraints()
+
+        // Each camera run/update should lead to a new systemConstraints update
+        var systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
+        cameraSystem.startCameraAndWaitUntilRunning()
+
+        var currentConstraints = systemConstraintsUpdate.awaitUntil()
+        val lensFacing = cameraSystem.getCurrentSettings().value?.cameraLensFacing
+
+        // Act: For each of the features — HDR, 60 FPS, UHD recording, await previous constraints
+        //  update and set the feature if the constraints supports it.
+
+        if (
+            currentConstraints
+                .perLensConstraints[lensFacing]
+                ?.supportedDynamicRanges
+                ?.contains(DynamicRange.HLG10) == true
+        ) {
+            systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
+            cameraSystem.setDynamicRange(DynamicRange.HLG10)
+            currentConstraints = systemConstraintsUpdate.awaitUntil()
+        }
+
+        if (
+            currentConstraints
+                .perLensConstraints[lensFacing]
+                ?.supportedFixedFrameRates
+                ?.contains(60) == true
+        ) {
+            systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
+            cameraSystem.setTargetFrameRate(60)
+            currentConstraints = systemConstraintsUpdate.awaitUntil()
+        }
+
+        if (
+            currentConstraints
+                .perLensConstraints[lensFacing]
+                ?.supportedVideoQualitiesMap
+                ?.get(cameraSystem.getCurrentSettings().value?.dynamicRange)
+                ?.contains(VideoQuality.UHD) == true
+        ) {
+            systemConstraintsUpdate = systemConstraintsFlow.observeNextUpdate(this)
+            cameraSystem.setVideoQuality(VideoQuality.UHD)
+            systemConstraintsUpdate.awaitUntil()
+        }
+
+        // Wait to ensure the async updateSystemConstraintsByFeatureGroups has time to run
+        // and potentially crash if there's an issue.
+        // As currentConstraints has already been updated, we just ensure we reach here without crash.
+
+        // Assert.
+        // If the test reaches here without crashing, it passes.
+        // This ensures that the feature group logic doesn't cause runtime exceptions
+        // even when high-end features are requested.
+        return@runBlocking
+    }
+
+    private fun <T> StateFlow<T?>.observeNextUpdate(scope: CoroutineScope): Deferred<T> {
+        return scope.async { drop(1).filterNotNull().first() }
+    }
+
+    suspend fun <T> Deferred<T>.awaitUntil(timeout: Duration = 2.seconds): T {
+        return withTimeout(timeout) {
+            await()
+        }
     }
 
     private suspend fun createAndInitCameraXCameraSystem(

--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/FeatureGroupHandlerTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/FeatureGroupHandlerTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import android.app.Application
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.common.testing.FakeFilePathGenerator
+import com.google.jetpackcamera.settings.SettableConstraintsRepositoryImpl
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FeatureGroupHandlerTest {
+
+    private lateinit var application: Application
+    private lateinit var cameraSystem: CameraXCameraSystem
+    private lateinit var featureGroupHandler: FeatureGroupHandler
+    private lateinit var cameraProvider: ProcessCameraProvider
+
+    @Before
+    fun setup() = runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        application = instrumentation.targetContext.applicationContext as Application
+
+        cameraProvider = ProcessCameraProvider.awaitInstance(application)
+
+        cameraSystem = CameraXCameraSystem(
+            application = application,
+            defaultDispatcher = Dispatchers.Main,
+            iODispatcher = Dispatchers.IO,
+            filePathGenerator = FakeFilePathGenerator(),
+            availabilityCheckers = emptyMap(),
+            effectProviders = emptyMap(),
+            imagePostProcessors = emptyMap()
+        )
+        cameraSystem.initialize(DEFAULT_CAMERA_APP_SETTINGS) {}
+
+        featureGroupHandler = FeatureGroupHandler(
+            cameraSystem = cameraSystem,
+            cameraProvider = cameraProvider,
+            defaultCameraSessionContext = cameraSystem.defaultCameraSessionContext,
+            defaultDispatcher = Dispatchers.Main
+        )
+    }
+
+    @Test
+    fun isGroupingSupported_returnsTrue_forDefaultSettings() = runBlocking {
+        val currentSettings = DEFAULT_CAMERA_APP_SETTINGS
+        val cameraSelector = currentSettings.cameraLensFacing.toCameraSelector()
+        val cameraInfo = cameraProvider.getCameraInfo(cameraSelector)
+
+        val result = featureGroupHandler.isGroupingSupported(
+            cameraAppSettings = currentSettings,
+            cameraInfo = cameraInfo,
+            initialSystemConstraints = cameraSystem.getSystemConstraints().value!!
+        )
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun filterSystemConstraints_returnsValidConstraints() = runBlocking {
+        val currentSettings = DEFAULT_CAMERA_APP_SETTINGS
+        val initialConstraints = cameraSystem.getSystemConstraints().value!!
+
+        val result = featureGroupHandler.filterSystemConstraints(
+            currentSettings = currentSettings,
+            initialSystemConstraints = initialConstraints,
+            currentSystemConstraints = initialConstraints
+        )
+
+        assertThat(result).isNotNull()
+        assertThat(
+            result.availableLenses
+        ).containsAtLeastElementsIn(initialConstraints.availableLenses)
+
+        // Ensure per-lens constraints for current lens are present
+        val lensFacing = currentSettings.cameraLensFacing
+        assertThat(result.perLensConstraints).containsKey(lensFacing)
+    }
+
+    @Test
+    fun filterSystemConstraints_forAllAvailableLenses() = runBlocking {
+        val initialConstraints = cameraSystem.getSystemConstraints().value!!
+        for (lensFacing in initialConstraints.availableLenses) {
+            val currentSettings = DEFAULT_CAMERA_APP_SETTINGS.copy(cameraLensFacing = lensFacing)
+            val result = featureGroupHandler.filterSystemConstraints(
+                currentSettings = currentSettings,
+                initialSystemConstraints = initialConstraints,
+                currentSystemConstraints = initialConstraints
+            )
+            assertThat(result.perLensConstraints).containsKey(lensFacing)
+        }
+    }
+
+    @Test
+    fun isHdrSupportedWithJpegR_initiallyNull() {
+        // Based on atomic<Boolean?>(null) initialization
+        assertThat(featureGroupHandler.isHdrSupportedWithJpegR()).isNull()
+    }
+
+    @Test
+    fun isHdrSupportedWithJpegR_updatesAfterConstraintsUpdate() = runBlocking {
+        val currentSettings = DEFAULT_CAMERA_APP_SETTINGS
+        val initialConstraints = cameraSystem.getSystemConstraints().value!!
+
+        featureGroupHandler.filterSystemConstraints(
+            currentSettings = currentSettings,
+            initialSystemConstraints = initialConstraints,
+            currentSystemConstraints = initialConstraints
+        )
+
+        // After update, it should return a boolean value (true or false), confirming the cache
+        // logic executed.
+        assertThat(featureGroupHandler.isHdrSupportedWithJpegR()).isNotNull()
+    }
+}

--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/FeatureGroupHandlerTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/FeatureGroupHandlerTest.kt
@@ -22,7 +22,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import com.google.jetpackcamera.core.common.testing.FakeFilePathGenerator
-import com.google.jetpackcamera.settings.SettableConstraintsRepositoryImpl
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraExt.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraExt.kt
@@ -29,7 +29,6 @@ import androidx.camera.core.DynamicRange as CXDynamicRange
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.Preview
 import androidx.camera.core.UseCase
-import androidx.camera.core.UseCaseGroup
 import androidx.camera.video.Quality
 import androidx.camera.video.Recorder
 import androidx.camera.video.VideoCapture
@@ -224,9 +223,9 @@ val CameraInfo.supportedImageFormats: Set<ImageOutputFormat>
         .mapNotNull(Int::toAppImageFormat)
         .toSet()
 
-fun UseCaseGroup.getVideoCapture() = getUseCaseOrNull<VideoCapture<Recorder>>()
-fun UseCaseGroup.getImageCapture() = getUseCaseOrNull<ImageCapture>()
+fun List<UseCase>.getVideoCapture() = getUseCaseOrNull<VideoCapture<Recorder>>()
+fun List<UseCase>.getImageCapture() = getUseCaseOrNull<ImageCapture>()
 
-private inline fun <reified T : UseCase> UseCaseGroup.getUseCaseOrNull(): T? {
-    return useCases.filterIsInstance<T>().singleOrNull()
+private inline fun <reified T : UseCase> List<UseCase>.getUseCaseOrNull(): T? {
+    return filterIsInstance<T>().singleOrNull()
 }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -543,6 +543,21 @@ internal fun applyDeviceRotation(deviceRotation: DeviceRotation, useCases: List<
     }
 }
 
+/**
+ * Creates a [SessionConfig] for a single camera session.
+ *
+ * This function constructs the session configuration, including binding use cases, setting up
+ * viewports, and applying necessary effects. It also determines the required feature group
+ * from the [sessionSettings] to ensure that the combination of features is supported by the
+ * device.
+ *
+ * @param cameraConstraints The constraints applicable to the current camera.
+ * @param initialTransientSettings The initial transient settings (e.g. flash, zoom).
+ * @param sessionSettings The persistent settings for the single camera session.
+ * @param videoCaptureUseCase The video capture use case, if video recording is enabled.
+ * @param sessionScope The coroutine scope for the session.
+ * @return A [SessionConfig] ready to be bound to the camera lifecycle.
+ */
 context(CameraSessionContext)
 @OptIn(ExperimentalCamera2Interop::class)
 internal suspend fun createSessionConfig(

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -48,6 +48,7 @@ import androidx.camera.core.SessionConfig
 import androidx.camera.core.TorchState
 import androidx.camera.core.UseCase
 import androidx.camera.core.ViewPort
+import androidx.camera.core.featuregroup.GroupableFeature
 import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.video.ExperimentalPersistentRecording
@@ -67,6 +68,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.core.net.toFile
 import androidx.lifecycle.asFlow
+import com.google.jetpackcamera.core.camera.FeatureGroupability.ExplicitlyGroupable
+import com.google.jetpackcamera.core.camera.FeatureGroupability.ImplicitlyGroupable
+import com.google.jetpackcamera.core.camera.FeatureGroupability.Ungroupable
 import com.google.jetpackcamera.core.camera.effects.SingleSurfaceForcingEffect
 import com.google.jetpackcamera.core.common.FilePathGenerator
 import com.google.jetpackcamera.model.AspectRatio
@@ -97,6 +101,8 @@ import kotlin.math.abs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -113,6 +119,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private const val TAG = "CameraSession"
 private val QUALITY_RANGE_MAP = mapOf(
@@ -135,22 +142,17 @@ internal suspend fun runSingleCameraSession(
         .primaryLensFacing.toCameraSelector()
 
     // only create video use case in standard or video_only
-    val videoCaptureUseCase = when (sessionSettings.captureMode) {
-        CaptureMode.STANDARD, CaptureMode.VIDEO_ONLY ->
-            createVideoUseCase(
-                cameraProvider.getCameraInfo(initialCameraSelector),
-                sessionSettings.aspectRatio,
-                sessionSettings.targetFrameRate,
-                sessionSettings.stabilizationMode,
-                sessionSettings.dynamicRange,
-                sessionSettings.videoQuality,
-                backgroundDispatcher
-            )
-
-        else -> {
-            null
-        }
-    }
+    val videoCaptureUseCase =
+        createVideoUseCase(
+            cameraProvider.getCameraInfo(initialCameraSelector),
+            sessionSettings.aspectRatio,
+            sessionSettings.captureMode,
+            backgroundDispatcher,
+            sessionSettings.targetFrameRate.takeIfNoFeatureGroup(sessionSettings),
+            sessionSettings.stabilizationMode.takeIfNoFeatureGroup(sessionSettings),
+            sessionSettings.dynamicRange.takeIfNoFeatureGroup(sessionSettings),
+            sessionSettings.videoQuality.takeIfNoFeatureGroup(sessionSettings)
+        )
 
     launch {
         processVideoControlEvents(
@@ -176,67 +178,18 @@ internal suspend fun runSingleCameraSession(
         .collectLatest { currentTransientSettings ->
             coroutineScope sessionScope@{
                 cameraProvider.unbindAll()
-                val currentCameraSelector = currentTransientSettings.primaryLensFacing
-                    .toCameraSelector()
-                val cameraInfo = cameraProvider.getCameraInfo(currentCameraSelector)
-                val camera2Info = Camera2CameraInfo.from(cameraInfo)
-                val cameraId = camera2Info.cameraId
-
-                var cameraEffect: CameraEffect? = null
-                var captureResults: MutableStateFlow<TotalCaptureResult?>? = null
-                if (currentTransientSettings.flashMode == FlashMode.LOW_LIGHT_BOOST) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
-                        cameraConstraints?.supportedIlluminants?.contains(
-                            Illuminant.LOW_LIGHT_BOOST_CAMERA_EFFECT
-                        ) == true && lowLightBoostEffectProvider != null
-                    ) {
-                        captureResults = MutableStateFlow(null)
-                        cameraEffect = lowLightBoostEffectProvider.create(
-                            cameraId = cameraId,
-                            captureResults = captureResults,
-                            coroutineScope = this@sessionScope,
-                            onSceneBrightnessChanged = { boostStrength ->
-                                val strength = LowLightBoostState.Active(strength = boostStrength)
-                                currentCameraState.update { old ->
-                                    if (old.lowLightBoostState != strength) {
-                                        old.copy(lowLightBoostState = strength)
-                                    } else {
-                                        old
-                                    }
-                                }
-                            },
-                            onLowLightBoostError = { e ->
-                                Log.w(TAG, "Emitting LLB Error", e)
-                                currentCameraState.update { old ->
-                                    old.copy(lowLightBoostState = LowLightBoostState.Error(e))
-                                }
-                            }
-                        )
-                    }
-                }
-                if (cameraEffect == null &&
-                    sessionSettings.streamConfig == StreamConfig.SINGLE_STREAM
-                ) {
-                    cameraEffect = SingleSurfaceForcingEffect(this@sessionScope)
-                }
                 val sessionConfig = createSessionConfig(
-                    cameraInfo = cameraProvider.getCameraInfo(currentCameraSelector),
+                    cameraConstraints = cameraConstraints,
                     videoCaptureUseCase = videoCaptureUseCase,
                     initialTransientSettings = currentTransientSettings,
-                    stabilizationMode = sessionSettings.stabilizationMode,
-                    aspectRatio = sessionSettings.aspectRatio,
-                    dynamicRange = sessionSettings.dynamicRange,
-                    imageFormat = sessionSettings.imageFormat,
-                    captureMode = sessionSettings.captureMode,
-                    effect = cameraEffect,
-                    captureResults = captureResults
-
+                    sessionSettings = sessionSettings,
+                    sessionScope = this@sessionScope
                 ).apply {
                     useCases.getImageCapture()?.let(onImageCaptureCreated)
                 }
 
                 cameraProvider.runWith(
-                    currentCameraSelector,
+                    currentTransientSettings.primaryLensFacing.toCameraSelector(),
                     sessionConfig
                 ) { camera ->
                     Log.d(TAG, "Camera session started")
@@ -259,11 +212,13 @@ internal suspend fun runSingleCameraSession(
                         val videoQuality = getVideoQualityFromResolution(
                             videoCaptureUseCase.resolutionInfo?.resolution
                         )
-                        if (videoQuality != sessionSettings.videoQuality) {
+                        if (sessionSettings.videoQuality != VideoQuality.UNSPECIFIED &&
+                            videoQuality != sessionSettings.videoQuality
+                        ) {
                             Log.e(
                                 TAG,
-                                "Failed to select video quality: $sessionSettings.videoQuality. " +
-                                    "Fallback: $videoQuality"
+                                "Failed to select video quality:" +
+                                    " ${sessionSettings.videoQuality}. Fallback: $videoQuality"
                             )
                         }
                         launch {
@@ -589,29 +544,74 @@ internal fun applyDeviceRotation(deviceRotation: DeviceRotation, useCases: List<
 }
 
 context(CameraSessionContext)
-internal fun createSessionConfig(
-    cameraInfo: CameraInfo,
+@OptIn(ExperimentalCamera2Interop::class)
+internal suspend fun createSessionConfig(
+    cameraConstraints: CameraConstraints?,
     initialTransientSettings: TransientSessionSettings,
-    stabilizationMode: StabilizationMode,
-    aspectRatio: AspectRatio,
+    sessionSettings: PerpetualSessionSettings.SingleCamera,
     videoCaptureUseCase: VideoCapture<Recorder>?,
-    dynamicRange: DynamicRange,
-    imageFormat: ImageOutputFormat,
-    captureMode: CaptureMode,
-    effect: CameraEffect? = null,
-    captureResults: MutableStateFlow<TotalCaptureResult?>? = null
+    sessionScope: CoroutineScope
 ): SessionConfig {
+    val currentCameraSelector = initialTransientSettings.primaryLensFacing
+        .toCameraSelector()
+    val cameraInfo = cameraProvider.getCameraInfo(currentCameraSelector)
+    val camera2Info = Camera2CameraInfo.from(cameraInfo)
+    val cameraId = camera2Info.cameraId
+
+    var cameraEffect: CameraEffect? = null
+    var captureResults: MutableStateFlow<TotalCaptureResult?>? = null
+    if (initialTransientSettings.flashMode == FlashMode.LOW_LIGHT_BOOST) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            cameraConstraints?.supportedIlluminants?.contains(
+                Illuminant.LOW_LIGHT_BOOST_CAMERA_EFFECT
+            ) == true && lowLightBoostEffectProvider != null
+        ) {
+            captureResults = MutableStateFlow(null)
+            cameraEffect = lowLightBoostEffectProvider.create(
+                cameraId = cameraId,
+                captureResults = captureResults,
+                coroutineScope = sessionScope,
+                onSceneBrightnessChanged = { boostStrength ->
+                    val strength = LowLightBoostState.Active(strength = boostStrength)
+                    currentCameraState.update { old ->
+                        if (old.lowLightBoostState != strength) {
+                            old.copy(lowLightBoostState = strength)
+                        } else {
+                            old
+                        }
+                    }
+                },
+                onLowLightBoostError = { e ->
+                    Log.w(TAG, "Emitting LLB Error", e)
+                    currentCameraState.update { old ->
+                        old.copy(lowLightBoostState = LowLightBoostState.Error(e))
+                    }
+                }
+            )
+        }
+    }
+    if (cameraEffect == null &&
+        sessionSettings.streamConfig == StreamConfig.SINGLE_STREAM
+    ) {
+        cameraEffect = SingleSurfaceForcingEffect(sessionScope)
+    }
+
     val previewUseCase =
         createPreviewUseCase(
             cameraInfo,
-            aspectRatio,
-            stabilizationMode,
+            sessionSettings.aspectRatio,
+            sessionSettings.stabilizationMode.takeIfNoFeatureGroup(sessionSettings),
             captureResults
         )
 
     // only create image use case in image or standard
-    val imageCaptureUseCase = if (captureMode != CaptureMode.VIDEO_ONLY) {
-        createImageUseCase(cameraInfo, aspectRatio, dynamicRange, imageFormat)
+    val imageCaptureUseCase = if (sessionSettings.captureMode != CaptureMode.VIDEO_ONLY) {
+        createImageUseCase(
+            cameraInfo,
+            sessionSettings.aspectRatio,
+            sessionSettings.dynamicRange,
+            sessionSettings.imageFormat.takeIfNoFeatureGroup(sessionSettings)
+        )
     } else {
         null
     }
@@ -637,15 +637,59 @@ internal fun createSessionConfig(
         "Setting initial device rotation to ${initialTransientSettings.deviceRotation}"
     )
 
+    val features = if (sessionSettings.toFeatureGroupabilities().shouldUse()) {
+        sessionSettings.toGroupableFeatures() ?: emptySet()
+    } else {
+        emptySet()
+    }
+
+    Log.d(TAG, "createSessionConfig: sessionSettings = $sessionSettings, features = $features")
+
     return SessionConfig(
         useCases = useCases,
         viewPort = ViewPort.Builder(
-            Rational(aspectRatio.numerator, aspectRatio.denominator),
+            Rational(
+                sessionSettings.aspectRatio.numerator,
+                sessionSettings.aspectRatio.denominator
+            ),
             // Initialize rotation to Preview's rotation, which comes from Display rotation
             previewUseCase.targetRotation
         ).build(),
-        effects = effect?.let { listOf(it) } ?: emptyList()
+        effects = cameraEffect?.let { listOf(it) } ?: emptyList(),
+        requiredFeatureGroup = features
     )
+}
+
+/**
+ * Creates a set of [GroupableFeature] from a [PerpetualSessionSettings.SingleCamera].
+ *
+ * Only the [PerpetualSessionSettings.SingleCamera] values that are supported by CameraX feature
+ * group APIs are included in the returned set.
+ *
+ * A null value is returned if the feature groups API can't be used for some value in
+ * [PerpetualSessionSettings.SingleCamera], e.g. optical stabilization, or 15 FPS.
+ */
+internal fun PerpetualSessionSettings.SingleCamera.toGroupableFeatures(): Set<GroupableFeature>? {
+    return buildSet {
+        this@toGroupableFeatures.toFeatureGroupabilities().forEach {
+            when (it) {
+                is ExplicitlyGroupable -> {
+                    val shouldAdd = when {
+                        it.feature == GroupableFeature.IMAGE_ULTRA_HDR ->
+                            captureMode != CaptureMode.VIDEO_ONLY
+                        it.feature.featureType == GroupableFeature.FEATURE_TYPE_RECORDING_QUALITY ->
+                            captureMode != CaptureMode.IMAGE_ONLY
+                        else -> true
+                    }
+                    if (shouldAdd) {
+                        add(it.feature)
+                    }
+                }
+                is ImplicitlyGroupable -> {} // No-op.
+                is Ungroupable -> return null
+            }
+        }
+    }.toSet()
 }
 
 private fun getVideoQualityFromResolution(resolution: Size?): VideoQuality =
@@ -673,7 +717,7 @@ internal fun createImageUseCase(
     cameraInfo: CameraInfo,
     aspectRatio: AspectRatio,
     dynamicRange: DynamicRange,
-    imageFormat: ImageOutputFormat
+    imageFormat: ImageOutputFormat? = null
 ): ImageCapture {
     val builder = ImageCapture.Builder()
     builder.setResolutionSelector(
@@ -689,12 +733,17 @@ internal fun createImageUseCase(
 internal fun createVideoUseCase(
     cameraInfo: CameraInfo,
     aspectRatio: AspectRatio,
-    targetFrameRate: Int,
-    stabilizationMode: StabilizationMode,
-    dynamicRange: DynamicRange,
-    videoQuality: VideoQuality,
-    backgroundDispatcher: CoroutineDispatcher
-): VideoCapture<Recorder> {
+    captureMode: CaptureMode,
+    backgroundDispatcher: CoroutineDispatcher,
+    targetFrameRate: Int? = null,
+    stabilizationMode: StabilizationMode? = null,
+    dynamicRange: DynamicRange? = null,
+    videoQuality: VideoQuality? = null
+): VideoCapture<Recorder>? {
+    if (captureMode != CaptureMode.STANDARD && captureMode != CaptureMode.VIDEO_ONLY) {
+        return null
+    }
+
     val sensorLandscapeRatio = cameraInfo.sensorLandscapeRatio
     val recorder = Recorder.Builder()
         .setAspectRatio(
@@ -702,7 +751,7 @@ internal fun createVideoUseCase(
         )
         .setExecutor(backgroundDispatcher.asExecutor())
         .apply {
-            videoQuality.toQuality()?.let { quality ->
+            videoQuality?.toQuality()?.let { quality ->
                 // No fallback strategy is used. The app will crash if the quality is unsupported
                 setQualitySelector(
                     QualitySelector.from(
@@ -719,11 +768,13 @@ internal fun createVideoUseCase(
             setVideoStabilizationEnabled(true)
         }
         // set target fps
-        if (targetFrameRate != TARGET_FPS_AUTO) {
+        if (targetFrameRate != TARGET_FPS_AUTO && targetFrameRate != null) {
             setTargetFrameRate(Range(targetFrameRate, targetFrameRate))
         }
 
-        setDynamicRange(dynamicRange.toCXDynamicRange())
+        if (dynamicRange != null) {
+            setDynamicRange(dynamicRange.toCXDynamicRange())
+        }
     }.build()
 }
 
@@ -745,10 +796,10 @@ private fun getAspectRatioForUseCase(sensorLandscapeRatio: Float, aspectRatio: A
     }
 
 context(CameraSessionContext)
-internal fun createPreviewUseCase(
+internal suspend fun createPreviewUseCase(
     cameraInfo: CameraInfo,
     aspectRatio: AspectRatio,
-    stabilizationMode: StabilizationMode,
+    stabilizationMode: StabilizationMode? = null,
     captureResults: MutableStateFlow<TotalCaptureResult?>? = null
 ): Preview = Preview.Builder().apply {
     updateCameraStateWithCaptureResults(
@@ -767,6 +818,7 @@ internal fun createPreviewUseCase(
             setPreviewStabilizationEnabled(false)
         }
         StabilizationMode.HIGH_QUALITY -> {} // No-op. Handled by VideoCapture use case.
+        null -> {} // No-op. Handled by feature groups API.
         else -> throw UnsupportedOperationException(
             "Unexpected stabilization mode: $stabilizationMode. Stabilization mode should always " +
                 "an explicit mode, such as ON, OPTICAL, OFF or HIGH_QUALITY"
@@ -778,8 +830,10 @@ internal fun createPreviewUseCase(
     )
 }.build()
     .apply {
-        setSurfaceProvider { surfaceRequest ->
-            surfaceRequests.update { surfaceRequest }
+        withContext(Dispatchers.Main) {
+            setSurfaceProvider { surfaceRequest ->
+                surfaceRequests.update { surfaceRequest }
+            }
         }
     }
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -69,8 +69,6 @@ import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.core.net.toFile
 import androidx.lifecycle.asFlow
 import com.google.jetpackcamera.core.camera.FeatureGroupability.ExplicitlyGroupable
-import com.google.jetpackcamera.core.camera.FeatureGroupability.ImplicitlyGroupable
-import com.google.jetpackcamera.core.camera.FeatureGroupability.Ungroupable
 import com.google.jetpackcamera.core.camera.effects.SingleSurfaceForcingEffect
 import com.google.jetpackcamera.core.common.FilePathGenerator
 import com.google.jetpackcamera.model.AspectRatio
@@ -653,7 +651,7 @@ internal suspend fun createSessionConfig(
     )
 
     val features = if (sessionSettings.toFeatureGroupabilities().shouldUse()) {
-        sessionSettings.toGroupableFeatures() ?: emptySet()
+        sessionSettings.toGroupableFeatures()
     } else {
         emptySet()
     }
@@ -678,13 +676,10 @@ internal suspend fun createSessionConfig(
 /**
  * Creates a set of [GroupableFeature] from a [PerpetualSessionSettings.SingleCamera].
  *
- * Only the [PerpetualSessionSettings.SingleCamera] values that are supported by CameraX feature
- * group APIs are included in the returned set.
- *
- * A null value is returned if the feature groups API can't be used for some value in
- * [PerpetualSessionSettings.SingleCamera], e.g. optical stabilization, or 15 FPS.
+ * Only the [PerpetualSessionSettings.SingleCamera] values that are compatible with CameraX feature
+ * group APIs (i.e. [ExplicitlyGroupable] features) are included in the returned set.
  */
-internal fun PerpetualSessionSettings.SingleCamera.toGroupableFeatures(): Set<GroupableFeature>? {
+internal fun PerpetualSessionSettings.SingleCamera.toGroupableFeatures(): Set<GroupableFeature> {
     return buildSet {
         this@toGroupableFeatures.toFeatureGroupabilities().forEach {
             when (it) {
@@ -700,8 +695,7 @@ internal fun PerpetualSessionSettings.SingleCamera.toGroupableFeatures(): Set<Gr
                         add(it.feature)
                     }
                 }
-                is ImplicitlyGroupable -> {} // No-op.
-                is Ungroupable -> return null
+                else -> {} // No-op.
             }
         }
     }.toSet()

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSession.kt
@@ -44,8 +44,9 @@ import androidx.camera.core.CameraInfo
 import androidx.camera.core.CameraState as CXCameraState
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.Preview
+import androidx.camera.core.SessionConfig
 import androidx.camera.core.TorchState
-import androidx.camera.core.UseCaseGroup
+import androidx.camera.core.UseCase
 import androidx.camera.core.ViewPort
 import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.core.resolutionselector.ResolutionSelector
@@ -218,7 +219,7 @@ internal suspend fun runSingleCameraSession(
                 ) {
                     cameraEffect = SingleSurfaceForcingEffect(this@sessionScope)
                 }
-                val useCaseGroup = createUseCaseGroup(
+                val sessionConfig = createSessionConfig(
                     cameraInfo = cameraProvider.getCameraInfo(currentCameraSelector),
                     videoCaptureUseCase = videoCaptureUseCase,
                     initialTransientSettings = currentTransientSettings,
@@ -231,12 +232,12 @@ internal suspend fun runSingleCameraSession(
                     captureResults = captureResults
 
                 ).apply {
-                    getImageCapture()?.let(onImageCaptureCreated)
+                    useCases.getImageCapture()?.let(onImageCaptureCreated)
                 }
 
                 cameraProvider.runWith(
                     currentCameraSelector,
-                    useCaseGroup
+                    sessionConfig
                 ) { camera ->
                     Log.d(TAG, "Camera session started")
                     launch {
@@ -352,11 +353,14 @@ internal suspend fun runSingleCameraSession(
                             }
                     }
 
-                    applyDeviceRotation(currentTransientSettings.deviceRotation, useCaseGroup)
+                    applyDeviceRotation(
+                        currentTransientSettings.deviceRotation,
+                        sessionConfig.useCases
+                    )
                     processTransientSettingEvents(
                         camera,
                         cameraConstraints,
-                        useCaseGroup,
+                        sessionConfig.useCases,
                         currentTransientSettings,
                         transientSettings,
                         sessionSettings
@@ -371,7 +375,7 @@ context(CameraSessionContext)
 internal suspend fun processTransientSettingEvents(
     camera: Camera,
     cameraConstraints: CameraConstraints?,
-    useCaseGroup: UseCaseGroup,
+    useCases: List<UseCase>,
     initialTransientSettings: TransientSessionSettings,
     transientSettings: StateFlow<TransientSessionSettings?>,
     sessionSettings: PerpetualSessionSettings.SingleCamera?
@@ -421,7 +425,7 @@ internal suspend fun processTransientSettingEvents(
         }
 
         // apply camera torch mode to image capture
-        useCaseGroup.getImageCapture()?.let { imageCapture ->
+        useCases.getImageCapture()?.let { imageCapture ->
             if (prevTransientSettings.flashMode != newTransientSettings.flashMode) {
                 setFlashModeInternal(
                     imageCapture = imageCapture,
@@ -440,7 +444,7 @@ internal suspend fun processTransientSettingEvents(
                     "${prevTransientSettings.deviceRotation} -> " +
                     "${newTransientSettings.deviceRotation}"
             )
-            applyDeviceRotation(newTransientSettings.deviceRotation, useCaseGroup)
+            applyDeviceRotation(newTransientSettings.deviceRotation, useCases)
         }
 
         // setzoomratio when the primary zoom value changes.
@@ -561,9 +565,9 @@ private suspend fun updateCamera2RequestOptions(
     }
 }
 
-internal fun applyDeviceRotation(deviceRotation: DeviceRotation, useCaseGroup: UseCaseGroup) {
+internal fun applyDeviceRotation(deviceRotation: DeviceRotation, useCases: List<UseCase>) {
     val targetRotation = deviceRotation.toUiSurfaceRotation()
-    useCaseGroup.useCases.forEach {
+    useCases.forEach {
         when (it) {
             is Preview -> {
                 // Preview's target rotation should not be updated with device rotation.
@@ -585,7 +589,7 @@ internal fun applyDeviceRotation(deviceRotation: DeviceRotation, useCaseGroup: U
 }
 
 context(CameraSessionContext)
-internal fun createUseCaseGroup(
+internal fun createSessionConfig(
     cameraInfo: CameraInfo,
     initialTransientSettings: TransientSessionSettings,
     stabilizationMode: StabilizationMode,
@@ -596,7 +600,7 @@ internal fun createUseCaseGroup(
     captureMode: CaptureMode,
     effect: CameraEffect? = null,
     captureResults: MutableStateFlow<TotalCaptureResult?>? = null
-): UseCaseGroup {
+): SessionConfig {
     val previewUseCase =
         createPreviewUseCase(
             cameraInfo,
@@ -620,26 +624,28 @@ internal fun createUseCaseGroup(
         )
     }
 
-    return UseCaseGroup.Builder().apply {
-        Log.d(
-            TAG,
-            "Setting initial device rotation to ${initialTransientSettings.deviceRotation}"
-        )
-        setViewPort(
-            ViewPort.Builder(
-                Rational(aspectRatio.numerator, aspectRatio.denominator),
-                // Initialize rotation to Preview's rotation, which comes from Display rotation
-                previewUseCase.targetRotation
-            ).build()
-        )
-        addUseCase(previewUseCase)
+    val useCases = buildList {
+        add(previewUseCase)
 
         // image and video use cases are only created if supported by the configuration
-        imageCaptureUseCase?.let { addUseCase(imageCaptureUseCase) }
-        videoCaptureUseCase?.let { addUseCase(videoCaptureUseCase) }
+        imageCaptureUseCase?.let { add(imageCaptureUseCase) }
+        videoCaptureUseCase?.let { add(videoCaptureUseCase) }
+    }
 
-        effect?.let { addEffect(it) }
-    }.build()
+    Log.d(
+        TAG,
+        "Setting initial device rotation to ${initialTransientSettings.deviceRotation}"
+    )
+
+    return SessionConfig(
+        useCases = useCases,
+        viewPort = ViewPort.Builder(
+            Rational(aspectRatio.numerator, aspectRatio.denominator),
+            // Initialize rotation to Preview's rotation, which comes from Display rotation
+            previewUseCase.targetRotation
+        ).build(),
+        effects = effect?.let { listOf(it) } ?: emptyList()
+    )
 }
 
 private fun getVideoQualityFromResolution(resolution: Size?): VideoQuality =
@@ -663,7 +669,7 @@ private fun getHeightFromCropRect(cropRect: Rect?): Int {
     return abs(cropRect.left - cropRect.right)
 }
 
-private fun createImageUseCase(
+internal fun createImageUseCase(
     cameraInfo: CameraInfo,
     aspectRatio: AspectRatio,
     dynamicRange: DynamicRange,
@@ -739,7 +745,7 @@ private fun getAspectRatioForUseCase(sensorLandscapeRatio: Float, aspectRatio: A
     }
 
 context(CameraSessionContext)
-private fun createPreviewUseCase(
+internal fun createPreviewUseCase(
     cameraInfo: CameraInfo,
     aspectRatio: AspectRatio,
     stabilizationMode: StabilizationMode,
@@ -815,7 +821,7 @@ private fun getResolutionSelector(
 }
 
 context(CameraSessionContext)
-private fun setFlashModeInternal(
+internal fun setFlashModeInternal(
     imageCapture: ImageCapture,
     flashMode: FlashMode,
     isFrontFacing: Boolean

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -294,6 +294,7 @@ class CameraXCameraSystem(
                                 supportedStabilizationModes = supportedStabilizationModes,
                                 supportedFixedFrameRates = supportedFixedFrameRates,
                                 supportedDynamicRanges = supportedDynamicRanges,
+                                supportedVideoQualitiesMap = supportedVideoQualitiesMap,
                                 supportedImageFormatsMap = mapOf(
                                     // Only JPEG is supported in single-stream mode, since
                                     // single-stream mode uses CameraEffect, which does not support
@@ -301,12 +302,15 @@ class CameraXCameraSystem(
                                     Pair(StreamConfig.SINGLE_STREAM, setOf(ImageOutputFormat.JPEG)),
                                     Pair(StreamConfig.MULTI_STREAM, supportedImageFormats)
                                 ),
-                                supportedVideoQualitiesMap = supportedVideoQualitiesMap,
                                 supportedIlluminants = supportedIlluminants,
                                 supportedFlashModes = supportedFlashModes,
                                 supportedZoomRange = supportedZoomRange,
                                 unsupportedStabilizationFpsMap = unsupportedStabilizationFpsMap,
-                                supportedTestPatterns = supportedTestPatterns
+                                supportedTestPatterns = supportedTestPatterns,
+                                supportedStreamConfigs = setOf(
+                                    StreamConfig.SINGLE_STREAM,
+                                    StreamConfig.MULTI_STREAM
+                                )
                             )
                         )
                     }
@@ -315,6 +319,8 @@ class CameraXCameraSystem(
         )
 
         initialSystemConstraints = systemConstraints
+        Log.d(TAG, "initialize: initialSystemConstraints = $initialSystemConstraints")
+
         _systemConstraints.value = systemConstraints
 
         currentSettings.value =
@@ -1220,8 +1226,8 @@ class CameraXCameraSystem(
             imageFormat =
             if (isHdrOn) ImageOutputFormat.JPEG_ULTRA_HDR else ImageOutputFormat.JPEG
         )
-            .tryApplyDynamicRangeConstraints()
-            .tryApplyImageFormatConstraints()
+            .tryApplyDynamicRangeConstraints(systemConstraints)
+            .tryApplyImageFormatConstraints(systemConstraints)
     }
 
     private suspend fun handleLowLightBoostErrors() {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -81,6 +81,7 @@ import com.google.jetpackcamera.settings.model.forCurrentLens
 import java.io.File
 import java.io.FileNotFoundException
 import javax.inject.Provider
+import kotlin.time.measureTime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -113,9 +114,11 @@ class CameraXCameraSystem(
     Map<ImagePostProcessorFeatureKey, @JvmSuppressWildcards Provider<ImagePostProcessor>>
 ) : CameraSystem {
     private lateinit var cameraProvider: ProcessCameraProvider
+    private lateinit var featureGroupHandler: FeatureGroupHandler
 
     private var imageCaptureUseCase: ImageCapture? = null
 
+    private lateinit var initialSystemConstraints: CameraSystemConstraints
     private lateinit var systemConstraints: CameraSystemConstraints
 
     private val screenFlashEvents: Channel<CameraSystem.ScreenFlashEvent> =
@@ -141,6 +144,8 @@ class CameraXCameraSystem(
     private val lowLightBoostAvailabilityChecker: LowLightBoostAvailabilityChecker?
     private val lowLightBoostEffectProvider: LowLightBoostEffectProvider?
 
+    internal lateinit var defaultCameraSessionContext: CameraSessionContext
+
     init {
         val entry = availabilityCheckers.entries.firstOrNull()
         if (entry == null) {
@@ -165,6 +170,27 @@ class CameraXCameraSystem(
         cameraProvider = configureAndGetCameraProvider(
             context = application,
             singleLensMode = debugSettings.singleLensMode
+        )
+
+        defaultCameraSessionContext = CameraSessionContext(
+            context = application,
+            cameraProvider = cameraProvider,
+            backgroundDispatcher = defaultDispatcher,
+            screenFlashEvents = Channel(),
+            filePathGenerator = filePathGenerator,
+            focusMeteringEvents = Channel(),
+            videoCaptureControlEvents = Channel(),
+            currentCameraState = MutableStateFlow(CameraState()),
+            surfaceRequests = MutableStateFlow(null),
+            transientSettings = MutableStateFlow(null),
+            lowLightBoostEffectProvider = lowLightBoostEffectProvider
+        )
+
+        featureGroupHandler = FeatureGroupHandler(
+            cameraSystem = this,
+            cameraProvider = cameraProvider,
+            defaultCameraSessionContext = defaultCameraSessionContext,
+            defaultDispatcher = defaultDispatcher
         )
 
         // updates values for available cameras
@@ -288,6 +314,7 @@ class CameraXCameraSystem(
             }
         )
 
+        initialSystemConstraints = systemConstraints
         _systemConstraints.value = systemConstraints
 
         currentSettings.value =
@@ -387,6 +414,39 @@ class CameraXCameraSystem(
         }
     }
 
+    internal fun CameraAppSettings.toTransientSessionSettings(): TransientSessionSettings {
+        return TransientSessionSettings(
+            isAudioEnabled = audioEnabled,
+            deviceRotation = deviceRotation,
+            flashMode = flashMode,
+            primaryLensFacing = cameraLensFacing,
+            zoomRatios = defaultZoomRatios,
+            testPattern = debugSettings.testPattern
+        )
+    }
+
+    internal suspend fun CameraAppSettings.toSingleCameraSessionSettings(
+        cameraConstraints: CameraConstraints
+    ): PerpetualSessionSettings.SingleCamera {
+        val resolvedStabilizationMode = resolveStabilizationMode(
+            requestedStabilizationMode = stabilizationMode,
+            cameraAppSettings = this,
+            cameraConstraints = cameraConstraints
+        )
+
+        return PerpetualSessionSettings.SingleCamera(
+            aspectRatio = aspectRatio,
+            captureMode = captureMode,
+            streamConfig = streamConfig,
+            targetFrameRate = targetFrameRate,
+            stabilizationMode = resolvedStabilizationMode,
+            dynamicRange = dynamicRange,
+            videoQuality = videoQuality,
+            imageFormat = imageFormat,
+            lowLightBoostPriority = lowLightBoostPriority
+        )
+    }
+
     @OptIn(ExperimentalCamera2Interop::class)
     override suspend fun runCamera() = coroutineScope {
         Log.d(TAG, "runCamera")
@@ -399,14 +459,7 @@ class CameraXCameraSystem(
         currentSettings
             .filterNotNull()
             .map { currentCameraSettings ->
-                transientSettings.value = TransientSessionSettings(
-                    isAudioEnabled = currentCameraSettings.audioEnabled,
-                    deviceRotation = currentCameraSettings.deviceRotation,
-                    flashMode = currentCameraSettings.flashMode,
-                    primaryLensFacing = currentCameraSettings.cameraLensFacing,
-                    zoomRatios = currentCameraSettings.defaultZoomRatios,
-                    testPattern = currentCameraSettings.debugSettings.testPattern
-                )
+                transientSettings.value = currentCameraSettings.toTransientSessionSettings()
 
                 when (currentCameraSettings.concurrentCameraMode) {
                     ConcurrentCameraMode.OFF -> {
@@ -417,24 +470,7 @@ class CameraXCameraSystem(
                                 "${currentCameraSettings.cameraLensFacing}"
                         }
 
-                        val resolvedStabilizationMode = resolveStabilizationMode(
-                            requestedStabilizationMode = currentCameraSettings.stabilizationMode,
-                            targetFrameRate = currentCameraSettings.targetFrameRate,
-                            cameraConstraints = cameraConstraints,
-                            concurrentCameraMode = currentCameraSettings.concurrentCameraMode
-                        )
-
-                        PerpetualSessionSettings.SingleCamera(
-                            aspectRatio = currentCameraSettings.aspectRatio,
-                            captureMode = currentCameraSettings.captureMode,
-                            streamConfig = currentCameraSettings.streamConfig,
-                            targetFrameRate = currentCameraSettings.targetFrameRate,
-                            stabilizationMode = resolvedStabilizationMode,
-                            dynamicRange = currentCameraSettings.dynamicRange,
-                            videoQuality = currentCameraSettings.videoQuality,
-                            imageFormat = currentCameraSettings.imageFormat,
-                            lowLightBoostPriority = currentCameraSettings.lowLightBoostPriority
-                        )
+                        currentCameraSettings.toSingleCameraSessionSettings(cameraConstraints)
                     }
 
                     ConcurrentCameraMode.DUAL -> {
@@ -483,13 +519,29 @@ class CameraXCameraSystem(
                     ) {
                         try {
                             when (sessionSettings) {
-                                is PerpetualSessionSettings.SingleCamera -> runSingleCameraSession(
-                                    sessionSettings,
-                                    systemConstraints.forCurrentLens(currentSettings.value!!),
-                                    onImageCaptureCreated = { imageCapture ->
-                                        imageCaptureUseCase = imageCapture
+                                is PerpetualSessionSettings.SingleCamera -> {
+                                    launch(backgroundDispatcher) {
+                                        // runSingleCameraSession never completes due to
+                                        // collectLatest on a StateFlow, so this must be launched
+                                        // beforehand
+
+                                        val duration =
+                                            measureTime { updateSystemConstraintsByFeatureGroups() }
+                                        Log.d(
+                                            TAG,
+                                            "runCamera: updateSystemConstraints" +
+                                                " completed in $duration"
+                                        )
                                     }
-                                )
+
+                                    runSingleCameraSession(
+                                        sessionSettings,
+                                        systemConstraints.forCurrentLens(currentSettings.value!!),
+                                        onImageCaptureCreated = { imageCapture ->
+                                            imageCaptureUseCase = imageCapture
+                                        }
+                                    )
+                                }
 
                                 is PerpetualSessionSettings.ConcurrentCamera ->
                                     runConcurrentCameraSession(
@@ -508,37 +560,71 @@ class CameraXCameraSystem(
             }
     }
 
-    private fun resolveStabilizationMode(
-        requestedStabilizationMode: StabilizationMode,
-        targetFrameRate: Int,
-        cameraConstraints: CameraConstraints,
-        concurrentCameraMode: ConcurrentCameraMode
-    ): StabilizationMode = if (concurrentCameraMode == ConcurrentCameraMode.DUAL) {
-        StabilizationMode.OFF
-    } else {
-        with(cameraConstraints) {
-            // Convert AUTO stabilization mode to the first supported stabilization mode
-            val stabilizationMode = if (requestedStabilizationMode == StabilizationMode.AUTO) {
-                // Choose between ON, OPTICAL, or OFF, depending on support, in that order
-                sequenceOf(StabilizationMode.ON, StabilizationMode.OPTICAL, StabilizationMode.OFF)
-                    .first {
-                        it in supportedStabilizationModes &&
-                            targetFrameRate !in it.unsupportedFpsSet
-                    }
-            } else {
-                requestedStabilizationMode
-            }
+    private suspend fun updateSystemConstraintsByFeatureGroups() {
+        val cameraAppSettings = requireNotNull(currentSettings.value)
 
-            // Check that the stabilization mode can be supported, otherwise return OFF
-            if (stabilizationMode in supportedStabilizationModes &&
-                targetFrameRate !in stabilizationMode.unsupportedFpsSet
-            ) {
-                stabilizationMode
-            } else {
-                StabilizationMode.OFF
+        systemConstraints = featureGroupHandler.filterSystemConstraints(
+            currentSettings = cameraAppSettings,
+            initialSystemConstraints = initialSystemConstraints,
+            currentSystemConstraints = systemConstraints
+        )
+
+        _systemConstraints.value = systemConstraints
+    }
+
+    internal suspend fun resolveStabilizationMode(
+        requestedStabilizationMode: StabilizationMode,
+        cameraAppSettings: CameraAppSettings,
+        cameraConstraints: CameraConstraints
+    ): StabilizationMode =
+        if (cameraAppSettings.concurrentCameraMode == ConcurrentCameraMode.DUAL) {
+            StabilizationMode.OFF
+        } else {
+            with(cameraConstraints) {
+                // Convert AUTO stabilization mode to the first supported stabilization mode
+                val stabilizationMode = if (requestedStabilizationMode == StabilizationMode.AUTO) {
+                    // Find if feature grouping is required due to other features
+                    val isFeatureGroupingRequired =
+                        cameraAppSettings.copy(stabilizationMode = StabilizationMode.OFF)
+                            .toFeatureGroupabilities()
+                            .any { it is FeatureGroupability.ExplicitlyGroupable }
+
+                    // Choose between ON, OPTICAL, or OFF, depending on support, in that order
+                    sequenceOf(
+                        StabilizationMode.ON,
+                        StabilizationMode.OPTICAL,
+                        StabilizationMode.OFF
+                    )
+                        .first {
+                            it in supportedStabilizationModes &&
+                                cameraAppSettings.targetFrameRate !in it.unsupportedFpsSet && (
+                                    !isFeatureGroupingRequired || (
+                                        it == StabilizationMode.OFF ||
+                                            featureGroupHandler.isGroupingSupported(
+                                                cameraAppSettings.applyStabilizationMode(it),
+                                                cameraProvider.getCameraInfo(
+                                                    cameraAppSettings
+                                                        .cameraLensFacing.toCameraSelector()
+                                                ),
+                                                initialSystemConstraints
+                                            ) == true
+                                        )
+                                    )
+                        }
+                } else {
+                    requestedStabilizationMode
+                }
+
+                // Check that the stabilization mode can be supported, otherwise return OFF
+                if (stabilizationMode in supportedStabilizationModes &&
+                    cameraAppSettings.targetFrameRate !in stabilizationMode.unsupportedFpsSet
+                ) {
+                    stabilizationMode
+                } else {
+                    StabilizationMode.OFF
+                }
             }
         }
-    }
 
     override suspend fun takePicture(onCaptureStarted: (() -> Unit)) {
         if (imageCaptureUseCase == null) {
@@ -677,8 +763,11 @@ class CameraXCameraSystem(
                 old?.copy(cameraLensFacing = lensFacing)
                     ?.tryApplyDynamicRangeConstraints()
                     ?.tryApplyImageFormatConstraints()
+                    ?.tryApplyFrameRateConstraints()
+                    ?.tryApplyStabilizationConstraints()
                     ?.tryApplyFlashModeConstraints()
                     ?.tryApplyCaptureModeConstraints()
+                    ?.tryApplyVideoQualityConstraints()
                     ?.tryApplyTestPatternConstraints()
             } else {
                 old
@@ -698,7 +787,8 @@ class CameraXCameraSystem(
      * mode will be applied. If left null, it will not change the current capture mode.
      */
     private fun CameraAppSettings.tryApplyCaptureModeConstraints(
-        defaultCaptureMode: CaptureMode? = null
+        defaultCaptureMode: CaptureMode? = null,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
     ): CameraAppSettings {
         Log.d(TAG, "applying capture mode constraints")
         return systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
@@ -780,13 +870,29 @@ class CameraXCameraSystem(
         } ?: this
     }
 
-    private fun CameraAppSettings.tryApplyDynamicRangeConstraints(): CameraAppSettings =
+    private fun CameraAppSettings.tryApplyDynamicRangeConstraints(
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings =
         systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedDynamicRanges) {
                 val newDynamicRange = if (contains(dynamicRange) &&
                     flashMode != FlashMode.LOW_LIGHT_BOOST
                 ) {
-                    dynamicRange
+                    if (captureMode == CaptureMode.IMAGE_ONLY) {
+                        // Reaching this point in code flow means that JPEG_R will be requested
+                        // later, and some devices may not support HDR and JPEG_R together. So,
+                        // we should enable HDR here only if it is supported with JPEG_R. However,
+                        // the value of isHdrSupportedWithJpegR is updated asynchronously and may
+                        // not be up-to-date in rare cases, so this is done on a best-effort basis.
+
+                        if (featureGroupHandler.isHdrSupportedWithJpegR() == false) {
+                            DynamicRange.SDR
+                        } else {
+                            dynamicRange
+                        }
+                    } else {
+                        dynamicRange
+                    }
                 } else {
                     DynamicRange.SDR
                 }
@@ -808,10 +914,14 @@ class CameraXCameraSystem(
             this.copy(aspectRatio = AspectRatio.NINE_SIXTEEN)
     }
 
-    private fun CameraAppSettings.tryApplyImageFormatConstraints(): CameraAppSettings =
+    private fun CameraAppSettings.tryApplyImageFormatConstraints(
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings =
         systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedImageFormatsMap[streamConfig]) {
-                val newImageFormat = if (this != null && contains(imageFormat)) {
+                val newImageFormat = if (this != null && contains(imageFormat) &&
+                    captureMode != CaptureMode.VIDEO_ONLY
+                ) {
                     imageFormat
                 } else {
                     ImageOutputFormat.JPEG
@@ -823,7 +933,9 @@ class CameraXCameraSystem(
             }
         } ?: this
 
-    private fun CameraAppSettings.tryApplyFrameRateConstraints(): CameraAppSettings =
+    private fun CameraAppSettings.tryApplyFrameRateConstraints(
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings =
         systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedFixedFrameRates) {
                 val newTargetFrameRate = if (contains(targetFrameRate)) {
@@ -838,7 +950,9 @@ class CameraXCameraSystem(
             }
         } ?: this
 
-    private fun CameraAppSettings.tryApplyStabilizationConstraints(): CameraAppSettings =
+    private fun CameraAppSettings.tryApplyStabilizationConstraints(
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings =
         systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints) {
                 val newStabilizationMode = if (stabilizationMode != StabilizationMode.AUTO &&
@@ -856,24 +970,27 @@ class CameraXCameraSystem(
             }
         } ?: this
 
-    private fun CameraAppSettings.tryApplyConcurrentCameraModeConstraints(): CameraAppSettings =
-        when (concurrentCameraMode) {
-            ConcurrentCameraMode.OFF -> this
-            else ->
-                if (systemConstraints.concurrentCamerasSupported &&
-                    dynamicRange == DynamicRange.SDR &&
-                    streamConfig == StreamConfig.MULTI_STREAM &&
-                    flashMode != FlashMode.LOW_LIGHT_BOOST
-                ) {
-                    copy(
-                        targetFrameRate = TARGET_FPS_AUTO
-                    )
-                } else {
-                    copy(concurrentCameraMode = ConcurrentCameraMode.OFF)
-                }
-        }
+    private fun CameraAppSettings.tryApplyConcurrentCameraModeConstraints(
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings = when (concurrentCameraMode) {
+        ConcurrentCameraMode.OFF -> this
+        else ->
+            if (systemConstraints.concurrentCamerasSupported &&
+                dynamicRange == DynamicRange.SDR &&
+                streamConfig == StreamConfig.MULTI_STREAM &&
+                flashMode != FlashMode.LOW_LIGHT_BOOST
+            ) {
+                copy(
+                    targetFrameRate = TARGET_FPS_AUTO
+                )
+            } else {
+                copy(concurrentCameraMode = ConcurrentCameraMode.OFF)
+            }
+    }
 
-    private fun CameraAppSettings.tryApplyVideoQualityConstraints(): CameraAppSettings =
+    private fun CameraAppSettings.tryApplyVideoQualityConstraints(
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings =
         systemConstraints.perLensConstraints[cameraLensFacing]?.let { constraints ->
             with(constraints.supportedVideoQualitiesMap) {
                 val newVideoQuality = get(dynamicRange).let {
@@ -943,9 +1060,17 @@ class CameraXCameraSystem(
 
     override suspend fun setVideoQuality(videoQuality: VideoQuality) {
         currentSettings.update { old ->
-            old?.copy(videoQuality = videoQuality)
-                ?.tryApplyVideoQualityConstraints()
+            old?.applyVideoQuality(videoQuality = videoQuality)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided [VideoQuality] applied. */
+    internal fun CameraAppSettings.applyVideoQuality(
+        videoQuality: VideoQuality,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings {
+        return copy(videoQuality = videoQuality)
+            .tryApplyVideoQualityConstraints(systemConstraints)
     }
 
     override suspend fun setLowLightBoostPriority(lowLightBoostPriority: LowLightBoostPriority) {
@@ -956,21 +1081,37 @@ class CameraXCameraSystem(
 
     override suspend fun setStreamConfig(streamConfig: StreamConfig) {
         currentSettings.update { old ->
-            old?.copy(streamConfig = streamConfig)
-                ?.tryApplyImageFormatConstraints()
-                ?.tryApplyConcurrentCameraModeConstraints()
-                ?.tryApplyCaptureModeConstraints()
-                ?.tryApplyVideoQualityConstraints()
+            old?.applyStreamConfig(streamConfig = streamConfig)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided [StreamConfig] applied. */
+    internal fun CameraAppSettings.applyStreamConfig(
+        streamConfig: StreamConfig,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings {
+        return copy(streamConfig = streamConfig)
+            .tryApplyImageFormatConstraints(systemConstraints)
+            .tryApplyConcurrentCameraModeConstraints(systemConstraints)
+            .tryApplyCaptureModeConstraints(systemConstraints = systemConstraints)
+            .tryApplyVideoQualityConstraints(systemConstraints)
     }
 
     override suspend fun setDynamicRange(dynamicRange: DynamicRange) {
         currentSettings.update { old ->
-            old?.copy(dynamicRange = dynamicRange)
-                ?.tryApplyDynamicRangeConstraints()
-                ?.tryApplyConcurrentCameraModeConstraints()
-                ?.tryApplyCaptureModeConstraints(CaptureMode.STANDARD)
+            old?.applyDynamicRange(dynamicRange)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided [DynamicRange] applied. */
+    internal fun CameraAppSettings.applyDynamicRange(
+        dynamicRange: DynamicRange,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings {
+        return copy(dynamicRange = dynamicRange)
+            .tryApplyDynamicRangeConstraints(systemConstraints)
+            .tryApplyConcurrentCameraModeConstraints(systemConstraints)
+            .tryApplyCaptureModeConstraints(CaptureMode.STANDARD, systemConstraints)
     }
 
     override fun setDeviceRotation(deviceRotation: DeviceRotation) {
@@ -989,10 +1130,18 @@ class CameraXCameraSystem(
 
     override suspend fun setImageFormat(imageFormat: ImageOutputFormat) {
         currentSettings.update { old ->
-            old?.copy(imageFormat = imageFormat)
-                ?.tryApplyImageFormatConstraints()
-                ?.tryApplyCaptureModeConstraints(CaptureMode.STANDARD)
+            old?.applyImageFormat(imageFormat = imageFormat)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided [ImageOutputFormat] applied. */
+    internal fun CameraAppSettings.applyImageFormat(
+        imageFormat: ImageOutputFormat,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings {
+        return copy(imageFormat = imageFormat)
+            .tryApplyImageFormatConstraints(systemConstraints)
+            .tryApplyCaptureModeConstraints(CaptureMode.STANDARD, systemConstraints)
     }
 
     override suspend fun setMaxVideoDuration(durationInMillis: Long) {
@@ -1005,15 +1154,31 @@ class CameraXCameraSystem(
 
     override suspend fun setStabilizationMode(stabilizationMode: StabilizationMode) {
         currentSettings.update { old ->
-            old?.copy(stabilizationMode = stabilizationMode)
+            old?.applyStabilizationMode(stabilizationMode = stabilizationMode)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided [StabilizationMode] applied. */
+    internal fun CameraAppSettings.applyStabilizationMode(
+        stabilizationMode: StabilizationMode
+    ): CameraAppSettings {
+        return copy(stabilizationMode = stabilizationMode)
     }
 
     override suspend fun setTargetFrameRate(targetFrameRate: Int) {
         currentSettings.update { old ->
-            old?.copy(targetFrameRate = targetFrameRate)?.tryApplyFrameRateConstraints()
-                ?.tryApplyConcurrentCameraModeConstraints()
+            old?.applyTargetFrameRate(targetFrameRate)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided frame rate applied. */
+    internal fun CameraAppSettings.applyTargetFrameRate(
+        targetFrameRate: Int,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings {
+        return copy(targetFrameRate = targetFrameRate)
+            .tryApplyFrameRateConstraints(systemConstraints)
+            .tryApplyConcurrentCameraModeConstraints(systemConstraints)
     }
 
     override suspend fun setAudioEnabled(isAudioEnabled: Boolean) {
@@ -1024,8 +1189,28 @@ class CameraXCameraSystem(
 
     override suspend fun setCaptureMode(captureMode: CaptureMode) {
         currentSettings.update { old ->
-            old?.copy(captureMode = captureMode)
+            old?.applyCaptureMode(captureMode = captureMode)
         }
+    }
+
+    /** Returns a new [CameraAppSettings] with the provided [captureMode] applied. */
+    internal fun CameraAppSettings.applyCaptureMode(
+        captureMode: CaptureMode,
+        systemConstraints: CameraSystemConstraints = this@CameraXCameraSystem.systemConstraints
+    ): CameraAppSettings {
+        val isHdrOn =
+            dynamicRange == DynamicRange.HLG10 ||
+                imageFormat == ImageOutputFormat.JPEG_ULTRA_HDR
+
+        return copy(
+            captureMode = captureMode,
+            dynamicRange =
+            if (isHdrOn) DynamicRange.HLG10 else DynamicRange.SDR,
+            imageFormat =
+            if (isHdrOn) ImageOutputFormat.JPEG_ULTRA_HDR else ImageOutputFormat.JPEG
+        )
+            .tryApplyDynamicRangeConstraints()
+            .tryApplyImageFormatConstraints()
     }
 
     private suspend fun handleLowLightBoostErrors() {

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -560,6 +560,17 @@ class CameraXCameraSystem(
             }
     }
 
+    /**
+     * Updates the [CameraSystemConstraints] based on feature group compatibility.
+     *
+     * This function checks various combinations of settings (dynamic range, frame rate,
+     * stabilization, etc.) against the device's capabilities using the CameraX feature groups API.
+     * It filters out unsupported options from the system constraints, ensuring that the UI only
+     * presents valid combinations to the user.
+     *
+     * This update happens asynchronously after the initial camera session is started to avoid
+     * blocking the UI thread.
+     */
     private suspend fun updateSystemConstraintsByFeatureGroups() {
         val cameraAppSettings = requireNotNull(currentSettings.value)
 

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
@@ -16,20 +16,31 @@
 package com.google.jetpackcamera.core.camera
 
 import android.annotation.SuppressLint
+import android.hardware.camera2.TotalCaptureResult
 import android.os.Build
 import android.util.Log
+import android.util.Rational
+import androidx.camera.core.CameraEffect
+import androidx.camera.core.CameraInfo
 import androidx.camera.core.CameraState as CXCameraState
 import androidx.camera.core.CompositionSettings
 import androidx.camera.core.TorchState
+import androidx.camera.core.UseCaseGroup
+import androidx.camera.core.ViewPort
+import androidx.camera.video.Recorder
+import androidx.camera.video.VideoCapture
 import androidx.lifecycle.asFlow
+import com.google.jetpackcamera.model.AspectRatio
 import com.google.jetpackcamera.model.CaptureMode
 import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.ImageOutputFormat
+import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.TARGET_FPS_AUTO
 import com.google.jetpackcamera.model.VideoQuality
 import com.google.jetpackcamera.settings.model.CameraConstraints
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -120,7 +131,7 @@ internal suspend fun runConcurrentCameraSession(
 
         launch {
             processVideoControlEvents(
-                useCaseGroup.getVideoCapture(),
+                useCaseGroup.useCases.getVideoCapture(),
                 captureTypeSuffix = "DualCam"
             )
         }
@@ -188,14 +199,72 @@ internal suspend fun runConcurrentCameraSession(
                 }
         }
 
-        applyDeviceRotation(initialTransientSettings.deviceRotation, useCaseGroup)
+        applyDeviceRotation(initialTransientSettings.deviceRotation, useCaseGroup.useCases)
         processTransientSettingEvents(
             primaryCamera,
             cameraConstraints,
-            useCaseGroup,
+            useCaseGroup.useCases,
             initialTransientSettings,
             transientSettings,
             null
         )
     }
+}
+
+context(CameraSessionContext)
+internal fun createUseCaseGroup(
+    cameraInfo: CameraInfo,
+    initialTransientSettings: TransientSessionSettings,
+    stabilizationMode: StabilizationMode,
+    aspectRatio: AspectRatio,
+    videoCaptureUseCase: VideoCapture<Recorder>?,
+    dynamicRange: DynamicRange,
+    imageFormat: ImageOutputFormat,
+    captureMode: CaptureMode,
+    effect: CameraEffect? = null,
+    captureResults: MutableStateFlow<TotalCaptureResult?>? = null
+): UseCaseGroup {
+    val previewUseCase =
+        createPreviewUseCase(
+            cameraInfo,
+            aspectRatio,
+            stabilizationMode,
+            captureResults
+        )
+
+    // only create image use case in image or standard
+    val imageCaptureUseCase = if (captureMode != CaptureMode.VIDEO_ONLY) {
+        createImageUseCase(cameraInfo, aspectRatio, dynamicRange, imageFormat)
+    } else {
+        null
+    }
+
+    imageCaptureUseCase?.let {
+        setFlashModeInternal(
+            imageCapture = imageCaptureUseCase,
+            flashMode = initialTransientSettings.flashMode,
+            isFrontFacing = cameraInfo.appLensFacing == LensFacing.FRONT
+        )
+    }
+
+    return UseCaseGroup.Builder().apply {
+        Log.d(
+            TAG,
+            "Setting initial device rotation to ${initialTransientSettings.deviceRotation}"
+        )
+        setViewPort(
+            ViewPort.Builder(
+                Rational(aspectRatio.numerator, aspectRatio.denominator),
+                // Initialize rotation to Preview's rotation, which comes from Display rotation
+                previewUseCase.targetRotation
+            ).build()
+        )
+        addUseCase(previewUseCase)
+
+        // image and video use cases are only created if supported by the configuration
+        imageCaptureUseCase?.let { addUseCase(imageCaptureUseCase) }
+        videoCaptureUseCase?.let { addUseCase(videoCaptureUseCase) }
+
+        effect?.let { addEffect(it) }
+    }.build()
 }

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/ConcurrentCameraSession.kt
@@ -69,21 +69,19 @@ internal suspend fun runConcurrentCameraSession(
         .filterNotNull()
         .first()
 
-    val videoCapture = if (sessionSettings.captureMode != CaptureMode.IMAGE_ONLY) {
+    val videoCapture =
         createVideoUseCase(
             cameraProvider.getCameraInfo(
                 initialTransientSettings.primaryLensFacing.toCameraSelector()
             ),
             sessionSettings.aspectRatio,
+            sessionSettings.captureMode,
+            backgroundDispatcher,
             TARGET_FPS_AUTO,
             StabilizationMode.OFF,
             DynamicRange.SDR,
-            VideoQuality.UNSPECIFIED,
-            backgroundDispatcher
+            VideoQuality.UNSPECIFIED
         )
-    } else {
-        null
-    }
 
     val useCaseGroup = createUseCaseGroup(
         cameraInfo = sessionSettings.primaryCameraInfo,
@@ -212,7 +210,7 @@ internal suspend fun runConcurrentCameraSession(
 }
 
 context(CameraSessionContext)
-internal fun createUseCaseGroup(
+internal suspend fun createUseCaseGroup(
     cameraInfo: CameraInfo,
     initialTransientSettings: TransientSessionSettings,
     stabilizationMode: StabilizationMode,

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CoroutineCameraProvider.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CoroutineCameraProvider.kt
@@ -21,6 +21,7 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.CompositionSettings
 import androidx.camera.core.ConcurrentCamera
 import androidx.camera.core.ConcurrentCamera.SingleCameraConfig
+import androidx.camera.core.SessionConfig
 import androidx.camera.core.UseCaseGroup
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.lifecycle.Lifecycle
@@ -40,11 +41,11 @@ import kotlinx.coroutines.coroutineScope
  */
 suspend fun <R> ProcessCameraProvider.runWith(
     cameraSelector: CameraSelector,
-    useCases: UseCaseGroup,
+    sessionConfig: SessionConfig,
     block: suspend CoroutineScope.(Camera) -> R
 ): R = coroutineScope {
     val scopedLifecycle = CoroutineLifecycleOwner(coroutineContext)
-    block(this@runWith.bindToLifecycle(scopedLifecycle, cameraSelector, useCases))
+    block(this@runWith.bindToLifecycle(scopedLifecycle, cameraSelector, sessionConfig))
 }
 
 @SuppressLint("RestrictedApi")

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/FeatureGroupHandler.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/FeatureGroupHandler.kt
@@ -1,0 +1,451 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import android.util.Log
+import androidx.camera.core.CameraInfo
+import androidx.camera.lifecycle.ProcessCameraProvider
+import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.DynamicRange
+import com.google.jetpackcamera.model.ImageOutputFormat
+import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.StreamConfig
+import com.google.jetpackcamera.model.VideoQuality
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraConstraints
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
+import com.google.jetpackcamera.settings.model.forCurrentLens
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private const val TAG = "FeatureGroupHandler"
+
+/**
+ * Handles logic related to CameraX feature groups.
+ *
+ * This class encapsulates the operations required to ensure camera settings are compatible with
+ * device capabilities using the CameraX feature group API.
+ *
+ * Key functionalities include:
+ * - [filterSystemConstraints]: Validates the current camera settings against feature group requirements
+ *   and updates [CameraSystemConstraints] to filter out unsupported options.
+ * - [isGroupingSupported]: Checks if a specific combination of [CameraAppSettings] is supported
+ *   as a valid feature group on the device.
+ */
+internal class FeatureGroupHandler(
+    // TODO: Remove the CameraXCameraSystem dependency from here by refactoring out all camera
+    //   setting applying APIs (e.g. applyDynamicRange) from CameraXCameraSystem
+    private val cameraSystem: CameraXCameraSystem,
+    private val cameraProvider: ProcessCameraProvider,
+    private val defaultCameraSessionContext: CameraSessionContext,
+    private val defaultDispatcher: CoroutineDispatcher
+) {
+    private var isHdrSupportedWithJpegR = atomic<Boolean?>(null)
+
+    /**
+     * Filters the [CameraSystemConstraints] based on feature group compatibility.
+     *
+     * This function checks various combinations of settings (dynamic range, frame rate,
+     * stabilization, etc.) against the device's capabilities using the CameraX feature groups API.
+     * It filters out unsupported options from the system constraints, ensuring that the UI only
+     * presents valid combinations to the user.
+     */
+    suspend fun filterSystemConstraints(
+        currentSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        currentSystemConstraints: CameraSystemConstraints
+    ): CameraSystemConstraints {
+        val initialCameraConstraints =
+            requireNotNull(initialSystemConstraints.forCurrentLens(currentSettings))
+
+        // Sanitize all AUTO values
+        val autoSanitizedSettings =
+            if (currentSettings.stabilizationMode == StabilizationMode.AUTO) {
+                currentSettings.copy(stabilizationMode = StabilizationMode.OFF)
+            } else {
+                currentSettings
+            }
+
+        Log.d(
+            TAG,
+            "filterSystemConstraints: cameraAppSettings = $currentSettings" +
+                ", autoSanitizedSettings = $autoSanitizedSettings" +
+                ", initialCameraConstraints = $initialCameraConstraints"
+        )
+
+        val featureDataSet = autoSanitizedSettings.toFeatureGroupabilities()
+
+        if (!featureDataSet.isCompatible()) {
+            Log.i(
+                TAG,
+                "filterSystemConstraints: since the settings is incompatible" +
+                    " with CameraX feature groups API, falling back to initial" +
+                    " system constraints without using feature groups. featureDataSet = " +
+                    " $featureDataSet."
+            )
+            return initialSystemConstraints
+        }
+
+        val cameraInfo =
+            cameraProvider.getCameraInfo(currentSettings.cameraLensFacing.toCameraSelector())
+
+        // TODO: More stabilization + FPS pairs can be supported with CameraX feature group API.
+        //  However, while the following code does provide such support, this function is called
+        //  only when camera session is recreated. So, updating unsupportedStabilizationFpsMap now
+        //  can cause regressions in scenarios where user tries to change both stabilization mode
+        //  and FPS mode from settings page directly. We need to ensure this function is used
+        //  for each setting value update to avoid that.
+
+//        val unsupportedStabilizationFpsMap = buildMap {
+//            initialCameraConstraints
+//                .unsupportedStabilizationFpsMap
+//                .forEach { (stabilizationMode, fpsList) ->
+//                    if (stabilizationMode.toFeatureGroupability() is Nongroupable) {
+//                        put(stabilizationMode, fpsList)
+//                        return@forEach
+//                    }
+//
+//                    fpsList.forEach { fps ->
+//                        if (fps.toFpsFeatureGroupability() is Nongroupable) {
+//                            put(stabilizationMode, fpsList)
+//                            return@forEach
+//                        }
+//
+//                        if (!cameraAppSettings.copyStabilizationMode(stabilizationMode)
+//                                .copyTargetFrameRate(fps).isGroupingSupported(cameraInfo)
+//                        ) {
+//                            put(stabilizationMode, fpsList)
+//                        }
+//                    }
+//                }
+//        }
+
+        val updatedPerLensConstraints = initialSystemConstraints.perLensConstraints.toMutableMap()
+
+        updatedPerLensConstraints[autoSanitizedSettings.cameraLensFacing] =
+            initialCameraConstraints
+                .copy(
+                    supportedDynamicRanges = filterGroupableDynamicRanges(
+                        autoSanitizedSettings,
+                        initialSystemConstraints,
+                        initialCameraConstraints,
+                        cameraInfo
+                    ),
+                    supportedFixedFrameRates = filterGroupableFrameRates(
+                        autoSanitizedSettings,
+                        initialSystemConstraints,
+                        initialCameraConstraints,
+                        cameraInfo
+                    ),
+                    supportedStabilizationModes = filterGroupableStabilizationModes(
+                        autoSanitizedSettings,
+                        initialSystemConstraints,
+                        initialCameraConstraints,
+                        cameraInfo
+                    ),
+                    supportedImageFormatsMap = filterGroupableImageFormatsMap(
+                        autoSanitizedSettings,
+                        initialSystemConstraints,
+                        initialCameraConstraints,
+                        cameraInfo
+                    ),
+                    supportedVideoQualitiesMap = filterGroupableVideoQualitiesMap(
+                        autoSanitizedSettings,
+                        initialSystemConstraints,
+                        initialCameraConstraints,
+                        cameraInfo
+                    )
+//                    unsupportedStabilizationFpsMap = unsupportedStabilizationFpsMap
+                )
+
+        val newConstraints = currentSystemConstraints.copy(
+            perLensConstraints = updatedPerLensConstraints
+        )
+
+        Log.d(TAG, "filterSystemConstraints: updated systemConstraints = $newConstraints")
+
+        cacheConcurrentHdrJpegRCapability(autoSanitizedSettings, newConstraints)
+
+        return newConstraints
+    }
+
+    /**
+     * Filters supported [DynamicRange]s by checking groupability with current settings.
+     */
+    private suspend fun filterGroupableDynamicRanges(
+        cameraAppSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        initialCameraConstraints: CameraConstraints,
+        cameraInfo: CameraInfo
+    ): Set<DynamicRange> {
+        Log.d(TAG, "filterGroupableDynamicRanges")
+
+        return initialCameraConstraints.supportedDynamicRanges.filter {
+            val settings = with(cameraSystem) {
+                cameraAppSettings.applyDynamicRange(it, initialSystemConstraints)
+            }
+            isGroupingSupported(settings, cameraInfo, initialSystemConstraints) == true
+        }.toSet()
+    }
+
+    /**
+     * Filters supported frame rates by checking groupability with current settings.
+     */
+    private suspend fun filterGroupableFrameRates(
+        cameraAppSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        initialCameraConstraints: CameraConstraints,
+        cameraInfo: CameraInfo
+    ): Set<Int> {
+        Log.d(TAG, "filterGroupableFrameRates")
+
+        return initialCameraConstraints.supportedFixedFrameRates.filter {
+            val settings = with(cameraSystem) {
+                cameraAppSettings.applyTargetFrameRate(it, initialSystemConstraints)
+            }
+            isGroupingSupported(settings, cameraInfo, initialSystemConstraints) == true
+        }.toSet()
+    }
+
+    /**
+     * Filters supported [StabilizationMode]s by checking groupability with current settings.
+     */
+    private suspend fun filterGroupableStabilizationModes(
+        cameraAppSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        initialCameraConstraints: CameraConstraints,
+        cameraInfo: CameraInfo
+    ): Set<StabilizationMode> {
+        Log.d(TAG, "filterGroupableStabilizationModes")
+
+        return initialCameraConstraints.supportedStabilizationModes.filter {
+            Log.d(TAG, "filterGroupableStabilizationModes: it = $it")
+
+            val resolvedStabilizationMode = with(cameraSystem) {
+                resolveStabilizationMode(
+                    requestedStabilizationMode = it,
+                    cameraAppSettings = cameraAppSettings,
+                    cameraConstraints = initialCameraConstraints
+                )
+            }
+            val settings = with(cameraSystem) {
+                cameraAppSettings.applyStabilizationMode(resolvedStabilizationMode)
+            }
+            isGroupingSupported(settings, cameraInfo, initialSystemConstraints) == true
+        }.toSet()
+    }
+
+    /**
+     * Filters supported [ImageOutputFormat]s by checking groupability with current settings.
+     */
+    private suspend fun filterGroupableImageFormatsMap(
+        cameraAppSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        initialCameraConstraints: CameraConstraints,
+        cameraInfo: CameraInfo
+    ): Map<StreamConfig, Set<ImageOutputFormat>> {
+        Log.d(TAG, "filterGroupableImageFormatsMap")
+
+        return buildMap {
+            initialCameraConstraints
+                .supportedImageFormatsMap
+                .forEach { (streamConfig, imageFormats) ->
+                    put(
+                        streamConfig,
+                        imageFormats.filter {
+                            val settings = with(cameraSystem) {
+                                cameraAppSettings
+                                    .applyStreamConfig(streamConfig, initialSystemConstraints)
+                                    .run {
+                                        if (it == ImageOutputFormat.JPEG_ULTRA_HDR) {
+                                            // tryApplyImageFormatConstraints changes capture mode
+                                            // to VIDEO_ONLY if both JPEG_R and HDR are supported
+                                            // with STANDARD capture mode. VIDEO_ONLY capture mode
+                                            // leads to IMAGE_ULTRA_HDR GroupableFeature not being
+                                            // set to CameraX. To workaround this issue, capture
+                                            // mode is manually set to IMAGE_ONLY to ensure the
+                                            // capability checking is correct.
+
+                                            applyCaptureMode(
+                                                CaptureMode.IMAGE_ONLY,
+                                                initialSystemConstraints
+                                            )
+                                        } else {
+                                            this
+                                        }
+                                    }
+                                    .applyImageFormat(it, initialSystemConstraints)
+                            }
+                            isGroupingSupported(
+                                settings,
+                                cameraInfo,
+                                initialSystemConstraints
+                            ) == true
+                        }.toSet()
+                    )
+                }
+        }
+    }
+
+    /**
+     * Filters supported [VideoQuality]s by checking groupability with current settings.
+     */
+    private suspend fun filterGroupableVideoQualitiesMap(
+        cameraAppSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        initialCameraConstraints: CameraConstraints,
+        cameraInfo: CameraInfo
+    ): Map<DynamicRange, List<VideoQuality>> {
+        Log.d(TAG, "filterGroupableVideoQualitiesMap")
+
+        return buildMap {
+            initialCameraConstraints
+                .supportedVideoQualitiesMap
+                .forEach { (dynamicRange, videoQualities) ->
+                    put(
+                        dynamicRange,
+                        videoQualities.filter {
+                            val settings = with(cameraSystem) {
+                                cameraAppSettings
+                                    .applyDynamicRange(dynamicRange, initialSystemConstraints)
+                                    .applyVideoQuality(it, initialSystemConstraints)
+                            }
+                            isGroupingSupported(
+                                settings,
+                                cameraInfo,
+                                initialSystemConstraints
+                            ) == true
+                        }
+                    )
+                }
+        }
+    }
+
+    /**
+     * Returns whether a [CameraAppSettings] is supported together as a group.
+     *
+     * High quality features sometimes can be supported individually while being unsupported
+     * together as a group. This API utilizes the CameraX feature group APIs to know if a
+     * [CameraAppSettings] is supported as a group.
+     *
+     * However, not all [CameraAppSettings] feature values are queryable through the feature group
+     * APIs. So, this API works in a best-effort manner by using only the queryable features.
+     *
+     * @return Whether a [CameraAppSettings] is supported together as a group, or a null value when
+     *   it is not possible to check.
+     */
+    internal suspend fun isGroupingSupported(
+        cameraAppSettings: CameraAppSettings,
+        cameraInfo: CameraInfo,
+        initialSystemConstraints: CameraSystemConstraints
+    ): Boolean? {
+        // TODO: Optimize feature group queries via pre-calculation and persistence.
+        //  Reconstructing the full SessionConfig and UseCases for every query is expensive.
+        //  Consider pre-calculating the 16 possible combinations of groupable features
+        //  (HDR, 60FPS, etc.) and persisting the results in a database. This would make UI checks
+        //  O(1) across app launches since hardware capabilities are generally static.
+
+        val cameraConstraints =
+            requireNotNull(initialSystemConstraints.forCurrentLens(cameraAppSettings))
+
+        val transientSettings =
+            with(cameraSystem) { cameraAppSettings.toTransientSessionSettings() }
+
+        val sessionSettings = with(cameraSystem) {
+            cameraAppSettings.toSingleCameraSessionSettings(cameraConstraints)
+        }
+
+        if (!sessionSettings.toFeatureGroupabilities().isCompatible()) {
+            Log.d(
+                TAG,
+                "isGroupingSupported: CameraX feature group is not compatible with this" +
+                    " session settings, so returning null. sessionSettings = $sessionSettings"
+            )
+            return null
+        }
+
+        // An explicit job is used here because simpler approach like `coroutineScope { ... }`
+        // seems to get stuck forever for StreamConfig.SINGLE_STREAM. The code flow for
+        // SINGLE_STREAM seems to be keeping the coroutine scope forever busy and thus the
+        // `coroutineScope` block never completes.
+        val job = Job()
+
+        val sessionConfig = with(
+            defaultCameraSessionContext.copy(
+                transientSettings = MutableStateFlow(transientSettings).asStateFlow()
+            )
+        ) {
+            val videoCaptureUseCase =
+                createVideoUseCase(
+                    cameraInfo,
+                    cameraAppSettings.aspectRatio,
+                    cameraAppSettings.captureMode,
+                    backgroundDispatcher,
+                    cameraAppSettings.targetFrameRate.takeIfNoFeatureGroup(sessionSettings),
+                    cameraAppSettings.stabilizationMode.takeIfNoFeatureGroup(sessionSettings),
+                    cameraAppSettings.dynamicRange.takeIfNoFeatureGroup(sessionSettings),
+                    cameraAppSettings.videoQuality.takeIfNoFeatureGroup(sessionSettings)
+                )
+
+            createSessionConfig(
+                cameraConstraints = cameraConstraints,
+                initialTransientSettings = transientSettings,
+                videoCaptureUseCase = videoCaptureUseCase,
+                sessionSettings = sessionSettings,
+                sessionScope = CoroutineScope(defaultDispatcher + job)
+            )
+        }
+
+        return cameraInfo.isSessionConfigSupported(sessionConfig).apply {
+            job.cancel()
+        }
+    }
+
+    private suspend fun cacheConcurrentHdrJpegRCapability(
+        cameraAppSettings: CameraAppSettings,
+        systemConstraints: CameraSystemConstraints
+    ) {
+        with(cameraSystem) {
+            val supported = isGroupingSupported(
+                cameraAppSettings
+                    .copy(dynamicRange = cameraAppSettings.dynamicRange)
+                    .applyImageFormat(
+                        imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR,
+                        systemConstraints = systemConstraints.copy()
+                    ),
+                cameraProvider
+                    .getCameraInfo(
+                        cameraAppSettings
+                            .cameraLensFacing
+                            .toCameraSelector()
+                    ),
+                systemConstraints
+            )
+
+            isHdrSupportedWithJpegR.value = supported
+        }
+    }
+
+    /**
+     * Returns whether HDR is supported with JPEG_R, a null value represents the result is still
+     * unknown.
+     */
+    fun isHdrSupportedWithJpegR(): Boolean? = isHdrSupportedWithJpegR.value
+}

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/FeatureGroupHandler.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/FeatureGroupHandler.kt
@@ -106,36 +106,36 @@ internal class FeatureGroupHandler(
         val cameraInfo =
             cameraProvider.getCameraInfo(currentSettings.cameraLensFacing.toCameraSelector())
 
-        // TODO: More stabilization + FPS pairs can be supported with CameraX feature group API.
-        //  However, while the following code does provide such support, this function is called
-        //  only when camera session is recreated. So, updating unsupportedStabilizationFpsMap now
-        //  can cause regressions in scenarios where user tries to change both stabilization mode
-        //  and FPS mode from settings page directly. We need to ensure this function is used
-        //  for each setting value update to avoid that.
-
-//        val unsupportedStabilizationFpsMap = buildMap {
-//            initialCameraConstraints
-//                .unsupportedStabilizationFpsMap
-//                .forEach { (stabilizationMode, fpsList) ->
-//                    if (stabilizationMode.toFeatureGroupability() is Nongroupable) {
-//                        put(stabilizationMode, fpsList)
-//                        return@forEach
-//                    }
-//
-//                    fpsList.forEach { fps ->
-//                        if (fps.toFpsFeatureGroupability() is Nongroupable) {
-//                            put(stabilizationMode, fpsList)
-//                            return@forEach
-//                        }
-//
-//                        if (!cameraAppSettings.copyStabilizationMode(stabilizationMode)
-//                                .copyTargetFrameRate(fps).isGroupingSupported(cameraInfo)
-//                        ) {
-//                            put(stabilizationMode, fpsList)
-//                        }
-//                    }
-//                }
-//        }
+        /*
+         * TODO: More stabilization + FPS pairs can be supported with CameraX feature group API.
+         *  However, while the following code does provide such support, this function is called
+         *  only when camera session is recreated. So, updating unsupportedStabilizationFpsMap now
+         *  can cause regressions in scenarios where user tries to change both stabilization mode
+         *  and FPS mode from settings page directly. We need to ensure this function is used
+         *  for each setting value update to avoid that.
+         *  Reference code:
+         *  val unsupportedStabilizationFpsMap = buildMap {
+         *      initialCameraConstraints
+         *          .unsupportedStabilizationFpsMap
+         *          .forEach { (stabilizationMode, fpsList) ->
+         *              if (stabilizationMode.toFeatureGroupability() is Nongroupable) {
+         *                  put(stabilizationMode, fpsList)
+         *                  return@forEach
+         *              }
+         *              fpsList.forEach { fps ->
+         *                  if (fps.toFpsFeatureGroupability() is Nongroupable) {
+         *                      put(stabilizationMode, fpsList)
+         *                      return@forEach
+         *                  }
+         *                  if (!cameraAppSettings.copyStabilizationMode(stabilizationMode)
+         *                          .copyTargetFrameRate(fps).isGroupingSupported(cameraInfo)
+         *                  ) {
+         *                      put(stabilizationMode, fpsList)
+         *                  }
+         *              }
+         *          }
+         *  }
+         */
 
         val updatedPerLensConstraints = initialSystemConstraints.perLensConstraints.toMutableMap()
 
@@ -171,8 +171,14 @@ internal class FeatureGroupHandler(
                         initialSystemConstraints,
                         initialCameraConstraints,
                         cameraInfo
+                    ),
+                    supportedStreamConfigs = filterStreamConfig(
+                        currentSettings,
+                        initialSystemConstraints,
+                        initialCameraConstraints,
+                        cameraInfo
                     )
-//                    unsupportedStabilizationFpsMap = unsupportedStabilizationFpsMap
+                    // TODO: unsupportedStabilizationFpsMap = unsupportedStabilizationFpsMap
                 )
 
         val newConstraints = currentSystemConstraints.copy(
@@ -336,6 +342,23 @@ internal class FeatureGroupHandler(
                     )
                 }
         }
+    }
+
+    /**
+     * Filters supported [StreamConfig]s by checking groupability with current settings.
+     */
+    private suspend fun filterStreamConfig(
+        cameraAppSettings: CameraAppSettings,
+        initialSystemConstraints: CameraSystemConstraints,
+        initialCameraConstraints: CameraConstraints,
+        cameraInfo: CameraInfo
+    ): Set<StreamConfig> {
+        return initialCameraConstraints.supportedStreamConfigs.filter {
+            val settings = with(cameraSystem) {
+                cameraAppSettings.applyStreamConfig(it)
+            }
+            isGroupingSupported(settings, cameraInfo, initialSystemConstraints) == true
+        }.toSet()
     }
 
     /**

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/FeatureGroupability.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/FeatureGroupability.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import androidx.camera.core.featuregroup.GroupableFeature
+import androidx.camera.video.GroupableFeatures
+import com.google.jetpackcamera.core.camera.FeatureGroupability.ExplicitlyGroupable
+import com.google.jetpackcamera.core.camera.FeatureGroupability.ImplicitlyGroupable
+import com.google.jetpackcamera.core.camera.FeatureGroupability.Ungroupable
+import com.google.jetpackcamera.model.DynamicRange
+import com.google.jetpackcamera.model.ImageOutputFormat
+import com.google.jetpackcamera.model.ImageOutputFormat.JPEG
+import com.google.jetpackcamera.model.ImageOutputFormat.JPEG_ULTRA_HDR
+import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.StabilizationMode.AUTO
+import com.google.jetpackcamera.model.StabilizationMode.HIGH_QUALITY
+import com.google.jetpackcamera.model.StabilizationMode.OFF
+import com.google.jetpackcamera.model.StabilizationMode.ON
+import com.google.jetpackcamera.model.StabilizationMode.OPTICAL
+import com.google.jetpackcamera.model.VideoQuality
+import com.google.jetpackcamera.model.VideoQuality.FHD
+import com.google.jetpackcamera.model.VideoQuality.HD
+import com.google.jetpackcamera.model.VideoQuality.SD
+import com.google.jetpackcamera.model.VideoQuality.UHD
+import com.google.jetpackcamera.model.VideoQuality.UNSPECIFIED
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+
+/**
+ * Categorizes how a camera feature can be used with CameraX's feature group query API.
+ *
+ * This allows internal JCA models like [DynamicRange] and [VideoQuality] to be mapped to CameraX
+ * [GroupableFeature]s for compatibility checking.
+ */
+sealed interface FeatureGroupability<out T> {
+    /** Corresponds to a specific [GroupableFeature] object. */
+    data class ExplicitlyGroupable(val feature: GroupableFeature) : FeatureGroupability<Nothing>
+
+    /**
+     * Does not correspond to a specific [GroupableFeature] object, but implicitly groupable as
+     * it is equivalent to the base value CameraX feature groups API will use.
+     */
+    object ImplicitlyGroupable : FeatureGroupability<Nothing>
+
+    /** Feature value that is not usable with CameraX feature groups API. */
+    data class Ungroupable<T>(val featureValue: T) : FeatureGroupability<T>
+}
+
+/**
+ * Returns whether a collection of [FeatureGroupability] represents that CameraX feature group
+ * query API should be used.
+ *
+ * This is based on the following points:
+ * - Feature group query API should be used whenever there's at least two [GroupableFeature].
+ * - Shouldn't be used for single feature cases in JCA for simplicity.
+ */
+internal fun Collection<FeatureGroupability<*>>.requiresFeatureGroupQuery(): Boolean {
+    return filterIsInstance<ExplicitlyGroupable>().size >= 2
+}
+
+/**
+ * Returns whether a collection of [FeatureGroupability] is compatible.
+ *
+ * An [Ungroupable] element represents the collection is incompatible.
+ */
+internal fun Collection<FeatureGroupability<*>>.isCompatible(): Boolean {
+    return none { it is Ungroupable }
+}
+
+/**
+ * Returns whether a collection of [FeatureGroupability] should be used.
+ *
+ * The collection should be used for camera session only when it is required and not invalid i.e.
+ * there are multiple [ExplicitlyGroupable] elements and no [Ungroupable] element.
+ */
+internal fun Collection<FeatureGroupability<*>>.shouldUse(): Boolean {
+    return requiresFeatureGroupQuery() && isCompatible()
+}
+
+/**
+ * Converts this [DynamicRange] to a [FeatureGroupability].
+ *
+ * This allows the dynamic range to be used in CameraX feature group compatibility checks.
+ */
+fun DynamicRange.toFeatureGroupability(): FeatureGroupability<DynamicRange> {
+    return when (this) {
+        DynamicRange.SDR -> ImplicitlyGroupable
+        DynamicRange.HLG10 -> ExplicitlyGroupable(GroupableFeature.HDR_HLG10)
+    }
+}
+
+/**
+ * Converts this [VideoQuality] to a [FeatureGroupability].
+ *
+ * This allows the video quality to be used in CameraX feature group compatibility checks.
+ */
+fun VideoQuality.toFeatureGroupability(): FeatureGroupability<VideoQuality> {
+    return when (this) {
+        SD -> ExplicitlyGroupable(GroupableFeatures.SD_RECORDING)
+        HD -> ExplicitlyGroupable(GroupableFeatures.HD_RECORDING)
+        FHD -> ExplicitlyGroupable(GroupableFeatures.FHD_RECORDING)
+        UHD -> ExplicitlyGroupable(GroupableFeatures.UHD_RECORDING)
+        UNSPECIFIED -> ImplicitlyGroupable
+    }
+}
+
+/**
+ * Converts this [ImageOutputFormat] to a [FeatureGroupability].
+ *
+ * This allows the image output format to be used in CameraX feature group compatibility checks.
+ */
+fun ImageOutputFormat.toFeatureGroupability(): FeatureGroupability<ImageOutputFormat> {
+    return when (this) {
+        JPEG -> ImplicitlyGroupable
+        JPEG_ULTRA_HDR -> ExplicitlyGroupable(GroupableFeature.IMAGE_ULTRA_HDR)
+    }
+}
+
+/**
+ * Converts this [StabilizationMode] to a [FeatureGroupability].
+ *
+ * This allows the stabilization mode to be used in CameraX feature group compatibility checks.
+ *
+ * @throws IllegalStateException When the value of this `StabilizationMode` is [AUTO].
+ */
+fun StabilizationMode.toFeatureGroupability(): FeatureGroupability<StabilizationMode> {
+    return when (this) {
+        OFF -> ImplicitlyGroupable
+        ON -> ExplicitlyGroupable(GroupableFeature.PREVIEW_STABILIZATION)
+        HIGH_QUALITY -> ExplicitlyGroupable(GroupableFeatures.VIDEO_STABILIZATION)
+        AUTO ->
+            throw IllegalStateException(
+                "AUTO should be resolved to concrete value before this API is called!"
+            )
+        OPTICAL -> Ungroupable(this)
+    }
+}
+
+/**
+ * Converts this integer FPS value to a [FeatureGroupability].
+ *
+ * This allows the frame rate to be used in CameraX feature group compatibility checks.
+ */
+fun Int.toFpsFeatureGroupability(): FeatureGroupability<Int> {
+    return when (this) {
+        60 -> ExplicitlyGroupable(GroupableFeature.FPS_60)
+        30, 0 -> ImplicitlyGroupable
+        else -> Ungroupable(this)
+    }
+}
+
+/**
+ * Creates a set of [FeatureGroupability] from a [com.google.jetpackcamera.settings.model.CameraAppSettings].
+ */
+internal fun CameraAppSettings.toFeatureGroupabilities(): Set<FeatureGroupability<*>> {
+    return setOf(
+        dynamicRange.toFeatureGroupability(),
+        targetFrameRate.toFpsFeatureGroupability(),
+        imageFormat.toFeatureGroupability(),
+        stabilizationMode.toFeatureGroupability(),
+        videoQuality.toFeatureGroupability()
+    )
+}
+
+/**
+ * Creates a set of [FeatureGroupability] from a [PerpetualSessionSettings.SingleCamera].
+ */
+internal fun PerpetualSessionSettings.SingleCamera.toFeatureGroupabilities():
+    Set<FeatureGroupability<*>> {
+    return setOf(
+        dynamicRange.toFeatureGroupability(),
+        targetFrameRate.toFpsFeatureGroupability(),
+        imageFormat.toFeatureGroupability(),
+        stabilizationMode.toFeatureGroupability(),
+        videoQuality.toFeatureGroupability()
+    )
+}
+
+/**
+ * Returns `this` value if the provided [sessionSettings] should not use CameraX feature groups.
+ */
+internal fun <T> T.takeIfNoFeatureGroup(
+    sessionSettings: PerpetualSessionSettings.SingleCamera
+): T? {
+    return if (sessionSettings.toFeatureGroupabilities().shouldUse()) null else this
+}

--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/FeatureGroupabilityTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/FeatureGroupabilityTest.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import androidx.camera.core.featuregroup.GroupableFeature
+import androidx.camera.video.GroupableFeatures
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.FeatureGroupability.ExplicitlyGroupable
+import com.google.jetpackcamera.core.camera.FeatureGroupability.ImplicitlyGroupable
+import com.google.jetpackcamera.core.camera.FeatureGroupability.Ungroupable
+import com.google.jetpackcamera.model.AspectRatio
+import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.DynamicRange
+import com.google.jetpackcamera.model.ImageOutputFormat
+import com.google.jetpackcamera.model.LowLightBoostPriority
+import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.StreamConfig
+import com.google.jetpackcamera.model.VideoQuality
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FeatureGroupabilityTest {
+    @Test
+    fun requiresFeatureGroupQuery_returnsTrue_whenTwoOrMoreExplicit() {
+        val collection = listOf(
+            ExplicitlyGroupable(GroupableFeatures.SD_RECORDING),
+            ExplicitlyGroupable(GroupableFeature.IMAGE_ULTRA_HDR),
+            ImplicitlyGroupable
+        )
+        assertThat(collection.requiresFeatureGroupQuery()).isTrue()
+    }
+
+    @Test
+    fun requiresFeatureGroupQuery_returnsFalse_whenLessThanTwoExplicit() {
+        val collection1 = listOf(
+            ExplicitlyGroupable(GroupableFeatures.SD_RECORDING),
+            ImplicitlyGroupable
+        )
+        val collection2 = listOf(
+            ImplicitlyGroupable,
+            ImplicitlyGroupable
+        )
+        assertThat(collection1.requiresFeatureGroupQuery()).isFalse()
+        assertThat(collection2.requiresFeatureGroupQuery()).isFalse()
+    }
+
+    @Test
+    fun shouldUse_returnsFalse_whenRequiresQueryAndHasUngroupable() {
+        val collection = listOf(
+            ExplicitlyGroupable(GroupableFeatures.SD_RECORDING),
+            ExplicitlyGroupable(GroupableFeature.IMAGE_ULTRA_HDR),
+            Ungroupable("someValue")
+        )
+        assertThat(collection.shouldUse()).isFalse()
+    }
+
+    @Test
+    fun shouldUse_returnsTrue_whenRequiresQueryAndNoUngroupable() {
+        val collection = listOf(
+            ExplicitlyGroupable(GroupableFeatures.SD_RECORDING),
+            ExplicitlyGroupable(GroupableFeature.IMAGE_ULTRA_HDR),
+            ImplicitlyGroupable
+        )
+        assertThat(collection.shouldUse()).isTrue()
+    }
+
+    @Test
+    fun shouldUse_returnsFalse_whenNotRequiresQueryAndHasUngroupable() {
+        val collection = listOf(
+            ExplicitlyGroupable(GroupableFeatures.SD_RECORDING),
+            Ungroupable("someValue")
+        )
+        assertThat(collection.shouldUse()).isFalse()
+    }
+
+    @Test
+    fun dynamicRange_toFeatureGroupability_mapsCorrectly() {
+        assertThat(DynamicRange.SDR.toFeatureGroupability()).isEqualTo(ImplicitlyGroupable)
+        assertThat(
+            DynamicRange.HLG10.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeature.HDR_HLG10))
+    }
+
+    @Test
+    fun videoQuality_toFeatureGroupability_mapsCorrectly() {
+        assertThat(
+            VideoQuality.SD.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeatures.SD_RECORDING))
+        assertThat(
+            VideoQuality.HD.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeatures.HD_RECORDING))
+        assertThat(
+            VideoQuality.FHD.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeatures.FHD_RECORDING))
+        assertThat(
+            VideoQuality.UHD.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeatures.UHD_RECORDING))
+    }
+
+    @Test
+    fun imageOutputFormat_toFeatureGroupability_mapsCorrectly() {
+        assertThat(ImageOutputFormat.JPEG.toFeatureGroupability()).isEqualTo(ImplicitlyGroupable)
+        assertThat(
+            ImageOutputFormat.JPEG_ULTRA_HDR.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeature.IMAGE_ULTRA_HDR))
+    }
+
+    @Test
+    fun stabilizationMode_toFeatureGroupability_mapsCorrectly() {
+        assertThat(StabilizationMode.OFF.toFeatureGroupability()).isEqualTo(ImplicitlyGroupable)
+        assertThat(
+            StabilizationMode.ON.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeature.PREVIEW_STABILIZATION))
+        assertThat(
+            StabilizationMode.HIGH_QUALITY.toFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeatures.VIDEO_STABILIZATION))
+        assertThrows(IllegalStateException::class.java) {
+            StabilizationMode.AUTO.toFeatureGroupability()
+        }
+        assertThat(
+            StabilizationMode.OPTICAL.toFeatureGroupability()
+        ).isInstanceOf(Ungroupable::class.java)
+    }
+
+    @Test
+    fun int_toFpsFeatureGroupability_mapsCorrectly() {
+        assertThat(
+            60.toFpsFeatureGroupability()
+        ).isEqualTo(ExplicitlyGroupable(GroupableFeature.FPS_60))
+        assertThat(30.toFpsFeatureGroupability()).isEqualTo(ImplicitlyGroupable)
+        assertThat(0.toFpsFeatureGroupability()).isEqualTo(ImplicitlyGroupable)
+        assertThat(15.toFpsFeatureGroupability()).isInstanceOf(Ungroupable::class.java)
+    }
+
+    @Test
+    fun singleCamera_toFeatureGroupabilities_containsCorrectElements() {
+        val settings = PerpetualSessionSettings.SingleCamera(
+            aspectRatio = AspectRatio.THREE_FOUR,
+            captureMode = CaptureMode.STANDARD,
+            streamConfig = StreamConfig.MULTI_STREAM,
+            targetFrameRate = 60,
+            stabilizationMode = StabilizationMode.ON,
+            dynamicRange = DynamicRange.HLG10,
+            videoQuality = VideoQuality.UHD,
+            imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR,
+            lowLightBoostPriority = LowLightBoostPriority.PRIORITIZE_AE_MODE
+        )
+
+        val dataSet = settings.toFeatureGroupabilities()
+
+        assertThat(dataSet).contains(ExplicitlyGroupable(GroupableFeature.FPS_60))
+        assertThat(dataSet).contains(ExplicitlyGroupable(GroupableFeature.PREVIEW_STABILIZATION))
+        assertThat(dataSet).contains(ExplicitlyGroupable(GroupableFeature.HDR_HLG10))
+        assertThat(dataSet).contains(ExplicitlyGroupable(GroupableFeatures.UHD_RECORDING))
+        assertThat(dataSet).contains(ExplicitlyGroupable(GroupableFeature.IMAGE_ULTRA_HDR))
+    }
+
+    @Test
+    fun takeIfFeatureGroupInvalid_returnsObject_whenInvalid() {
+        // Construct an invalid combination: e.g. using feature groups (>=2 explicit) AND an ungroupable
+        // Here: 60fps (Explicit), Stabilization ON (Explicit) AND Stabilization OPTICAL (Ungroupable - wait, can't set two stabilization modes)
+
+        // Let's use a combination that results in 2 explicits and 1 ungroupable.
+        // Explicit: 60fps
+        // Explicit: HLG10
+        // Ungroupable: Stabilization OPTICAL
+
+        val settings = PerpetualSessionSettings.SingleCamera(
+            aspectRatio = AspectRatio.THREE_FOUR,
+            captureMode = CaptureMode.STANDARD,
+            streamConfig = StreamConfig.MULTI_STREAM,
+            targetFrameRate = 60, // Explicit
+            stabilizationMode = StabilizationMode.OPTICAL, // Ungroupable
+            dynamicRange = DynamicRange.HLG10, // Explicit
+            videoQuality = VideoQuality.SD, // Explicit
+            imageFormat = ImageOutputFormat.JPEG, // Implicit
+            lowLightBoostPriority = LowLightBoostPriority.PRIORITIZE_AE_MODE
+        )
+
+        val obj = "TestObject"
+        assertThat(obj.takeIfNoFeatureGroup(settings)).isEqualTo(obj)
+    }
+
+    @Test
+    fun takeIfFeatureGroupInvalid_returnsNull_whenValid() {
+        // Valid combination: 2 explicits, no ungroupables
+        val settings = PerpetualSessionSettings.SingleCamera(
+            aspectRatio = AspectRatio.THREE_FOUR,
+            captureMode = CaptureMode.STANDARD,
+            streamConfig = StreamConfig.MULTI_STREAM,
+            targetFrameRate = 60, // Explicit
+            stabilizationMode = StabilizationMode.ON, // Explicit
+            dynamicRange = DynamicRange.HLG10, // Explicit
+            videoQuality = VideoQuality.SD, // Explicit
+            imageFormat = ImageOutputFormat.JPEG, // Implicit
+            lowLightBoostPriority = LowLightBoostPriority.PRIORITIZE_AE_MODE
+        )
+
+        val obj = "TestObject"
+        assertThat(obj.takeIfNoFeatureGroup(settings)).isNull()
+    }
+
+    @Test
+    fun singleCamera_toGroupableFeatures_returnsCorrectSet() {
+        val settings = PerpetualSessionSettings.SingleCamera(
+            aspectRatio = AspectRatio.THREE_FOUR,
+            captureMode = CaptureMode.STANDARD,
+            streamConfig = StreamConfig.MULTI_STREAM,
+            targetFrameRate = 60,
+            stabilizationMode = StabilizationMode.ON,
+            dynamicRange = DynamicRange.HLG10,
+            videoQuality = VideoQuality.UHD,
+            imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR,
+            lowLightBoostPriority = LowLightBoostPriority.PRIORITIZE_AE_MODE
+        )
+
+        val features = settings.toGroupableFeatures()
+
+        assertThat(features!!).contains(GroupableFeature.FPS_60)
+        assertThat(features).contains(GroupableFeature.PREVIEW_STABILIZATION)
+        assertThat(features).contains(GroupableFeature.HDR_HLG10)
+        assertThat(features).contains(GroupableFeatures.UHD_RECORDING)
+        assertThat(features).contains(GroupableFeature.IMAGE_ULTRA_HDR)
+    }
+
+    @Test
+    fun singleCamera_toGroupableFeatures_filtersUltraHdrWhenVideoOnly() {
+        val settings = PerpetualSessionSettings.SingleCamera(
+            aspectRatio = AspectRatio.THREE_FOUR,
+            captureMode = CaptureMode.VIDEO_ONLY,
+            streamConfig = StreamConfig.MULTI_STREAM,
+            targetFrameRate = 60,
+            stabilizationMode = StabilizationMode.ON,
+            dynamicRange = DynamicRange.HLG10,
+            videoQuality = VideoQuality.UHD,
+            imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR,
+            lowLightBoostPriority = LowLightBoostPriority.PRIORITIZE_AE_MODE
+        )
+
+        val features = settings.toGroupableFeatures()
+
+        assertThat(features!!).contains(GroupableFeature.FPS_60)
+        assertThat(features).contains(GroupableFeature.PREVIEW_STABILIZATION)
+        assertThat(features).contains(GroupableFeature.HDR_HLG10)
+        assertThat(features).contains(GroupableFeatures.UHD_RECORDING)
+        assertThat(features).doesNotContain(GroupableFeature.IMAGE_ULTRA_HDR)
+    }
+
+    @Test
+    fun singleCamera_toGroupableFeatures_filtersVideoQualityWhenImageOnly() {
+        val settings = PerpetualSessionSettings.SingleCamera(
+            aspectRatio = AspectRatio.THREE_FOUR,
+            captureMode = CaptureMode.IMAGE_ONLY,
+            streamConfig = StreamConfig.MULTI_STREAM,
+            targetFrameRate = 60,
+            stabilizationMode = StabilizationMode.ON,
+            dynamicRange = DynamicRange.HLG10,
+            videoQuality = VideoQuality.UHD,
+            imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR,
+            lowLightBoostPriority = LowLightBoostPriority.PRIORITIZE_AE_MODE
+        )
+
+        val features = settings.toGroupableFeatures()
+
+        assertThat(features!!).contains(GroupableFeature.FPS_60)
+        assertThat(features).contains(GroupableFeature.PREVIEW_STABILIZATION)
+        assertThat(features).contains(GroupableFeature.HDR_HLG10)
+        assertThat(features).doesNotContain(GroupableFeatures.UHD_RECORDING)
+        assertThat(features).contains(GroupableFeature.IMAGE_ULTRA_HDR)
+    }
+}

--- a/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
+++ b/data/settings/src/main/java/com/google/jetpackcamera/settings/model/Constraints.kt
@@ -115,7 +115,8 @@ data class CameraConstraints(
     val supportedFlashModes: Set<FlashMode>,
     val supportedZoomRange: Range<Float>?,
     val unsupportedStabilizationFpsMap: Map<StabilizationMode, Set<Int>>,
-    val supportedTestPatterns: Set<TestPattern>
+    val supportedTestPatterns: Set<TestPattern>,
+    val supportedStreamConfigs: Set<StreamConfig>
 ) {
     val StabilizationMode.unsupportedFpsSet
         get() = unsupportedStabilizationFpsMap[this] ?: emptySet()
@@ -145,7 +146,11 @@ val TYPICAL_SYSTEM_CONSTRAINTS =
                         supportedFlashModes = setOf(FlashMode.OFF, FlashMode.ON, FlashMode.AUTO),
                         supportedZoomRange = Range(.5f, 10f),
                         unsupportedStabilizationFpsMap = emptyMap(),
-                        supportedTestPatterns = setOf(TestPattern.Off)
+                        supportedTestPatterns = setOf(TestPattern.Off),
+                        supportedStreamConfigs = setOf(
+                            StreamConfig.SINGLE_STREAM,
+                            StreamConfig.MULTI_STREAM
+                        )
                     )
                 )
             }

--- a/data/settings/src/test/java/com/google/jetpackcamera/settings/ConstraintsTest.kt
+++ b/data/settings/src/test/java/com/google/jetpackcamera/settings/ConstraintsTest.kt
@@ -144,7 +144,8 @@ class ConstraintsTest {
             supportedFlashModes = emptySet(),
             supportedZoomRange = null,
             unsupportedStabilizationFpsMap = emptyMap(),
-            supportedTestPatterns = emptySet()
+            supportedTestPatterns = emptySet(),
+            supportedStreamConfigs = emptySet()
         )
     }
 }

--- a/feature/postcapture/build.gradle.kts
+++ b/feature/postcapture/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.feature.postcapture"
-    compileSdk = 35
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Used directly in build.gradle.kts files
-compileSdk = "35"
+compileSdk = "36"
 desugar_jdk_libs = "2.1.5"
 orchestrator = "1.5.1"
 minSdk = "23"
@@ -21,7 +21,7 @@ androidxActivityCompose = "1.10.1"
 androidxAppCompat = "1.7.1"
 androidxAnnotation = "1.7.1"
 androidxBenchmark = "1.3.4"
-androidxCamera = "1.5.0-SNAPSHOT"
+androidxCamera = "1.6.0-SNAPSHOT"
 androidxConcurrentFutures = "1.3.0"
 androidxCoreKtx = "1.16.0"
 androidxDatastore = "1.1.7"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         maven {
-            setUrl("https://androidx.dev/snapshots/builds/13672667/artifacts/repository")
+            setUrl("https://androidx.dev/snapshots/builds/14496918/artifacts/repository")
         }
         google()
         mavenCentral()

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/StreamConfigsUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/StreamConfigsUiStateAdapter.kt
@@ -16,7 +16,6 @@
 package com.google.jetpackcamera.ui.uistateadapter.capture
 
 import com.google.jetpackcamera.model.ConcurrentCameraMode
-import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.StreamConfig
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.ui.uistate.capture.StreamConfigUiState
@@ -49,16 +48,14 @@ fun StreamConfigUiState.Companion.from(cameraAppSettings: CameraAppSettings): St
     return createFrom(
         cameraAppSettings.streamConfig,
         ORDERED_UI_SUPPORTED_STREAM_CONFIGS.toSet(),
-        cameraAppSettings.concurrentCameraMode,
-        cameraAppSettings.imageFormat
+        cameraAppSettings.concurrentCameraMode
     )
 }
 
 private fun createFrom(
     selectedStreamConfig: StreamConfig,
     supportedStreamConfigs: Set<StreamConfig>,
-    concurrentCameraMode: ConcurrentCameraMode,
-    imageOutputFormat: ImageOutputFormat
+    concurrentCameraMode: ConcurrentCameraMode
 ): StreamConfigUiState {
     // Ensure we at least support one flash mode
     check(supportedStreamConfigs.isNotEmpty()) {
@@ -78,10 +75,7 @@ private fun createFrom(
         StreamConfigUiState.Available(
             selectedStreamConfig = selectedStreamConfig,
             availableStreamConfigs = availableStreamConfigs,
-            isActive = !(
-                concurrentCameraMode == ConcurrentCameraMode.DUAL ||
-                    imageOutputFormat == ImageOutputFormat.JPEG_ULTRA_HDR
-                )
+            isActive = concurrentCameraMode != ConcurrentCameraMode.DUAL
         )
     }
 }

--- a/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
+++ b/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/FlashModeUiStateAdapterTest.kt
@@ -41,7 +41,8 @@ class FlashModeUiStateAdapterTest {
         supportedFlashModes = emptySet(),
         supportedZoomRange = null,
         unsupportedStabilizationFpsMap = emptyMap(),
-        supportedTestPatterns = emptySet()
+        supportedTestPatterns = emptySet(),
+        supportedStreamConfigs = emptySet()
     )
 
     private val defaultCameraAppSettings = CameraAppSettings()


### PR DESCRIPTION
# Description

This PR adopts the new **CameraX Feature Group API** to validate feature combinations and dynamically update system constraints. This ensures that the app only allows supported combinations of settings (e.g., HDR, FPS, Stabilization), preventing runtime failures on devices that do not support specific combinations (like HDR + 60 FPS on Pixel 9).

## Key Changes
*   **CameraX Update:** Updated CameraX dependencies to `1.6.0-SNAPSHOT` to access the stable Feature Groups API.
*   **Feature Mapping:** Added `FeatureGroupData` to map JCA internal models (`DynamicRange`, `VideoQuality`, `StabilizationMode`, etc.) to CameraX's `GroupableFeature`.
*   **Dynamic Constraints:** Implemented `updateSystemConstraintsByFeatureGroups` in `CameraXCameraSystem`. This method asynchronously validates the current session settings against the device capabilities and filters out unsupported options for other settings (e.g., if 60 FPS is selected, it might disable HDR if they can't be used together).
*   **Refactoring:** Migrated from `UseCaseGroup` to `SessionConfig` for single camera session creation to align with the new API usage and allow for `isSessionConfigSupported` checks.

## Bug Fixes & Enhancements
*   Fixes a crash/black screen issue on Pixel 9 devices when enabling both HDR and 60 FPS.
*   Stream mode is now selectable based on whether supported, rather being always disabled, when HDR is enabled.
*   Feature combinations can now be supported more often (due to the additional guaranteed combinations from feature combination query API), e.g. UHD recording with single stream mode in Samsung S23U.

## Known Limitations & Future Work
### System constraints not updating for multiple updates from setting screen
The system constraints are currently updated only when the camera session is initialized or re-created (e.g., upon returning to the preview screen). This means that if a user sets feature options (like UHD and  60 FPS) directly from the settings menu *without* navigating back to the preview screen, the system constraints is not re-evaluated.
Consequently, it allows users to select a combination of features that are not mutually supported by the device, which can lead to issues when they eventually navigate back to the preview screen.  

**TODO:** Addressing this limitation requires further architectural refactoring to trigger constraint updates dynamically upon any individual setting change. Or, the constraints repository should be updated with the info of all possible constraints at initialization, rather than only the settings state navigable from the current settings state.

### Features incompatible with CameraX Feature Group API
CameraX depends on the Camera2 feature combination query (FCQ) API which guarantees support only a limited set of features. So, the scenarios using features incompatible with the FCQ API do not get much benefits from this PR.

### Asynchronous system constraints update
System constraints are updated asynchronously, creating a window where a user might enable an unsupported combination of features before the update completes.  

**Future Work:** This could be addressed by waiting for the constraints update to finish and restricting setting changes until it is complete.

## Tests
*   Added `FeatureGroupDataTest` (unit tests) to verify mapping logic between JCA models and CameraX `GroupableFeature`.
*   Added `setMultipleFeatures_systemConstraintsUpdatedAndFeaturesSetIfSupported` to `CameraXCameraSystemTest` (integration test) to verify that the camera system dynamically updates constraints and sets features correctly based on CameraX feature group compatibility.

## Additional Context
*   https://android-developers.googleblog.com/2025/10/beyond-single-features-guaranteeing.html

## Related Issues
*   Fixes #457
*   Fixes #454