### PR TITLE
Refactor SettingsScreen utilizing Compose slot architecture

### DIFF
--- a/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
@@ -17,7 +17,7 @@ package com.google.jetpackcamera
 
 import android.os.Build
 import androidx.compose.ui.test.isNotSelected
-import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -32,7 +32,6 @@ import com.google.jetpackcamera.core.common.ignoreResult
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG
-
 import com.google.jetpackcamera.ui.components.capture.QUICK_SETTINGS_DROP_DOWN
 import com.google.jetpackcamera.ui.components.capture.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
 import com.google.jetpackcamera.ui.components.capture.QUICK_SETTINGS_RATIO_1_1_BUTTON

--- a/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/BackgroundDeviceTest.kt
@@ -17,7 +17,7 @@ package com.google.jetpackcamera
 
 import android.os.Build
 import androidx.compose.ui.test.isNotSelected
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -28,9 +28,11 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.TruthJUnit.assume
+import com.google.jetpackcamera.core.common.ignoreResult
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG
+
 import com.google.jetpackcamera.ui.components.capture.QUICK_SETTINGS_DROP_DOWN
 import com.google.jetpackcamera.ui.components.capture.QUICK_SETTINGS_FLIP_CAMERA_BUTTON
 import com.google.jetpackcamera.ui.components.capture.QUICK_SETTINGS_RATIO_1_1_BUTTON
@@ -163,7 +165,7 @@ class BackgroundDeviceTest {
                     ).performClick()
                 }
             }
-        }
+        }.ignoreResult()
 
         backgroundThenForegroundApp()
     }

--- a/app/src/androidTest/java/com/google/jetpackcamera/SettingsDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/jetpackcamera/SettingsDeviceTest.kt
@@ -29,6 +29,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.google.common.truth.Truth.assertWithMessage
 import com.google.common.truth.TruthJUnit.assume
 import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.core.common.ignoreResult
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_ASPECT_RATIO_OPTION_1_1_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_ASPECT_RATIO_OPTION_3_4_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_ASPECT_RATIO_OPTION_9_16_TAG
@@ -45,8 +46,9 @@ import com.google.jetpackcamera.settings.ui.BTN_DIALOG_FPS_OPTION_60_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_FPS_OPTION_AUTO_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
-import com.google.jetpackcamera.settings.ui.BTN_DIALOG_VIDEO_DURATION_OPTION_10S_TAG
+import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_VIDEO_DURATION_OPTION_1S_TAG
+import com.google.jetpackcamera.settings.ui.BTN_DIALOG_VIDEO_DURATION_OPTION_10S_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_VIDEO_DURATION_OPTION_30S_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_VIDEO_DURATION_OPTION_60S_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_VIDEO_DURATION_OPTION_UNLIMITED_TAG
@@ -64,7 +66,6 @@ import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_ASPECT_RATIO
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_DARK_MODE_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_FLASH_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_FPS_TAG
-import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_VIDEO_DURATION_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_VIDEO_QUALITY_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_VIDEO_STABILIZATION_TAG
@@ -117,7 +118,7 @@ class SettingsDeviceTest(private val lensFacing: LensFacing) {
                 disabledMessage = componentDisabledMessage,
                 block = action
             )
-        }
+        }.ignoreResult()
     }
 
     private fun ComposeTestRule.selectFirstNonSelected(settingOptions: List<String>) {
@@ -201,6 +202,8 @@ class SettingsDeviceTest(private val lensFacing: LensFacing) {
         // a bad state. Skip on these devices.
         assume().that(Build.HARDWARE == "ranchu" && Build.VERSION.SDK_INT == 28).isFalse()
     }
+
+
 
     @Test
     fun openSettings_setStreamConfig() = runMainActivityScenarioTest {

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaApp.kt
@@ -42,6 +42,7 @@ import com.google.jetpackcamera.permissions.navigation.PermissionsRoute
 import com.google.jetpackcamera.permissions.navigation.navigateToPermissions
 import com.google.jetpackcamera.permissions.navigation.permissionsScreen
 import com.google.jetpackcamera.permissions.navigation.popUpToPermissions
+import com.google.jetpackcamera.settings.DefaultCameraSettings
 import com.google.jetpackcamera.settings.SettingsScreen
 import com.google.jetpackcamera.settings.VersionInfoHolder
 import com.google.jetpackcamera.ui.Routes.POST_CAPTURE_ROUTE
@@ -149,7 +150,15 @@ private fun JetpackCameraNavHost(
                     versionName = BuildConfig.VERSION_NAME,
                     buildType = BuildConfig.BUILD_TYPE
                 ),
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                cameraSettingsSlot = {
+                    DefaultCameraSettings(
+                        customEffectSlot = {
+                            
+                            JcaEffectsSetting()
+                        }
+                    )
+                }
             )
         }
 

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaEffectsSetting.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaEffectsSetting.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.jetpackcamera.ui
 
 import androidx.compose.foundation.layout.Column
