### PR TITLE
Fix snackbar assertion regression in Compose tests

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -33,7 +34,6 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -182,7 +182,7 @@ fun ComposeTestRule.waitForSnackbarWithText(
 ) {
     val expectedText = getResString(textResId)
     waitUntil(timeoutMillis = timeoutMillis) {
-        onAllNodes(hasTestTag(SNACKBAR_NODE_TAG) and hasText(expectedText))
+        onAllNodes(hasAnyAncestor(hasTestTag(SNACKBAR_NODE_TAG)) and hasText(expectedText))
             .fetchSemanticsNodes().isNotEmpty()
     }
 }

--- a/feature/postcapture/src/main/java/com/google/jetpackcamera/feature/postcapture/PostCaptureScreen.kt
+++ b/feature/postcapture/src/main/java/com/google/jetpackcamera/feature/postcapture/PostCaptureScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
 import com.google.jetpackcamera.feature.postcapture.PostCaptureViewModel.PostCaptureEvent
@@ -34,7 +33,6 @@ import com.google.jetpackcamera.feature.postcapture.ui.PostCaptureLayout
 import com.google.jetpackcamera.feature.postcapture.ui.SaveCurrentMediaButton
 import com.google.jetpackcamera.feature.postcapture.ui.ShareCurrentMediaButton
 import com.google.jetpackcamera.feature.postcapture.utils.MediaSharing
-import com.google.jetpackcamera.ui.components.capture.SNACKBAR_NODE_TAG
 import com.google.jetpackcamera.ui.components.capture.TestableSnackbar
 import com.google.jetpackcamera.ui.controller.SnackBarController
 import com.google.jetpackcamera.ui.uistate.SnackBarUiState
@@ -143,7 +141,7 @@ fun PostCaptureComponent(
                         if (snackBarData != null) {
                             snackBarController?.let {
                                 TestableSnackbar(
-                                    modifier = modifier.testTag(SNACKBAR_NODE_TAG),
+                                    modifier = modifier,
                                     snackbarToShow = snackBarData,
                                     snackbarHostState = snackbarHostState,
                                     snackBarController = snackBarController

--- a/feature/postcapture/src/main/java/com/google/jetpackcamera/feature/postcapture/ui/PostCaptureLayout.kt
+++ b/feature/postcapture/src/main/java/com/google/jetpackcamera/feature/postcapture/ui/PostCaptureLayout.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.google.jetpackcamera.ui.components.capture.SNACKBAR_NODE_TAG
 
 @Composable
 fun PostCaptureLayout(
@@ -45,7 +47,12 @@ fun PostCaptureLayout(
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.testTag(SNACKBAR_NODE_TAG)
+            )
+        }
     ) { paddingValues ->
         Box(
             modifier = modifier

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewScreen.kt
@@ -84,7 +84,6 @@ import com.google.jetpackcamera.ui.components.capture.PauseResumeToggleButton
 import com.google.jetpackcamera.ui.components.capture.PreviewDisplay
 import com.google.jetpackcamera.ui.components.capture.PreviewLayout
 import com.google.jetpackcamera.ui.components.capture.R
-import com.google.jetpackcamera.ui.components.capture.SNACKBAR_NODE_TAG
 import com.google.jetpackcamera.ui.components.capture.ScreenFlashScreen
 import com.google.jetpackcamera.ui.components.capture.StabilizationIcon
 import com.google.jetpackcamera.ui.components.capture.TestableSnackbar
@@ -657,7 +656,7 @@ private fun ContentScreen(
                 if (snackBarData != null) {
                     snackBarController?.let { snackBarController ->
                         TestableSnackbar(
-                            modifier = modifier.testTag(SNACKBAR_NODE_TAG),
+                            modifier = modifier,
                             snackbarToShow = snackBarData,
                             snackbarHostState = snackbarHostState,
                             snackBarController = snackBarController

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureLayout.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureLayout.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -81,7 +82,12 @@ fun PreviewLayout(
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.testTag(SNACKBAR_NODE_TAG)
+            )
+        }
     ) { paddingValues ->
         Box(modifier = modifier.background(Color.Black)) {
             Column {


### PR DESCRIPTION
 Fixes a bug where  `waitForSnackbarWithText` assertion failures occurred because the semantics tag and the snackbar text were on separate, sibling Compose nodes.
  
  • 🐛 **Cause**: **PR #507** scoped snackbar assertions to `SNACKBAR_NODE_TAG`. However, the tag was applied to `TestableSnackbar`  (an empty trigger box ), while the actual text is rendered in the Scaffold 's  SnackbarHost . 

Because they are siblings, the  `hasTestTag(...) and hasText(...)` matcher always timed out.
  • 🔨  **Fix**: Moved  SNACKBAR_NODE_TAG  to the  SnackbarHost  in  CaptureLayout  and  PostCaptureLayout . Updated `waitForSnackbarWithText`  to use  `hasAnyAncestor(hasTestTag(SNACKBAR_NODE_TAG))` to scope the text search inside the host hierarchy.
