### PR TITLE
Move CameraAppSettingsViewModelTest to src/test and fix constraints

### DIFF
--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -95,6 +95,13 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.junit)
+    testImplementation(libs.androidx.rules)
+    testImplementation(libs.truth)
+    testImplementation(libs.robolectric)
+    testImplementation(project(":core:settings:datastore-prefs"))
+    testImplementation(project(":core:settings:datastore-prefs:testing"))
+    testImplementation(libs.androidx.datastore.preferences)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.truth)

--- a/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -295,7 +295,17 @@ internal class CameraAppSettingsViewModelTest {
 
         val customViewModel = createViewModelWithConstraints(
             systemConstraints = TYPICAL_SYSTEM_CONSTRAINTS.copy(
-                concurrentCamerasSupported = true
+                concurrentCamerasSupported = true,
+                perLensConstraints = buildMap {
+                    for (lensFacing in listOf(LensFacing.FRONT, LensFacing.BACK)) {
+                        put(
+                            lensFacing,
+                            TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints[lensFacing]!!.copy(
+                                supportedEffects = setOf(SingleStreamEffectKey.id)
+                            )
+                        )
+                    }
+                }
             )
         )
         advanceUntilIdle()

--- a/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -296,15 +296,8 @@ internal class CameraAppSettingsViewModelTest {
         val customViewModel = createViewModelWithConstraints(
             systemConstraints = TYPICAL_SYSTEM_CONSTRAINTS.copy(
                 concurrentCamerasSupported = true,
-                perLensConstraints = buildMap {
-                    for (lensFacing in listOf(LensFacing.FRONT, LensFacing.BACK)) {
-                        put(
-                            lensFacing,
-                            TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints[lensFacing]!!.copy(
-                                supportedEffects = setOf(SingleStreamEffectKey.id)
-                            )
-                        )
-                    }
+                perLensConstraints = TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints.mapValues { (_, constraints) ->
+                    constraints.copy(supportedEffects = setOf(SingleStreamEffectKey.id))
                 }
             )
         )

--- a/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -296,7 +296,8 @@ internal class CameraAppSettingsViewModelTest {
         val customViewModel = createViewModelWithConstraints(
             systemConstraints = TYPICAL_SYSTEM_CONSTRAINTS.copy(
                 concurrentCamerasSupported = true,
-                perLensConstraints = TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints.mapValues { (_, constraints) ->
+                perLensConstraints =
+                TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints.mapValues { (_, constraints) ->
                     constraints.copy(supportedEffects = setOf(SingleStreamEffectKey.id))
                 }
             )


### PR DESCRIPTION
## Summary
Moves `CameraAppSettingsViewModelTest` from `feature/settings/src/androidTest/` to `feature/settings/src/test/`.

## Rationale
`CameraAppSettingsViewModelTest` is a host-side unit test that tests `SettingsViewModel` state management using fake repositories and mock constraints. It does not touch Camera2 hardware APIs, preview surfaces, or UI components, and does not require an Android device or emulator.

Moving it to `src/test/`:
1. Allows standard Gradle unit test tasks (`./gradlew test`) to run and verify `CameraAppSettingsViewModelTest` on the JVM without an emulator.
2. Ensures consistency across the project, where all other ViewModel tests (`PreviewViewModelTest`, `PostCaptureViewModelTest`) are placed in `src/test/`.

## Changes
- Moved `CameraAppSettingsViewModelTest.kt` from `src/androidTest/` to `src/test/`.
- Added `testImplementation` dependencies (`robolectric`, `androidx.test.ext:junit`, `truth`, datastore testing) to `feature/settings/build.gradle.kts`.
- Updated `concurrentCamera_whenCameraEffectIsActive_isDisabled` to include `SingleStreamEffectKey.id` in `supportedEffects`.

## Test Plan
- Ran `./gradlew :feature:settings:test` on host JVM — **BUILD SUCCESSFUL**.