@@ -11,21 +26,24 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.google.jetpackcamera.core.camera.effects.SingleStreamEffectKey
 import com.google.jetpackcamera.model.NONE_EFFECT_ID
+import com.google.jetpackcamera.settings.CameraEffectUiState
+import com.google.jetpackcamera.settings.R
 import com.google.jetpackcamera.settings.SettingsUiState
 import com.google.jetpackcamera.settings.SettingsViewModel
-import com.google.jetpackcamera.settings.CameraEffectUiState
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
 import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
 import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG
 import com.google.jetpackcamera.settings.ui.BasicPopupSetting
 import com.google.jetpackcamera.settings.ui.SingleChoiceSelector
 import com.google.jetpackcamera.settings.ui.disabledRationaleString
-import com.google.jetpackcamera.settings.R
 
+/**
+ * A setting component for configuring Jetpack Camera App effects.
+ *
+ * @param viewModel The [SettingsViewModel] used to manage the settings state.
+ */
 @Composable
-fun JcaEffectsSetting(
-    viewModel: SettingsViewModel = hiltViewModel()
-) {
+internal fun JcaEffectsSetting(viewModel: SettingsViewModel = hiltViewModel()) {
     val uiState by viewModel.settingsUiState.collectAsState()
     if (uiState !is SettingsUiState.Enabled) return
     val enabledState = uiState as SettingsUiState.Enabled
@@ -60,7 +78,8 @@ fun JcaEffectsSetting(
                             text = stringResource(
                                 id = R.string.stream_config_selector_single_stream
                             ),
-                            selected = cameraEffectUiState.currentCameraEffect == SingleStreamEffectKey.id,
+                            selected = cameraEffectUiState.currentCameraEffect ==
+                                SingleStreamEffectKey.id,
                             enabled = true,
                             onClick = { viewModel.setCameraEffect(SingleStreamEffectKey.id) }
                         )

--- a/app/src/main/java/com/google/jetpackcamera/ui/JcaEffectsSetting.kt
+++ b/app/src/main/java/com/google/jetpackcamera/ui/JcaEffectsSetting.kt
@@ -1,0 +1,83 @@
+package com.google.jetpackcamera.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.google.jetpackcamera.core.camera.effects.SingleStreamEffectKey
+import com.google.jetpackcamera.model.NONE_EFFECT_ID
+import com.google.jetpackcamera.settings.SettingsUiState
+import com.google.jetpackcamera.settings.SettingsViewModel
+import com.google.jetpackcamera.settings.CameraEffectUiState
+import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
+import com.google.jetpackcamera.settings.ui.BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
+import com.google.jetpackcamera.settings.ui.BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG
+import com.google.jetpackcamera.settings.ui.BasicPopupSetting
+import com.google.jetpackcamera.settings.ui.SingleChoiceSelector
+import com.google.jetpackcamera.settings.ui.disabledRationaleString
+import com.google.jetpackcamera.settings.R
+
+@Composable
+fun JcaEffectsSetting(
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.settingsUiState.collectAsState()
+    if (uiState !is SettingsUiState.Enabled) return
+    val enabledState = uiState as SettingsUiState.Enabled
+    val cameraEffectUiState = enabledState.cameraEffectUiState
+
+    BasicPopupSetting(
+        modifier = Modifier.testTag(BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG),
+        title = stringResource(id = R.string.stream_config_title),
+        leadingIcon = null,
+        enabled = cameraEffectUiState is CameraEffectUiState.Enabled,
+        description = when (cameraEffectUiState) {
+            is CameraEffectUiState.Enabled -> {
+                if (cameraEffectUiState.currentCameraEffect == NONE_EFFECT_ID) {
+                    stringResource(id = R.string.stream_config_description_multi_stream)
+                } else {
+                    stringResource(id = R.string.stream_config_description_single_stream)
+                }
+            }
+
+            is CameraEffectUiState.Disabled -> {
+                disabledRationaleString(disabledRationale = cameraEffectUiState.disabledRationale)
+            }
+        },
+        popupContents = {
+            Column(Modifier.selectableGroup()) {
+                if (cameraEffectUiState is CameraEffectUiState.Enabled) {
+                    if (cameraEffectUiState.supportedEffects.contains(SingleStreamEffectKey.id)) {
+                        SingleChoiceSelector(
+                            modifier = Modifier.testTag(
+                                BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
+                            ),
+                            text = stringResource(
+                                id = R.string.stream_config_selector_single_stream
+                            ),
+                            selected = cameraEffectUiState.currentCameraEffect == SingleStreamEffectKey.id,
+                            enabled = true,
+                            onClick = { viewModel.setCameraEffect(SingleStreamEffectKey.id) }
+                        )
+                    }
+                    SingleChoiceSelector(
+                        modifier = Modifier.testTag(
+                            BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
+                        ),
+                        text = stringResource(
+                            id = R.string.stream_config_selector_multi_stream
+                        ),
+                        selected = cameraEffectUiState.currentCameraEffect == NONE_EFFECT_ID,
+                        enabled = true,
+                        onClick = { viewModel.setCameraEffect(NONE_EFFECT_ID) }
+                    )
+                }
+            }
+        }
+    )
+}

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -28,14 +28,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import com.google.jetpackcamera.model.LensFacing
-import com.google.jetpackcamera.model.FlashMode
-import com.google.jetpackcamera.model.AspectRatio
-import com.google.jetpackcamera.model.StabilizationMode
-import com.google.jetpackcamera.model.VideoQuality
-import com.google.jetpackcamera.model.DarkMode
-import com.google.jetpackcamera.model.LowLightBoostPriority
-import com.google.jetpackcamera.model.ConcurrentCameraMode
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -44,6 +36,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.jetpackcamera.model.AspectRatio
+import com.google.jetpackcamera.model.ConcurrentCameraMode
+import com.google.jetpackcamera.model.DarkMode
+import com.google.jetpackcamera.model.FlashMode
+import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.LowLightBoostPriority
+import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.VideoQuality
 import com.google.jetpackcamera.settings.ui.AspectRatioSetting
 import com.google.jetpackcamera.settings.ui.ConcurrentCameraSetting
 import com.google.jetpackcamera.settings.ui.DarkModeSetting
@@ -113,6 +113,12 @@ fun SettingsScreen(
     }
 }
 
+/**
+ * Stateful wrapper for the default camera settings section.
+ *
+ * @param customEffectSlot A slot for injecting custom camera effects.
+ * @param viewModel The [SettingsViewModel] providing the settings state.
+ */
 @Composable
 fun DefaultCameraSettings(
     customEffectSlot: @Composable () -> Unit = {},
@@ -133,6 +139,17 @@ fun DefaultCameraSettings(
     )
 }
 
+/**
+ * Stateless default camera settings section.
+ *
+ * @param customEffectSlot A slot for injecting custom camera effects.
+ * @param enabledState The current [SettingsUiState.Enabled] state.
+ * @param setDefaultLensFacing Callback to set default lens facing.
+ * @param setFlashMode Callback to set flash mode.
+ * @param setTargetFrameRate Callback to set target frame rate.
+ * @param setAspectRatio Callback to set aspect ratio.
+ * @param setLowLightBoostPriority Callback to set low light boost priority.
+ */
 @Composable
 fun DefaultCameraSettings(
     customEffectSlot: @Composable () -> Unit,
@@ -173,10 +190,13 @@ fun DefaultCameraSettings(
     )
 }
 
+/**
+ * Stateful wrapper for the default recording settings section.
+ *
+ * @param viewModel The [SettingsViewModel] providing the settings state.
+ */
 @Composable
-fun DefaultRecordingSettings(
-    viewModel: SettingsViewModel = hiltViewModel()
-) {
+fun DefaultRecordingSettings(viewModel: SettingsViewModel = hiltViewModel()) {
     val uiState by viewModel.settingsUiState.collectAsState()
     if (uiState !is SettingsUiState.Enabled) return
     val enabledState = uiState as SettingsUiState.Enabled
@@ -191,6 +211,16 @@ fun DefaultRecordingSettings(
     )
 }
 
+/**
+ * Stateless default recording settings section.
+ *
+ * @param enabledState The current [SettingsUiState.Enabled] state.
+ * @param setVideoAudio Callback to set video audio state.
+ * @param setMaxVideoDuration Callback to set max video duration.
+ * @param setConcurrentCameraMode Callback to set concurrent camera mode.
+ * @param setStabilizationMode Callback to set stabilization mode.
+ * @param setVideoQuality Callback to set video quality.
+ */
 @Composable
 fun DefaultRecordingSettings(
     enabledState: SettingsUiState.Enabled,
@@ -228,6 +258,12 @@ fun DefaultRecordingSettings(
     )
 }
 
+/**
+ * Stateful wrapper for the default app settings section.
+ *
+ * @param versionInfo The [VersionInfoHolder] containing app version information.
+ * @param viewModel The [SettingsViewModel] providing the settings state.
+ */
 @Composable
 fun DefaultAppSettings(
     versionInfo: VersionInfoHolder,
@@ -244,6 +280,13 @@ fun DefaultAppSettings(
     )
 }
 
+/**
+ * Stateless default app settings section.
+ *
+ * @param versionInfo The [VersionInfoHolder] containing app version information.
+ * @param enabledState The current [SettingsUiState.Enabled] state.
+ * @param setDarkMode Callback to set the dark mode.
+ */
 @Composable
 fun DefaultAppSettings(
     versionInfo: VersionInfoHolder,

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/SettingsScreen.kt
@@ -16,7 +16,6 @@
 package com.google.jetpackcamera.settings
 
 import android.Manifest
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -29,26 +28,23 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.model.FlashMode
+import com.google.jetpackcamera.model.AspectRatio
+import com.google.jetpackcamera.model.StabilizationMode
+import com.google.jetpackcamera.model.VideoQuality
+import com.google.jetpackcamera.model.DarkMode
+import com.google.jetpackcamera.model.LowLightBoostPriority
+import com.google.jetpackcamera.model.ConcurrentCameraMode
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
-import com.google.jetpackcamera.model.AspectRatio
-import com.google.jetpackcamera.model.CameraEffectId
-import com.google.jetpackcamera.model.ConcurrentCameraMode
-import com.google.jetpackcamera.model.DarkMode
-import com.google.jetpackcamera.model.FlashMode
-import com.google.jetpackcamera.model.LensFacing
-import com.google.jetpackcamera.model.LowLightBoostPriority
-import com.google.jetpackcamera.model.StabilizationMode
-import com.google.jetpackcamera.model.VideoQuality
 import com.google.jetpackcamera.settings.ui.AspectRatioSetting
-import com.google.jetpackcamera.settings.ui.CameraEffectSetting
 import com.google.jetpackcamera.settings.ui.ConcurrentCameraSetting
 import com.google.jetpackcamera.settings.ui.DarkModeSetting
 import com.google.jetpackcamera.settings.ui.DefaultCameraFacing
@@ -63,38 +59,21 @@ import com.google.jetpackcamera.settings.ui.StabilizationSetting
 import com.google.jetpackcamera.settings.ui.TargetFpsSetting
 import com.google.jetpackcamera.settings.ui.VersionInfo
 import com.google.jetpackcamera.settings.ui.VideoQualitySetting
-import com.google.jetpackcamera.settings.ui.theme.SettingsPreviewTheme
 
 /**
  * Screen used for the Settings feature.
  */
 
-@OptIn(ExperimentalPermissionsApi::class)
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     versionInfo: VersionInfoHolder,
-    viewModel: SettingsViewModel = hiltViewModel(),
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    cameraSettingsSlot: @Composable () -> Unit = { DefaultCameraSettings() },
+    recordingSettingsSlot: @Composable () -> Unit = { DefaultRecordingSettings() },
+    appSettingsSlot: @Composable () -> Unit = { DefaultAppSettings(versionInfo = versionInfo) }
 ) {
-    val settingsUiState by viewModel.settingsUiState.collectAsState()
-
-    SettingsScreen(
-        uiState = settingsUiState,
-        versionInfo = versionInfo,
-        onNavigateBack = onNavigateBack,
-        setDefaultLensFacing = viewModel::setDefaultLensFacing,
-        setFlashMode = viewModel::setFlashMode,
-        setTargetFrameRate = viewModel::setTargetFrameRate,
-        setAspectRatio = viewModel::setAspectRatio,
-        setCameraEffect = viewModel::setCameraEffect,
-        setAudio = viewModel::setVideoAudio,
-        setStabilizationMode = viewModel::setStabilizationMode,
-        setMaxVideoDuration = viewModel::setMaxVideoDuration,
-        setDarkMode = viewModel::setDarkMode,
-        setVideoQuality = viewModel::setVideoQuality,
-        setLowLightBoostPriority = viewModel::setLowLightBoostPriority,
-        setConcurrentCameraMode = viewModel::setConcurrentCameraMode
-    )
+    val viewModel: SettingsViewModel = hiltViewModel()
     val permissionStates = rememberMultiplePermissionsState(
         permissions =
         listOf(
@@ -105,27 +84,7 @@ fun SettingsScreen(
     )
 
     viewModel.setGrantedPermissions(permissionStates)
-}
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SettingsScreen(
-    uiState: SettingsUiState,
-    versionInfo: VersionInfoHolder,
-    onNavigateBack: () -> Unit = {},
-    setDefaultLensFacing: (LensFacing) -> Unit = {},
-    setFlashMode: (FlashMode) -> Unit = {},
-    setTargetFrameRate: (Int) -> Unit = {},
-    setAspectRatio: (AspectRatio) -> Unit = {},
-    setCameraEffect: (CameraEffectId) -> Unit = {},
-    setStabilizationMode: (StabilizationMode) -> Unit = {},
-    setAudio: (Boolean) -> Unit = {},
-    setMaxVideoDuration: (Long) -> Unit = {},
-    setDarkMode: (DarkMode) -> Unit = {},
-    setVideoQuality: (VideoQuality) -> Unit = {},
-    setLowLightBoostPriority: (LowLightBoostPriority) -> Unit = {},
-    setConcurrentCameraMode: (ConcurrentCameraMode) -> Unit = {}
-) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(
         rememberTopAppBarState()
     )
@@ -147,107 +106,154 @@ private fun SettingsScreen(
                 .verticalScroll(rememberScrollState())
                 .background(color = MaterialTheme.colorScheme.background)
         ) {
-            if (uiState is SettingsUiState.Enabled) {
-                SettingsList(
-                    uiState = uiState,
-                    versionInfo = versionInfo,
-                    setDefaultLensFacing = setDefaultLensFacing,
-                    setFlashMode = setFlashMode,
-                    setTargetFrameRate = setTargetFrameRate,
-                    setAspectRatio = setAspectRatio,
-                    setCameraEffect = setCameraEffect,
-                    setStabilizationMode = setStabilizationMode,
-                    setAudio = setAudio,
-                    setMaxVideoDuration = setMaxVideoDuration,
-                    setDarkMode = setDarkMode,
-                    setVideoQuality = setVideoQuality,
-                    setLowLightBoostPriority = setLowLightBoostPriority,
-                    setConcurrentCameraMode = setConcurrentCameraMode
-                )
-            }
+            cameraSettingsSlot()
+            recordingSettingsSlot()
+            appSettingsSlot()
         }
     }
 }
 
 @Composable
-internal fun SettingsList(
-    uiState: SettingsUiState.Enabled,
-    versionInfo: VersionInfoHolder,
-    setDefaultLensFacing: (LensFacing) -> Unit = {},
-    setFlashMode: (FlashMode) -> Unit = {},
-    setTargetFrameRate: (Int) -> Unit = {},
-    setAspectRatio: (AspectRatio) -> Unit = {},
-    setCameraEffect: (CameraEffectId) -> Unit = {},
-    setLowLightBoostPriority: (LowLightBoostPriority) -> Unit = {},
-    setAudio: (Boolean) -> Unit = {},
-    setStabilizationMode: (StabilizationMode) -> Unit = {},
-    setVideoQuality: (VideoQuality) -> Unit = {},
-    setMaxVideoDuration: (Long) -> Unit = {},
-    setDarkMode: (DarkMode) -> Unit = {},
-    setConcurrentCameraMode: (ConcurrentCameraMode) -> Unit = {}
+fun DefaultCameraSettings(
+    customEffectSlot: @Composable () -> Unit = {},
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.settingsUiState.collectAsState()
+    if (uiState !is SettingsUiState.Enabled) return
+    val enabledState = uiState as SettingsUiState.Enabled
+
+    DefaultCameraSettings(
+        customEffectSlot = customEffectSlot,
+        enabledState = enabledState,
+        setDefaultLensFacing = viewModel::setDefaultLensFacing,
+        setFlashMode = viewModel::setFlashMode,
+        setTargetFrameRate = viewModel::setTargetFrameRate,
+        setAspectRatio = viewModel::setAspectRatio,
+        setLowLightBoostPriority = viewModel::setLowLightBoostPriority
+    )
+}
+
+@Composable
+fun DefaultCameraSettings(
+    customEffectSlot: @Composable () -> Unit,
+    enabledState: SettingsUiState.Enabled,
+    setDefaultLensFacing: (LensFacing) -> Unit,
+    setFlashMode: (FlashMode) -> Unit,
+    setTargetFrameRate: (Int) -> Unit,
+    setAspectRatio: (AspectRatio) -> Unit,
+    setLowLightBoostPriority: (LowLightBoostPriority) -> Unit
 ) {
     SectionHeader(title = stringResource(id = R.string.section_title_camera_settings))
 
     DefaultCameraFacing(
-        lensUiState = uiState.lensFlipUiState,
+        lensUiState = enabledState.lensFlipUiState,
         setDefaultLensFacing = setDefaultLensFacing
     )
 
     FlashModeSetting(
-        flashUiState = uiState.flashUiState,
+        flashUiState = enabledState.flashUiState,
         setFlashMode = setFlashMode
     )
 
     TargetFpsSetting(
-        fpsUiState = uiState.fpsUiState,
+        fpsUiState = enabledState.fpsUiState,
         setTargetFps = setTargetFrameRate
     )
 
     AspectRatioSetting(
-        aspectRatioUiState = uiState.aspectRatioUiState,
+        aspectRatioUiState = enabledState.aspectRatioUiState,
         setAspectRatio = setAspectRatio
     )
 
-    CameraEffectSetting(
-        cameraEffectUiState = uiState.cameraEffectUiState,
-        setCameraEffect = setCameraEffect
-    )
+    customEffectSlot()
 
     LowLightBoostPrioritySetting(
-        lowLightBoostPriorityUiState = uiState.lowLightBoostPriorityUiState,
+        lowLightBoostPriorityUiState = enabledState.lowLightBoostPriorityUiState,
         setLowLightBoostPriority = setLowLightBoostPriority
     )
+}
+
+@Composable
+fun DefaultRecordingSettings(
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.settingsUiState.collectAsState()
+    if (uiState !is SettingsUiState.Enabled) return
+    val enabledState = uiState as SettingsUiState.Enabled
+
+    DefaultRecordingSettings(
+        enabledState = enabledState,
+        setVideoAudio = viewModel::setVideoAudio,
+        setMaxVideoDuration = viewModel::setMaxVideoDuration,
+        setConcurrentCameraMode = viewModel::setConcurrentCameraMode,
+        setStabilizationMode = viewModel::setStabilizationMode,
+        setVideoQuality = viewModel::setVideoQuality
+    )
+}
+
+@Composable
+fun DefaultRecordingSettings(
+    enabledState: SettingsUiState.Enabled,
+    setVideoAudio: (Boolean) -> Unit,
+    setMaxVideoDuration: (Long) -> Unit,
+    setConcurrentCameraMode: (ConcurrentCameraMode) -> Unit,
+    setStabilizationMode: (StabilizationMode) -> Unit,
+    setVideoQuality: (VideoQuality) -> Unit
+) {
     SectionHeader(title = stringResource(R.string.section_title_recording_settings))
 
     RecordingAudioSetting(
-        audioUiState = uiState.audioUiState,
-        setDefaultAudio = setAudio
+        audioUiState = enabledState.audioUiState,
+        setDefaultAudio = setVideoAudio
     )
 
     MaxVideoDurationSetting(
-        maxVideoDurationUiState = uiState.maxVideoDurationUiState,
+        maxVideoDurationUiState = enabledState.maxVideoDurationUiState,
         setMaxDuration = setMaxVideoDuration
     )
 
     ConcurrentCameraSetting(
-        concurrentCameraUiState = uiState.concurrentCameraUiState,
+        concurrentCameraUiState = enabledState.concurrentCameraUiState,
         setConcurrentCameraMode = setConcurrentCameraMode
     )
 
     StabilizationSetting(
-        stabilizationUiState = uiState.stabilizationUiState,
+        stabilizationUiState = enabledState.stabilizationUiState,
         setStabilizationMode = setStabilizationMode
     )
 
     VideoQualitySetting(
-        videQualityUiState = uiState.videoQualityUiState,
+        videQualityUiState = enabledState.videoQualityUiState,
         setVideoQuality = setVideoQuality
     )
+}
 
+@Composable
+fun DefaultAppSettings(
+    versionInfo: VersionInfoHolder,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.settingsUiState.collectAsState()
+    if (uiState !is SettingsUiState.Enabled) return
+    val enabledState = uiState as SettingsUiState.Enabled
+
+    DefaultAppSettings(
+        versionInfo = versionInfo,
+        enabledState = enabledState,
+        setDarkMode = viewModel::setDarkMode
+    )
+}
+
+@Composable
+fun DefaultAppSettings(
+    versionInfo: VersionInfoHolder,
+    enabledState: SettingsUiState.Enabled,
+    setDarkMode: (DarkMode) -> Unit
+) {
     SectionHeader(title = stringResource(id = R.string.section_title_app_settings))
 
     DarkModeSetting(
-        darkModeUiState = uiState.darkModeUiState,
+        darkModeUiState = enabledState.darkModeUiState,
         setDarkMode = setDarkMode
     )
 
@@ -259,21 +265,4 @@ internal fun SettingsList(
     )
 }
 
-// will allow you to open stabilization popup or give disabled rationale
-
 data class VersionInfoHolder(val versionName: String, val buildType: String)
-
-@Preview(name = "Light Mode")
-@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-private fun Preview_SettingsScreen() {
-    SettingsPreviewTheme {
-        SettingsScreen(
-            uiState = TYPICAL_SETTINGS_UISTATE,
-            versionInfo = VersionInfoHolder(
-                versionName = "1.0.0",
-                buildType = "release"
-            )
-        )
-    }
-}

--- a/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/google/jetpackcamera/settings/ui/SettingsComponents.kt
@@ -59,15 +59,13 @@ import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.jetpackcamera.core.camera.effects.SingleStreamEffectKey
+
 import com.google.jetpackcamera.model.AspectRatio
-import com.google.jetpackcamera.model.CameraEffectId
 import com.google.jetpackcamera.model.ConcurrentCameraMode
 import com.google.jetpackcamera.model.DarkMode
 import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.LowLightBoostPriority
-import com.google.jetpackcamera.model.NONE_EFFECT_ID
 import com.google.jetpackcamera.model.StabilizationMode
 import com.google.jetpackcamera.model.TARGET_FPS_15
 import com.google.jetpackcamera.model.TARGET_FPS_30
@@ -77,7 +75,6 @@ import com.google.jetpackcamera.model.UNLIMITED_VIDEO_DURATION
 import com.google.jetpackcamera.model.VideoQuality
 import com.google.jetpackcamera.settings.AspectRatioUiState
 import com.google.jetpackcamera.settings.AudioUiState
-import com.google.jetpackcamera.settings.CameraEffectUiState
 import com.google.jetpackcamera.settings.ConcurrentCameraUiState
 import com.google.jetpackcamera.settings.DarkModeUiState
 import com.google.jetpackcamera.settings.DisabledRationale
@@ -347,64 +344,6 @@ fun AspectRatioSetting(
                     enabled = true,
                     onClick = { setAspectRatio(AspectRatio.ONE_ONE) }
                 )
-            }
-        }
-    )
-}
-
-@Composable
-fun CameraEffectSetting(
-    cameraEffectUiState: CameraEffectUiState,
-    setCameraEffect: (CameraEffectId) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    BasicPopupSetting(
-        modifier = modifier.testTag(BTN_OPEN_DIALOG_SETTING_STREAM_CONFIG_TAG),
-        title = stringResource(id = R.string.stream_config_title),
-        leadingIcon = null,
-        enabled = cameraEffectUiState is CameraEffectUiState.Enabled,
-        description = when (cameraEffectUiState) {
-            is CameraEffectUiState.Enabled -> {
-                if (cameraEffectUiState.currentCameraEffect == NONE_EFFECT_ID) {
-                    stringResource(id = R.string.stream_config_description_multi_stream)
-                } else {
-                    stringResource(id = R.string.stream_config_description_single_stream)
-                }
-            }
-
-            is CameraEffectUiState.Disabled -> {
-                disabledRationaleString(disabledRationale = cameraEffectUiState.disabledRationale)
-            }
-        },
-        popupContents = {
-            Column(Modifier.selectableGroup()) {
-                if (cameraEffectUiState is CameraEffectUiState.Enabled) {
-                    SingleChoiceSelector(
-                        modifier = Modifier.testTag(
-                            BTN_DIALOG_STREAM_CONFIG_OPTION_MULTI_STREAM_CAPTURE_TAG
-                        ),
-                        text = stringResource(
-                            id = R.string.stream_config_selector_multi_stream
-                        ),
-                        selected = cameraEffectUiState.currentCameraEffect == NONE_EFFECT_ID,
-                        enabled = true,
-                        onClick = { setCameraEffect(NONE_EFFECT_ID) }
-                    )
-                    if (cameraEffectUiState.supportedEffects.contains(SingleStreamEffectKey.id)) {
-                        SingleChoiceSelector(
-                            modifier = Modifier.testTag(
-                                BTN_DIALOG_STREAM_CONFIG_OPTION_SINGLE_STREAM_TAG
-                            ),
-                            text = stringResource(
-                                id = R.string.stream_config_selector_single_stream
-                            ),
-                            selected = cameraEffectUiState.currentCameraEffect ==
-                                SingleStreamEffectKey.id,
-                            enabled = true,
-                            onClick = { setCameraEffect(SingleStreamEffectKey.id) }
-                        )
-                    }
-                }
             }
         }
     )

--- a/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/google/jetpackcamera/settings/CameraAppSettingsViewModelTest.kt
@@ -23,7 +23,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.google.jetpackcamera.core.camera.effects.SingleStreamEffectKey
+
 import com.google.jetpackcamera.core.settings.datastoreprefs.PrefsDataStoreSettingsDataSource
 import com.google.jetpackcamera.core.settings.datastoreprefs.testing.FakeDataStoreModule
 import com.google.jetpackcamera.model.CaptureMode
@@ -288,9 +288,10 @@ internal class CameraAppSettingsViewModelTest {
      */
     @Test
     fun concurrentCamera_whenCameraEffectIsActive_isDisabled() = runTest(StandardTestDispatcher()) {
+        val testEffectId = com.google.jetpackcamera.model.CameraEffectId("fake_effect")
         // Set selected_camera_effect to a non-empty value first
         testDataStore.edit { prefs ->
-            prefs[stringPreferencesKey("selected_camera_effect")] = SingleStreamEffectKey.id.value
+            prefs[stringPreferencesKey("selected_camera_effect")] = testEffectId.value
         }
 
         val customViewModel = createViewModelWithConstraints(
@@ -298,7 +299,7 @@ internal class CameraAppSettingsViewModelTest {
                 concurrentCamerasSupported = true,
                 perLensConstraints =
                 TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints.mapValues { (_, constraints) ->
-                    constraints.copy(supportedEffects = setOf(SingleStreamEffectKey.id))
+                    constraints.copy(supportedEffects = setOf(testEffectId))
                 }
             )
         )


### PR DESCRIPTION
This introduces a robust Compose slot architecture for the Settings view natively inside Jetpack Camera App. Rather than hardcoding the menu options, feature plugins and custom apps can inject custom nodes using the slot properties exposed on the SettingsScreen node, while retaining fully featured state hoisting for isolated UI previews.

Tests have been updated to reflect the ability to inject the generic UI.