### PR TITLE
Fix: Provide fallback for LocalOverlapTargetBounds to prevent crashes in external implementations

### DIFF
--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CameraControlBackgroundStyle.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CameraControlBackgroundStyle.kt
@@ -29,12 +29,14 @@ internal enum class CameraControlBackgroundStyle {
     WHITE_20
 }
 
+private val DefaultOverlapTargetBounds = mutableStateOf(Rect.Zero)
+
 /**
  * Provides the global bounds of the target overlapping region.
  * Elements can read this to determine their overlap with the targeted background (e.g. ViewFinder).
  */
 internal val LocalOverlapTargetBounds = compositionLocalOf<MutableState<Rect>> {
-    mutableStateOf(Rect.Zero)
+    DefaultOverlapTargetBounds
 }
 
 /**

--- a/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CameraControlBackgroundStyle.kt
+++ b/ui/components/capture/src/main/java/com/google/jetpackcamera/ui/components/capture/CameraControlBackgroundStyle.kt
@@ -17,6 +17,7 @@ package com.google.jetpackcamera.ui.components.capture
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Rect
 
 /**
@@ -33,7 +34,7 @@ internal enum class CameraControlBackgroundStyle {
  * Elements can read this to determine their overlap with the targeted background (e.g. ViewFinder).
  */
 internal val LocalOverlapTargetBounds = compositionLocalOf<MutableState<Rect>> {
-    error("No LocalOverlapTargetBounds provided")
+    mutableStateOf(Rect.Zero)
 }
 
 /**

--- a/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/OverlapAwareStyleProviderTest.kt
+++ b/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/OverlapAwareStyleProviderTest.kt
@@ -148,8 +148,8 @@ class OverlapAwareStyleProviderTest {
             }
         }
         composeTestRule.waitForIdle()
-        
-        // Because the missing provider falls back to Rect.Zero, 
+
+        // Because the missing provider falls back to Rect.Zero,
         // the 0f intersection correctly results in WHITE_20.
         assertThat(detectedStyle).isEqualTo(CameraControlBackgroundStyle.WHITE_20)
     }

--- a/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/OverlapAwareStyleProviderTest.kt
+++ b/ui/components/capture/src/test/java/com/google/jetpackcamera/ui/components/capture/OverlapAwareStyleProviderTest.kt
@@ -129,4 +129,28 @@ class OverlapAwareStyleProviderTest {
         composeTestRule.waitForIdle()
         assertThat(detectedStyle).isEqualTo(CameraControlBackgroundStyle.WHITE_20)
     }
+
+    @Test
+    fun overlapAware_noProvider_defaultsSafelyToWhite20() {
+        var detectedStyle: CameraControlBackgroundStyle? = null
+
+        composeTestRule.setContent {
+            // We consciously DO NOT wrap this in a CompositionLocalProvider
+            // to test the new fallback mechanism.
+            Box(Modifier.size(500.dp)) {
+                OverlapAwareStyleProvider(
+                    modifier = Modifier
+                        .offset(x = 0.dp, y = 10.dp)
+                        .size(100.dp)
+                ) {
+                    detectedStyle = LocalCameraControlBackgroundStyle.current
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        
+        // Because the missing provider falls back to Rect.Zero, 
+        // the 0f intersection correctly results in WHITE_20.
+        assertThat(detectedStyle).isEqualTo(CameraControlBackgroundStyle.WHITE_20)
+    }
 }


### PR DESCRIPTION
Provides a default Rect.Zero value for LocalOverlapTargetBounds instead of throwing an IllegalStateException. This prevents crashes when external callers omit the CompositionLocal provider. Also adds a test verifying the new robust isolation behavior.