### PR TITLE
fix debug screen zoom control bug

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/DebugOverlayTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/DebugOverlayTest.kt
@@ -18,6 +18,7 @@ package com.google.jetpackcamera
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -30,6 +31,9 @@ import com.google.jetpackcamera.ui.components.capture.FLIP_CAMERA_BUTTON
 import com.google.jetpackcamera.ui.components.capture.ZOOM_BUTTON_ROW_TAG
 import com.google.jetpackcamera.ui.debug.BTN_DEBUG_HIDE_COMPONENTS_TAG
 import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_SET_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD
 import com.google.jetpackcamera.ui.debug.LOGICAL_CAMERA_ID_TAG
 import com.google.jetpackcamera.ui.debug.PHYSICAL_CAMERA_ID_TAG
 import com.google.jetpackcamera.ui.debug.ZOOM_RATIO_TAG
@@ -45,7 +49,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class DebugHideComponentsTest {
+class DebugOverlayTest {
     @get:Rule
     val permissionsRule: GrantPermissionRule =
         GrantPermissionRule.grant(*(TEST_REQUIRED_PERMISSIONS).toTypedArray())
@@ -90,6 +94,37 @@ class DebugHideComponentsTest {
             composeTestRule.onNodeWithTag(DEBUG_OVERLAY_BUTTON).assertExists()
             composeTestRule.onNodeWithTag(LOGICAL_CAMERA_ID_TAG).assertExists()
             composeTestRule.onNodeWithTag(PHYSICAL_CAMERA_ID_TAG).assertExists()
+            composeTestRule.onNodeWithTag(ZOOM_RATIO_TAG).assertExists()
+        }
+    }
+
+    @Test
+    fun setZoomRatio_viaDebugOverlay() {
+        runMainActivityScenarioTest(debugExtra) {
+            composeTestRule.waitForCaptureButton()
+
+            // Open debug menu
+            composeTestRule.onNodeWithTag(DEBUG_OVERLAY_BUTTON).performClick()
+
+            // Click "Set Zoom Ratio" button
+            composeTestRule.waitForNodeWithTag(DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON)
+            composeTestRule.onNodeWithTag(DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON).performClick()
+
+            // Find text field and enter value
+            composeTestRule.waitForNodeWithTag(DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD)
+            composeTestRule.onNodeWithTag(
+                DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD
+            ).performTextInput("1.5")
+
+            // Click "Confirm"
+            composeTestRule.onNodeWithTag(DEBUG_OVERLAY_SET_ZOOM_RATIO_SET_BUTTON).performClick()
+
+            // Verify dialog closed (text field should not exist anymore)
+            composeTestRule.onNodeWithTag(
+                DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD
+            ).assertDoesNotExist()
+
+            // Verify zoom ratio text exists
             composeTestRule.onNodeWithTag(ZOOM_RATIO_TAG).assertExists()
         }
     }

--- a/app/src/androidTest/java/com/google/jetpackcamera/ExternalAutomationCompatibilityTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ExternalAutomationCompatibilityTest.kt
@@ -21,6 +21,7 @@ import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import com.google.common.truth.Truth.assertWithMessage
 import com.google.jetpackcamera.ui.components.capture.CAPTURE_BUTTON
 import com.google.jetpackcamera.ui.components.capture.FLIP_CAMERA_BUTTON
 import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_BUTTON
@@ -30,7 +31,6 @@ import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD
 import com.google.jetpackcamera.utils.TEST_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.utils.debugExtra
 import com.google.jetpackcamera.utils.runMainActivityScenarioTest
-import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -55,14 +55,15 @@ class ExternalAutomationCompatibilityTest {
         runMainActivityScenarioTest {
             // Wait for the capture button to be visible to UI Automator via Resource ID
             val captureButton = device.wait(Until.findObject(By.res(CAPTURE_BUTTON)), TIMEOUT_MS)
-            assertNotNull("Capture button not found by UI Automator via Resource ID", captureButton)
+            assertWithMessage("Capture button not found by UI Automator via Resource ID")
+                .that(captureButton)
+                .isNotNull()
 
             // Verify flip camera button is visible via Resource ID
             val flipButton = device.findObject(By.res(FLIP_CAMERA_BUTTON))
-            assertNotNull(
-                "Flip camera button not found by UI Automator via Resource ID",
-                flipButton
-            )
+            assertWithMessage("Flip camera button not found by UI Automator via Resource ID")
+                .that(flipButton)
+                .isNotNull()
         }
     }
 
@@ -74,10 +75,9 @@ class ExternalAutomationCompatibilityTest {
                 Until.findObject(By.res(DEBUG_OVERLAY_BUTTON)),
                 TIMEOUT_MS
             )
-            assertNotNull(
-                "Debug overlay button not found by UI Automator via Resource ID",
-                debugButton
-            )
+            assertWithMessage("Debug overlay button not found by UI Automator via Resource ID")
+                .that(debugButton)
+                .isNotNull()
         }
     }
 
