### PR TITLE
Add setSystemConstraints and setCurrentCameraState to FakeCameraSystem

### DIFF
--- a/core/camera/testing/src/main/java/com/google/jetpackcamera/core/camera/testing/FakeCameraSystem.kt
+++ b/core/camera/testing/src/main/java/com/google/jetpackcamera/core/camera/testing/FakeCameraSystem.kt
@@ -152,6 +152,15 @@ class FakeCameraSystem(defaultCameraSettings: CameraAppSettings = CameraAppSetti
     }
 
     private val _currentCameraState = MutableStateFlow(CameraState())
+
+    /**
+     * Test-only method to manipulate the current camera state.
+     * Use this to simulate changes in the camera's lifecycle or state (e.g., recording vs not recording)
+     * during tests, triggering downstream observers.
+     */
+    fun setCurrentCameraState(cameraState: CameraState) {
+        _currentCameraState.value = cameraState
+    }
     override fun changeZoomRatio(newZoomState: CameraZoomRatio) {
         zoomChanges.update { newZoomState }
     }
@@ -165,6 +174,15 @@ class FakeCameraSystem(defaultCameraSettings: CameraAppSettings = CameraAppSetti
     override fun getCurrentCameraState(): StateFlow<CameraState> = _currentCameraState.asStateFlow()
 
     private val _systemConstraints = MutableStateFlow<CameraSystemConstraints?>(null)
+
+    /**
+     * Test-only method to manipulate the camera system constraints.
+     * Use this to simulate different device capabilities (e.g., available lenses, flash support)
+     * during tests, ensuring the UI adapts correctly.
+     */
+    fun setSystemConstraints(systemConstraints: CameraSystemConstraints?) {
+        _systemConstraints.value = systemConstraints
+    }
     override fun getSystemConstraints(): StateFlow<CameraSystemConstraints?> =
         _systemConstraints.asStateFlow()
 

--- a/core/camera/testing/src/test/java/com/google/jetpackcamera/core/camera/testing/FakeCameraSystemTest.kt
+++ b/core/camera/testing/src/test/java/com/google/jetpackcamera/core/camera/testing/FakeCameraSystemTest.kt
@@ -16,10 +16,12 @@
 package com.google.jetpackcamera.core.camera.testing
 
 import com.google.common.truth.Truth
+import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
+import com.google.jetpackcamera.settings.model.TYPICAL_SYSTEM_CONSTRAINTS
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -147,6 +149,22 @@ class FakeCameraSystemTest {
                 CameraSystem.ScreenFlashEvent.Type.CLEAR_UI
             )
         ).inOrder()
+    }
+
+    @Test
+    fun setSystemConstraints_updatesFlow() = runTest(testDispatcher) {
+        cameraSystem.setSystemConstraints(TYPICAL_SYSTEM_CONSTRAINTS)
+        advanceUntilIdle()
+        Truth.assertThat(
+            cameraSystem.getSystemConstraints().value
+        ).isEqualTo(TYPICAL_SYSTEM_CONSTRAINTS)
+    }
+
+    @Test
+    fun setCurrentCameraState_updatesFlow() = runTest(testDispatcher) {
+        val newState = CameraState(isCameraRunning = true)
+        cameraSystem.setCurrentCameraState(newState)
+        Truth.assertThat(cameraSystem.getCurrentCameraState().value).isEqualTo(newState)
     }
 
     private fun TestScope.initAndRunCamera() {


### PR DESCRIPTION
Added `setCurrentCameraState` and `setSystemConstraints` test-only methods to `FakeCameraSystem` to allow for manipulating state flow easily. Updated `FakeCameraSystemTest` to cover these two new methods, and included KDocs as per the style guide.