### PR TITLE
Fix video aspect ratio override when capture mode changes

### DIFF
--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraXCameraSystemTest.kt
@@ -34,7 +34,9 @@ import com.google.jetpackcamera.core.camera.utils.APP_REQUIRED_PERMISSIONS
 import com.google.jetpackcamera.core.camera.utils.provideUpdatingSurface
 import com.google.jetpackcamera.core.common.ignoreResult
 import com.google.jetpackcamera.core.common.testing.FakeFilePathGenerator
+import com.google.jetpackcamera.model.AspectRatio
 import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.ConcurrentCameraMode
 import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.Illuminant
@@ -689,6 +691,86 @@ class CameraXCameraSystemTest {
         settings = settingsCheck.receive()
         assertThat(settings.captureMode).isEqualTo(CaptureMode.IMAGE_ONLY)
         assertThat(settings.imageFormat).isEqualTo(ImageOutputFormat.JPEG_ULTRA_HDR)
+
+        // Clean-up.
+        settingsCheck.cancel()
+    }
+
+    @Test
+    fun switchCaptureMode_updatesAspectRatio(): Unit = runBlocking {
+        // Arrange. Start with STANDARD mode and 4:3 aspect ratio
+        val cameraSystem =
+            createAndInitCameraXCameraSystem(
+                appSettings =
+                CameraAppSettings(
+                    captureMode = CaptureMode.STANDARD,
+                    aspectRatio = AspectRatio.THREE_FOUR
+                )
+            )
+        cameraSystem.startCameraAndWaitUntilRunning()
+
+        val settingsCheck = cameraSystem.getCurrentSettings().filterNotNull().produceIn(this)
+
+        // Ensure we start in STANDARD with 4:3
+        var settings = settingsCheck.receive()
+        assertThat(settings.captureMode).isEqualTo(CaptureMode.STANDARD)
+        assertThat(settings.aspectRatio).isEqualTo(AspectRatio.THREE_FOUR)
+
+        // Act. Switch to VIDEO_ONLY
+        cameraSystem.setCaptureMode(CaptureMode.VIDEO_ONLY)
+
+        // Assert. Aspect ratio should be overridden to NINE_SIXTEEN
+        settings = settingsCheck.receive()
+        assertThat(settings.captureMode).isEqualTo(CaptureMode.VIDEO_ONLY)
+        assertThat(settings.aspectRatio).isEqualTo(AspectRatio.NINE_SIXTEEN)
+
+        // Act. Switch to IMAGE_ONLY
+        cameraSystem.setCaptureMode(CaptureMode.IMAGE_ONLY)
+
+        // Assert. Aspect ratio should be overridden to THREE_FOUR
+        settings = settingsCheck.receive()
+        assertThat(settings.captureMode).isEqualTo(CaptureMode.IMAGE_ONLY)
+        assertThat(settings.aspectRatio).isEqualTo(AspectRatio.THREE_FOUR)
+
+        // Clean-up.
+        settingsCheck.cancel()
+    }
+
+    @Test
+    fun switchConcurrentCameraMode_toDual_updatesAspectRatio(): Unit = runBlocking {
+        // Arrange. Start with STANDARD mode and 4:3 aspect ratio
+        val cameraSystem =
+            createAndInitCameraXCameraSystem(
+                appSettings =
+                CameraAppSettings(
+                    captureMode = CaptureMode.STANDARD,
+                    aspectRatio = AspectRatio.THREE_FOUR
+                )
+            )
+        val systemConstraints = cameraSystem.getSystemConstraints().value
+        assume()
+            .withMessage("Concurrent camera not supported, skip the test.")
+            .that(systemConstraints?.concurrentCamerasSupported == true)
+            .isTrue()
+
+        cameraSystem.startCameraAndWaitUntilRunning()
+
+        val settingsCheck = cameraSystem.getCurrentSettings().filterNotNull().produceIn(this)
+
+        // Ensure we start in STANDARD with 4:3
+        var settings = settingsCheck.receive()
+        assertThat(settings.captureMode).isEqualTo(CaptureMode.STANDARD)
+        assertThat(settings.aspectRatio).isEqualTo(AspectRatio.THREE_FOUR)
+
+        // Act. Switch to DUAL concurrent camera mode.
+        // This should force capture mode to VIDEO_ONLY and aspect ratio to NINE_SIXTEEN.
+        cameraSystem.setConcurrentCameraMode(ConcurrentCameraMode.DUAL)
+
+        // Assert.
+        settings = settingsCheck.receive()
+        assertThat(settings.concurrentCameraMode).isEqualTo(ConcurrentCameraMode.DUAL)
+        assertThat(settings.captureMode).isEqualTo(CaptureMode.VIDEO_ONLY)
+        assertThat(settings.aspectRatio).isEqualTo(AspectRatio.NINE_SIXTEEN)
 
         // Clean-up.
         settingsCheck.cancel()

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraXCameraSystem.kt
@@ -732,7 +732,7 @@ class CameraXCameraSystem(
             Log.d(TAG, "new capture mode $newCaptureMode")
             this@tryApplyCaptureModeConstraints.copy(
                 captureMode = newCaptureMode
-            )
+            ).tryApplyAspectRatioForExternalCapture(newCaptureMode)
         } ?: this
     }
 
@@ -1033,6 +1033,7 @@ class CameraXCameraSystem(
         currentSettings.update { old ->
             old?.copy(captureMode = captureMode)
                 ?.tryApplyDynamicRangeConstraints()
+                ?.tryApplyAspectRatioForExternalCapture(captureMode)
                 ?.tryApplyImageFormatConstraints()
                 ?.tryApplyConcurrentCameraModeConstraints()
         }


### PR DESCRIPTION
This PR ensures that 'tryApplyAspectRatioForExternalCapture' is called when 'setCaptureMode' is invoked. This guarantees that switching to VIDEO_ONLY mode correctly overrides the aspect ratio to 16:9, and switching to IMAGE_ONLY overrides it to 4:3, even if the user had a different aspect ratio selected in standard mode.