@@ -89,7 +89,7 @@ class ExternalAutomationCompatibilityTest {
                 Until.findObject(By.res(DEBUG_OVERLAY_BUTTON)),
                 TIMEOUT_MS
             )
-            assertNotNull("Debug overlay button not found", debugButton)
+            assertWithMessage("Debug overlay button not found").that(debugButton).isNotNull()
             debugButton.click()
 
             // Click "Set Zoom Ratio" button using UI Automator
@@ -97,7 +97,7 @@ class ExternalAutomationCompatibilityTest {
                 Until.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON)),
                 TIMEOUT_MS
             )
-            assertNotNull("Set Zoom Ratio button not found", setZoomButton)
+            assertWithMessage("Set Zoom Ratio button not found").that(setZoomButton).isNotNull()
             setZoomButton.click()
 
             // Verify the zoom dialog text field is visible to UI Automator
@@ -105,11 +105,15 @@ class ExternalAutomationCompatibilityTest {
                 Until.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD)),
                 TIMEOUT_MS
             )
-            assertNotNull("Zoom text field not found by UI Automator", textField)
+            assertWithMessage(
+                "Zoom text field not found by UI Automator"
+            ).that(textField).isNotNull()
 
             // Verify the confirm button is visible to UI Automator
             val confirmButton = device.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_SET_BUTTON))
-            assertNotNull("Confirm button not found by UI Automator", confirmButton)
+            assertWithMessage(
+                "Confirm button not found by UI Automator"
+            ).that(confirmButton).isNotNull()
         }
     }
 

--- a/app/src/androidTest/java/com/google/jetpackcamera/ExternalAutomationCompatibilityTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ExternalAutomationCompatibilityTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Android Open Source Project
+ * Copyright (C) 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,12 @@ import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_BUTTON
 import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON
 import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_SET_BUTTON
 import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD
+import com.google.jetpackcamera.utils.APP_START_TIMEOUT_MILLIS
+import com.google.jetpackcamera.utils.DEFAULT_TIMEOUT_MILLIS
 import com.google.jetpackcamera.utils.TEST_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.utils.debugExtra
 import com.google.jetpackcamera.utils.runMainActivityScenarioTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -50,11 +53,21 @@ class ExternalAutomationCompatibilityTest {
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     }
 
+    @After
+    fun tearDown() {
+        device.pressBack()
+        device.pressHome()
+    }
+
     @Test
     fun verifyUiAutomator_canFindCaptureControls() {
         runMainActivityScenarioTest {
             // Wait for the capture button to be visible to UI Automator via Resource ID
-            val captureButton = device.wait(Until.findObject(By.res(CAPTURE_BUTTON)), TIMEOUT_MS)
+            val captureButton =
+                device.wait(
+                    Until.findObject(By.res(CAPTURE_BUTTON)),
+                    APP_START_TIMEOUT_MILLIS
+                )
             assertWithMessage("Capture button not found by UI Automator via Resource ID")
                 .that(captureButton)
                 .isNotNull()
@@ -73,7 +86,7 @@ class ExternalAutomationCompatibilityTest {
             // Verify debug overlay button is visible via Resource ID
             val debugButton = device.wait(
                 Until.findObject(By.res(DEBUG_OVERLAY_BUTTON)),
-                TIMEOUT_MS
+                APP_START_TIMEOUT_MILLIS
             )
             assertWithMessage("Debug overlay button not found by UI Automator via Resource ID")
                 .that(debugButton)
@@ -87,7 +100,7 @@ class ExternalAutomationCompatibilityTest {
             // Open debug menu using UI Automator
             val debugButton = device.wait(
                 Until.findObject(By.res(DEBUG_OVERLAY_BUTTON)),
-                TIMEOUT_MS
+                APP_START_TIMEOUT_MILLIS
             )
             assertWithMessage("Debug overlay button not found").that(debugButton).isNotNull()
             debugButton.click()
@@ -95,7 +108,7 @@ class ExternalAutomationCompatibilityTest {
             // Click "Set Zoom Ratio" button using UI Automator
             val setZoomButton = device.wait(
                 Until.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON)),
-                TIMEOUT_MS
+                DEFAULT_TIMEOUT_MILLIS
             )
             assertWithMessage("Set Zoom Ratio button not found").that(setZoomButton).isNotNull()
             setZoomButton.click()
@@ -103,7 +116,7 @@ class ExternalAutomationCompatibilityTest {
             // Verify the zoom dialog text field is visible to UI Automator
             val textField = device.wait(
                 Until.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD)),
-                TIMEOUT_MS
+                DEFAULT_TIMEOUT_MILLIS
             )
             assertWithMessage(
                 "Zoom text field not found by UI Automator"
@@ -115,9 +128,5 @@ class ExternalAutomationCompatibilityTest {
                 "Confirm button not found by UI Automator"
             ).that(confirmButton).isNotNull()
         }
-    }
-
-    companion object {
-        private const val TIMEOUT_MS = 5000L
     }
 }

--- a/app/src/androidTest/java/com/google/jetpackcamera/ExternalAutomationCompatibilityTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/ExternalAutomationCompatibilityTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import com.google.jetpackcamera.ui.components.capture.CAPTURE_BUTTON
+import com.google.jetpackcamera.ui.components.capture.FLIP_CAMERA_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_SET_BUTTON
+import com.google.jetpackcamera.ui.debug.DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD
+import com.google.jetpackcamera.utils.TEST_REQUIRED_PERMISSIONS
+import com.google.jetpackcamera.utils.debugExtra
+import com.google.jetpackcamera.utils.runMainActivityScenarioTest
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExternalAutomationCompatibilityTest {
+
+    @get:Rule
+    val permissionsRule: GrantPermissionRule =
+        GrantPermissionRule.grant(*(TEST_REQUIRED_PERMISSIONS).toTypedArray())
+
+    private lateinit var device: UiDevice
+
+    @Before
+    fun setUp() {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    }
+
+    @Test
+    fun verifyUiAutomator_canFindCaptureControls() {
+        runMainActivityScenarioTest {
+            // Wait for the capture button to be visible to UI Automator via Resource ID
+            val captureButton = device.wait(Until.findObject(By.res(CAPTURE_BUTTON)), TIMEOUT_MS)
+            assertNotNull("Capture button not found by UI Automator via Resource ID", captureButton)
+
+            // Verify flip camera button is visible via Resource ID
+            val flipButton = device.findObject(By.res(FLIP_CAMERA_BUTTON))
+            assertNotNull(
+                "Flip camera button not found by UI Automator via Resource ID",
+                flipButton
+            )
+        }
+    }
+
+    @Test
+    fun verifyUiAutomator_canFindDebugOverlayControls() {
+        runMainActivityScenarioTest(debugExtra) {
+            // Verify debug overlay button is visible via Resource ID
+            val debugButton = device.wait(
+                Until.findObject(By.res(DEBUG_OVERLAY_BUTTON)),
+                TIMEOUT_MS
+            )
+            assertNotNull(
+                "Debug overlay button not found by UI Automator via Resource ID",
+                debugButton
+            )
+        }
+    }
+
+    @Test
+    fun verifyUiAutomator_canFindDebugZoomDialogControls() {
+        runMainActivityScenarioTest(debugExtra) {
+            // Open debug menu using UI Automator
+            val debugButton = device.wait(
+                Until.findObject(By.res(DEBUG_OVERLAY_BUTTON)),
+                TIMEOUT_MS
+            )
+            assertNotNull("Debug overlay button not found", debugButton)
+            debugButton.click()
+
+            // Click "Set Zoom Ratio" button using UI Automator
+            val setZoomButton = device.wait(
+                Until.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_BUTTON)),
+                TIMEOUT_MS
+            )
+            assertNotNull("Set Zoom Ratio button not found", setZoomButton)
+            setZoomButton.click()
+
+            // Verify the zoom dialog text field is visible to UI Automator
+            val textField = device.wait(
+                Until.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_TEXT_FIELD)),
+                TIMEOUT_MS
+            )
+            assertNotNull("Zoom text field not found by UI Automator", textField)
+
+            // Verify the confirm button is visible to UI Automator
+            val confirmButton = device.findObject(By.res(DEBUG_OVERLAY_SET_ZOOM_RATIO_SET_BUTTON))
+            assertNotNull("Confirm button not found by UI Automator", confirmButton)
+        }
+    }
+
+    companion object {
+        private const val TIMEOUT_MS = 5000L
+    }
+}

--- a/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/utils/ComposeTestRuleExt.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureButtonComponents.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CaptureButtonComponents.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -607,7 +608,10 @@ private fun LockSwitchCaptureButtonNucleus(
                     .align(Alignment.CenterStart)
                     .padding(start = 8.dp)
                     .offset(x = -(switchWidth - pressedNucleusSize))
-                    .clickable(indication = null, interactionSource = null) {
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ) {
                         onToggleSwitchPosition()
                     },
                 tint = Color.White,

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/quicksettings/ui/QuickSettingsComponents.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/quicksettings/ui/QuickSettingsComponents.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera.ui.components.capture.quicksettings.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -49,6 +50,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -802,7 +804,7 @@ private fun TopBarQuickSettingIcon(
             modifier = modifier
                 .size(IconButtonDefaults.smallIconSize)
                 .clickable(
-                    interactionSource = null,
+                    interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onClick,
                     enabled = enabled

--- a/ui/debug/src/main/java/com/google/jetpackcamera/ui/debug/DebugOverlayComponents.kt
+++ b/ui/debug/src/main/java/com/google/jetpackcamera/ui/debug/DebugOverlayComponents.kt
@@ -23,6 +23,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -458,7 +459,7 @@ private fun SetTestPatternDialog(
 
 @Composable
 private fun Modifier.noIndicationClickable(onClick: () -> Unit): Modifier = this.clickable(
-    interactionSource = null,
+    interactionSource = remember { MutableInteractionSource() },
     indication = null,
     onClick = onClick
 )


### PR DESCRIPTION
fix debug screen zoom control bug where debug zoom controls were missing from accessibility tree, which led to automated test failures on some devices.