### PR TITLE
Make MediaRepository and ImageWellController optional in CaptureControllerImpl

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 }
 
 android {
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     namespace = "com.google.jetpackcamera"
 

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -21,7 +21,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.benchmark"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/core/camera/build.gradle.kts
+++ b/core/camera/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/effects/single-stream/build.gradle.kts
+++ b/core/camera/effects/single-stream/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.effects"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/low-light-playservices-di/build.gradle.kts
+++ b/core/camera/low-light-playservices-di/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.lowlight.playservices.di"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/low-light-playservices/build.gradle.kts
+++ b/core/camera/low-light-playservices/build.gradle.kts
@@ -21,7 +21,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.lowlight.playservices"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/low-light/build.gradle.kts
+++ b/core/camera/low-light/build.gradle.kts
@@ -21,7 +21,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.lowlight"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/low-light/low-light-di/build.gradle.kts
+++ b/core/camera/low-light/low-light-di/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.lowlight.di"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/postprocess/build.gradle.kts
+++ b/core/camera/postprocess/build.gradle.kts
@@ -21,7 +21,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.postprocess"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/postprocess/postprocess-di/build.gradle.kts
+++ b/core/camera/postprocess/postprocess-di/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.postprocess.di"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/camera/testing/build.gradle.kts
+++ b/core/camera/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.camera.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.common"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/common/testing/build.gradle.kts
+++ b/core/common/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.common.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.model"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/settings/build.gradle.kts
+++ b/core/settings/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.settings"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/settings/datastore-prefs/build.gradle.kts
+++ b/core/settings/datastore-prefs/build.gradle.kts
@@ -19,7 +19,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.settings.datastoreprefs"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/core/settings/datastore-prefs/testing/build.gradle.kts
+++ b/core/settings/datastore-prefs/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.core.settings.datastoreprefs.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/data/camera/build.gradle.kts
+++ b/data/camera/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.data.camera"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/data/media/build.gradle.kts
+++ b/data/media/build.gradle.kts
@@ -21,7 +21,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.data.media"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/data/media/testing/build.gradle.kts
+++ b/data/media/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.data.media.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.data.settings"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/data/settings/testing/build.gradle.kts
+++ b/data/settings/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.settings.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/permissions/build.gradle.kts
+++ b/feature/permissions/build.gradle.kts
@@ -23,7 +23,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.permissions"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/postcapture/build.gradle.kts
+++ b/feature/postcapture/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.feature.postcapture"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -23,7 +23,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.feature.preview"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.jetpackcamera.core.camera.CameraSystem.Companion.applyDiffs
 import com.google.jetpackcamera.data.camera.CameraSystemRepository
+import com.google.jetpackcamera.data.media.MediaDescriptor
 import com.google.jetpackcamera.data.media.MediaRepository
 import com.google.jetpackcamera.feature.preview.navigation.getCaptureUris
 import com.google.jetpackcamera.feature.preview.navigation.getDebugSettings
@@ -205,7 +206,6 @@ class PreviewViewModel @Inject constructor(
     val captureController: CaptureController = CaptureControllerImpl(
         trackedCaptureUiState = trackedCaptureUiState,
         cameraSystem = cameraSystemRepository.cameraSystem,
-        mediaRepository = mediaRepository,
         saveMode = saveMode,
         externalCaptureMode = externalCaptureMode,
         externalCapturesCallback = {
@@ -225,6 +225,20 @@ class PreviewViewModel @Inject constructor(
         },
         captureEvents = incomingCaptureEvents,
         imageWellController = imageWellController,
+        onImageCached = { uri ->
+            viewModelScope.launch {
+                mediaRepository.setCurrentMedia(
+                    MediaDescriptor.Content.Image(uri, null, true)
+                )
+            }
+        },
+        onVideoCached = { uri ->
+            viewModelScope.launch {
+                mediaRepository.setCurrentMedia(
+                    MediaDescriptor.Content.Video(uri, null, true)
+                )
+            }
+        },
         coroutineContext = viewModelScope.coroutineContext
     )
 

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -23,7 +23,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.settings"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # Used directly in build.gradle.kts files
-compileSdk = "36"
+compileSdk = "37"
+compileSdkMinor = "1"
 desugar_jdk_libs = "2.1.5"
 orchestrator = "1.6.1"
 minSdk = "24"

--- a/ui/components/build.gradle.kts
+++ b/ui/components/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.components"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/components/capture/build.gradle.kts
+++ b/ui/components/capture/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.components.capture"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/controller/build.gradle.kts
+++ b/ui/controller/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.controller"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/controller/impl/build.gradle.kts
+++ b/ui/controller/impl/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.controller.impl"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -66,12 +66,12 @@ private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
 class CaptureControllerImpl(
     private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
     private val cameraSystem: CameraSystem,
-    private val mediaRepository: MediaRepository,
+    private val mediaRepository: MediaRepository? = null,
     private val saveMode: SaveMode,
     private val externalCaptureMode: ExternalCaptureMode,
     private val externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?>,
     override val captureEvents: Channel<CaptureEvent>,
-    private val imageWellController: ImageWellController,
+    private val imageWellController: ImageWellController? = null,
     coroutineContext: CoroutineContext
 ) : CaptureController {
 
@@ -113,14 +113,16 @@ class CaptureControllerImpl(
                         }
                     }
                     if (saveLocation !is SaveLocation.Cache) {
-                        imageWellController.updateLastCapturedMedia()
+                        imageWellController?.updateLastCapturedMedia()
                     } else {
-                        savedUri?.let {
-                            scope.launch {
-                                postCurrentMediaToMediaRepository(
-                                    mediaRepository,
-                                    MediaDescriptor.Content.Image(it, null, true)
-                                )
+                        savedUri?.let { uri ->
+                            mediaRepository?.let { repo ->
+                                scope.launch {
+                                    postCurrentMediaToMediaRepository(
+                                        repo,
+                                        MediaDescriptor.Content.Image(uri, null, true)
+                                    )
+                                }
                             }
                         }
                     }
@@ -164,13 +166,15 @@ class CaptureControllerImpl(
                             }
 
                             if (saveLocation !is SaveLocation.Cache) {
-                                imageWellController.updateLastCapturedMedia()
+                                imageWellController?.updateLastCapturedMedia()
                             } else {
-                                scope.launch {
-                                    postCurrentMediaToMediaRepository(
-                                        mediaRepository,
-                                        MediaDescriptor.Content.Video(it.savedUri, null, true)
-                                    )
+                                mediaRepository?.let { repo ->
+                                    scope.launch {
+                                        postCurrentMediaToMediaRepository(
+                                            repo,
+                                            MediaDescriptor.Content.Video(it.savedUri, null, true)
+                                        )
+                                    }
                                 }
                             }
 

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -16,12 +16,11 @@
 package com.google.jetpackcamera.ui.controller.impl
 
 import android.content.ContentResolver
+import android.net.Uri
 import android.util.Log
 import androidx.tracing.traceAsync
 import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.core.camera.OnVideoRecordEvent
-import com.google.jetpackcamera.data.media.MediaDescriptor
-import com.google.jetpackcamera.data.media.MediaRepository
 import com.google.jetpackcamera.model.CaptureEvent
 import com.google.jetpackcamera.model.ExternalCaptureMode
 import com.google.jetpackcamera.model.ImageCaptureEvent
@@ -32,7 +31,6 @@ import com.google.jetpackcamera.model.VideoCaptureEvent
 import com.google.jetpackcamera.ui.controller.CaptureController
 import com.google.jetpackcamera.ui.controller.ImageWellController
 import com.google.jetpackcamera.ui.controller.impl.Utils.nextSaveLocation
-import com.google.jetpackcamera.ui.controller.impl.Utils.postCurrentMediaToMediaRepository
 import com.google.jetpackcamera.ui.uistate.capture.TrackedCaptureUiState
 import kotlin.coroutines.CoroutineContext
 import kotlinx.atomicfu.atomic
@@ -50,28 +48,29 @@ private const val TAG = "CaptureButtonControllerImpl"
 private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
 
 /**
- * Implementation of [CaptureController] that interacts with [CameraSystem] and [MediaRepository].
+ * Implementation of [CaptureController] that interacts with [CameraSystem].
  *
  * @param trackedCaptureUiState State for tracking UI changes during capture.
  * @param cameraSystem The camera system to perform capture operations.
- * @param mediaRepository Repository for managing captured media.
  * @param saveMode Mode for saving captured media.
  * @param externalCaptureMode Mode for external capture requests.
  * @param externalCapturesCallback Callback for getting external capture information.
  * @property captureEvents Channel for sending capture-related events.
- * @param captureScreenController Controller for UI-related capture screen actions.
- * @param snackBarController Controller for showing snackbars.
+ * @param imageWellController Controller for managing the image well UI.
+ * @param onImageCached Callback invoked when an image is saved to cache.
+ * @param onVideoCached Callback invoked when a video is saved to cache.
  * @param coroutineContext The [CoroutineContext] for launching coroutines.
  */
 class CaptureControllerImpl(
     private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
     private val cameraSystem: CameraSystem,
-    private val mediaRepository: MediaRepository? = null,
     private val saveMode: SaveMode,
     private val externalCaptureMode: ExternalCaptureMode,
     private val externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?>,
     override val captureEvents: Channel<CaptureEvent>,
     private val imageWellController: ImageWellController? = null,
+    private val onImageCached: ((Uri) -> Unit)? = null,
+    private val onVideoCached: ((Uri) -> Unit)? = null,
     coroutineContext: CoroutineContext
 ) : CaptureController {
 
@@ -116,14 +115,7 @@ class CaptureControllerImpl(
                         imageWellController?.updateLastCapturedMedia()
                     } else {
                         savedUri?.let { uri ->
-                            mediaRepository?.let { repo ->
-                                scope.launch {
-                                    postCurrentMediaToMediaRepository(
-                                        repo,
-                                        MediaDescriptor.Content.Image(uri, null, true)
-                                    )
-                                }
-                            }
+                            onImageCached?.invoke(uri)
                         }
                     }
                     captureEvents.trySend(event)
@@ -168,14 +160,7 @@ class CaptureControllerImpl(
                             if (saveLocation !is SaveLocation.Cache) {
                                 imageWellController?.updateLastCapturedMedia()
                             } else {
-                                mediaRepository?.let { repo ->
-                                    scope.launch {
-                                        postCurrentMediaToMediaRepository(
-                                            repo,
-                                            MediaDescriptor.Content.Video(it.savedUri, null, true)
-                                        )
-                                    }
-                                }
+                                onVideoCached?.invoke(it.savedUri)
                             }
 
                             captureEvents.trySend(event)

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -69,9 +69,7 @@ class CaptureControllerImpl(
     private val externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?>,
     override val captureEvents: Channel<CaptureEvent>,
     private val imageWellController: ImageWellController? = null,
-    private val imageWellController: ImageWellController? = null,
-    private val onImageCaptureComplete: ((Uri) -> Unit)? = null,
-    private val onVideoCaptureComplete: ((Uri) -> Unit)? = null,
+    private val onImageCached: ((Uri) -> Unit)? = null,
     private val onVideoCached: ((Uri) -> Unit)? = null,
     coroutineContext: CoroutineContext
 ) : CaptureController {

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -69,7 +69,9 @@ class CaptureControllerImpl(
     private val externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?>,
     override val captureEvents: Channel<CaptureEvent>,
     private val imageWellController: ImageWellController? = null,
-    private val onImageCached: ((Uri) -> Unit)? = null,
+    private val imageWellController: ImageWellController? = null,
+    private val onImageCaptureComplete: ((Uri) -> Unit)? = null,
+    private val onVideoCaptureComplete: ((Uri) -> Unit)? = null,
     private val onVideoCached: ((Uri) -> Unit)? = null,
     coroutineContext: CoroutineContext
 ) : CaptureController {

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/ImageWellControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/ImageWellControllerImpl.kt
@@ -18,7 +18,6 @@ package com.google.jetpackcamera.ui.controller.impl
 import com.google.jetpackcamera.data.media.MediaDescriptor
 import com.google.jetpackcamera.data.media.MediaRepository
 import com.google.jetpackcamera.ui.controller.ImageWellController
-import com.google.jetpackcamera.ui.controller.impl.Utils.postCurrentMediaToMediaRepository
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -42,10 +41,7 @@ class ImageWellControllerImpl(
     private val scope = CoroutineScope(coroutineContext + job)
     override fun imageWellToRepository(mediaDescriptor: MediaDescriptor) {
         scope.launch {
-            postCurrentMediaToMediaRepository(
-                mediaRepository,
-                mediaDescriptor
-            )
+            mediaRepository.setCurrentMedia(mediaDescriptor)
         }
     }
     override fun updateLastCapturedMedia() {

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/Utils.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/Utils.kt
@@ -15,26 +15,12 @@
  */
 package com.google.jetpackcamera.ui.controller.impl
 
-import com.google.jetpackcamera.data.media.MediaDescriptor
-import com.google.jetpackcamera.data.media.MediaRepository
 import com.google.jetpackcamera.model.ExternalCaptureMode
 import com.google.jetpackcamera.model.IntProgress
 import com.google.jetpackcamera.model.SaveLocation
 import com.google.jetpackcamera.model.SaveMode
 
 object Utils {
-    /**
-     * Posts the given [MediaDescriptor] to the [MediaRepository] as the current media.
-     *
-     * @param mediaRepository The repository to update.
-     * @param mediaDescriptor The media to set as current.
-     */
-    suspend fun postCurrentMediaToMediaRepository(
-        mediaRepository: MediaRepository,
-        mediaDescriptor: MediaDescriptor
-    ) {
-        mediaRepository.setCurrentMedia(mediaDescriptor)
-    }
 
     /**
      * Determines the next [SaveLocation] and optional [IntProgress] for a capture.

--- a/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImplTest.kt
+++ b/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImplTest.kt
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.ui.controller.impl
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import androidx.camera.core.ImageCapture
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.CameraSystem
+import com.google.jetpackcamera.core.camera.OnVideoRecordEvent
+import com.google.jetpackcamera.core.camera.testing.FakeCameraSystem
+import com.google.jetpackcamera.data.media.MediaDescriptor
+import com.google.jetpackcamera.model.CaptureEvent
+import com.google.jetpackcamera.model.ExternalCaptureMode
+import com.google.jetpackcamera.model.ImageCaptureEvent
+import com.google.jetpackcamera.model.IntProgress
+import com.google.jetpackcamera.model.SaveLocation
+import com.google.jetpackcamera.model.SaveMode
+import com.google.jetpackcamera.model.VideoCaptureEvent
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
+import com.google.jetpackcamera.ui.controller.ImageWellController
+import com.google.jetpackcamera.ui.uistate.capture.TrackedCaptureUiState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CaptureControllerImplTest {
+    private val testScope = TestScope()
+    private val testDispatcher = StandardTestDispatcher(testScope.testScheduler)
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
+    private val fakeCameraSystem = FakeCameraSystem()
+    private val testCameraSystem = TestCameraSystem(fakeCameraSystem)
+    private val trackedCaptureUiState = MutableStateFlow(TrackedCaptureUiState())
+    private val captureEvents = Channel<CaptureEvent>(capacity = Channel.UNLIMITED)
+    private val fakeImageWellController = FakeImageWellController()
+    private lateinit var contentResolver: ContentResolver
+
+    private val testImageUri = Uri.parse("content://media/external/images/media/1")
+    private val testVideoUri = Uri.parse("content://media/external/video/media/2")
+    private val testCacheDir = Uri.parse("file:///tmp/cache")
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        contentResolver = context.contentResolver
+        testCameraSystem.savedImageUri = testImageUri
+        testCameraSystem.savedVideoUri = testVideoUri
+    }
+
+    private fun createCaptureController(
+        saveMode: SaveMode = SaveMode.Immediate,
+        externalCaptureMode: ExternalCaptureMode = ExternalCaptureMode.Standard,
+        externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?> = {
+            Pair(SaveLocation.Default, null)
+        },
+        imageWellController: ImageWellController? = fakeImageWellController,
+        onImageCached: ((Uri) -> Unit)? = null,
+        onVideoCached: ((Uri) -> Unit)? = null
+    ): CaptureControllerImpl {
+        return CaptureControllerImpl(
+            trackedCaptureUiState = trackedCaptureUiState,
+            cameraSystem = testCameraSystem,
+            saveMode = saveMode,
+            externalCaptureMode = externalCaptureMode,
+            externalCapturesCallback = externalCapturesCallback,
+            captureEvents = captureEvents,
+            imageWellController = imageWellController,
+            onImageCached = onImageCached,
+            onVideoCached = onVideoCached,
+            coroutineContext = testScope.coroutineContext
+        )
+    }
+
+    @Test
+    fun captureImage_standardSaveLocation_updatesImageWellAndEmitsSingleImageSaved() =
+        runCameraTest {
+            var imageCachedUri: Uri? = null
+            val controller = createCaptureController(
+                saveMode = SaveMode.Immediate,
+                onImageCached = { imageCachedUri = it }
+            )
+
+            controller.captureImage(contentResolver)
+            advanceUntilIdle()
+
+            assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(1)
+            assertThat(imageCachedUri).isNull()
+            val event = captureEvents.receive()
+            assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageSaved::class.java)
+            assertThat(
+                (event as ImageCaptureEvent.SingleImageSaved).capturedUri
+            ).isEqualTo(testImageUri)
+        }
+
+    @Test
+    fun captureImage_cacheSaveLocation_invokesOnImageCachedAndEmitsSingleImageCached() =
+        runCameraTest {
+            var imageCachedUri: Uri? = null
+            val controller = createCaptureController(
+                saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
+                onImageCached = { imageCachedUri = it }
+            )
+
+            controller.captureImage(contentResolver)
+            advanceUntilIdle()
+
+            assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(0)
+            assertThat(imageCachedUri).isEqualTo(testImageUri)
+            val event = captureEvents.receive()
+            assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageCached::class.java)
+            assertThat(
+                (event as ImageCaptureEvent.SingleImageCached).capturedUri
+            ).isEqualTo(testImageUri)
+        }
+
+    @Test
+    fun captureImage_nullOptionalDependencies_succeedsWithoutError() = runCameraTest {
+        val controller = createCaptureController(
+            saveMode = SaveMode.Immediate,
+            imageWellController = null,
+            onImageCached = null
+        )
+
+        controller.captureImage(contentResolver)
+        advanceUntilIdle()
+
+        val event = captureEvents.receive()
+        assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageSaved::class.java)
+    }
+
+    @Test
+    fun captureImage_cacheModeWithNullOnImageCached_succeedsWithoutError() = runCameraTest {
+        val controller = createCaptureController(
+            saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
+            imageWellController = null,
+            onImageCached = null
+        )
+
+        controller.captureImage(contentResolver)
+        advanceUntilIdle()
+
+        val event = captureEvents.receive()
+        assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageCached::class.java)
+    }
+
+    @Test
+    fun captureImage_externalVideoCaptureMode_emitsImageCaptureExternalUnsupported() =
+        runCameraTest {
+            val controller = createCaptureController(
+                externalCaptureMode = ExternalCaptureMode.VideoCapture
+            )
+
+            controller.captureImage(contentResolver)
+            advanceUntilIdle()
+
+            val event = captureEvents.receive()
+            assertThat(event).isEqualTo(ImageCaptureEvent.ImageCaptureExternalUnsupported)
+        }
+
+    @Test
+    fun captureImage_multipleImageCaptureMode_emitsSequentialImageSaved() = runCameraTest {
+        val progress = IntProgress(1, 1..3)
+        val controller = createCaptureController(
+            externalCaptureMode = ExternalCaptureMode.MultipleImageCapture,
+            externalCapturesCallback = {
+                Pair(SaveLocation.Explicit(testImageUri), progress)
+            }
+        )
+
+        controller.captureImage(contentResolver)
+        advanceUntilIdle()
+
+        val event = captureEvents.receive()
+        assertThat(event).isInstanceOf(ImageCaptureEvent.SequentialImageSaved::class.java)
+        val sequentialEvent = event as ImageCaptureEvent.SequentialImageSaved
+        assertThat(sequentialEvent.capturedUri).isEqualTo(testImageUri)
+        assertThat(sequentialEvent.progress).isEqualTo(progress)
+    }
+
+    @Test
+    fun startVideoRecording_standardSaveLocation_updatesImageWellAndEmitsVideoSaved() =
+        runCameraTest {
+            var videoCachedUri: Uri? = null
+            val controller = createCaptureController(
+                saveMode = SaveMode.Immediate,
+                onVideoCached = { videoCachedUri = it }
+            )
+
+            controller.startVideoRecording()
+            advanceUntilIdle()
+
+            assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(1)
+            assertThat(videoCachedUri).isNull()
+            val event = captureEvents.receive()
+            assertThat(event).isInstanceOf(VideoCaptureEvent.VideoSaved::class.java)
+            assertThat((event as VideoCaptureEvent.VideoSaved).savedUri).isEqualTo(testVideoUri)
+        }
+
+    @Test
+    fun startVideoRecording_cacheSaveLocation_invokesOnVideoCachedAndEmitsVideoCached() =
+        runCameraTest {
+            var videoCachedUri: Uri? = null
+            val controller = createCaptureController(
+                saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
+                onVideoCached = { videoCachedUri = it }
+            )
+
+            controller.startVideoRecording()
+            advanceUntilIdle()
+
+            assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(0)
+            assertThat(videoCachedUri).isEqualTo(testVideoUri)
+            val event = captureEvents.receive()
+            assertThat(event).isInstanceOf(VideoCaptureEvent.VideoCached::class.java)
+            assertThat((event as VideoCaptureEvent.VideoCached).capturedUri).isEqualTo(testVideoUri)
+        }
+
+    @Test
+    fun startVideoRecording_nullOptionalDependencies_succeedsWithoutError() = runCameraTest {
+        val controller = createCaptureController(
+            saveMode = SaveMode.Immediate,
+            imageWellController = null,
+            onVideoCached = null
+        )
+
+        controller.startVideoRecording()
+        advanceUntilIdle()
+
+        val event = captureEvents.receive()
+        assertThat(event).isInstanceOf(VideoCaptureEvent.VideoSaved::class.java)
+    }
+
+    @Test
+    fun startVideoRecording_externalImageCaptureMode_emitsVideoCaptureExternalUnsupported() =
+        runCameraTest {
+            val controller = createCaptureController(
+                externalCaptureMode = ExternalCaptureMode.ImageCapture
+            )
+
+            controller.startVideoRecording()
+            advanceUntilIdle()
+
+            val event = captureEvents.receive()
+            assertThat(event).isEqualTo(VideoCaptureEvent.VideoCaptureExternalUnsupported)
+        }
+
+    @Test
+    fun startVideoRecording_onError_emitsVideoCaptureError() = runCameraTest {
+        val expectedError = RuntimeException("Recording failed")
+        testCameraSystem.videoRecordError = expectedError
+
+        val controller = createCaptureController()
+        controller.startVideoRecording()
+        advanceUntilIdle()
+
+        val event = captureEvents.receive()
+        assertThat(event).isInstanceOf(VideoCaptureEvent.VideoCaptureError::class.java)
+        assertThat((event as VideoCaptureEvent.VideoCaptureError).error).isEqualTo(expectedError)
+    }
+
+    @Test
+    fun setLockedRecording_updatesTrackedCaptureUiState() {
+        val controller = createCaptureController()
+        controller.setLockedRecording(true)
+        assertThat(trackedCaptureUiState.value.isRecordingLocked).isTrue()
+
+        controller.setLockedRecording(false)
+        assertThat(trackedCaptureUiState.value.isRecordingLocked).isFalse()
+    }
+
+    @Test
+    fun setPaused_pausesAndResumesRecording() = runTest(testDispatcher) {
+        val controller = createCaptureController()
+
+        controller.setPaused(true)
+        advanceUntilIdle()
+        assertThat(fakeCameraSystem.isRecordingPaused).isTrue()
+
+        controller.setPaused(false)
+        advanceUntilIdle()
+        assertThat(fakeCameraSystem.isRecordingPaused).isFalse()
+    }
+
+    private fun runCameraTest(testBody: suspend TestScope.() -> Unit) = runTest(testDispatcher) {
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            fakeCameraSystem.initialize(DEFAULT_CAMERA_APP_SETTINGS) {}
+            fakeCameraSystem.runCamera()
+        }
+        testBody()
+    }
+}
+
+private class TestCameraSystem(private val delegate: FakeCameraSystem) :
+    CameraSystem by delegate {
+    var savedImageUri: Uri? = null
+    var savedVideoUri: Uri = Uri.EMPTY
+    var videoRecordError: Throwable? = null
+
+    override suspend fun takePicture(
+        contentResolver: ContentResolver,
+        saveLocation: SaveLocation,
+        onCaptureStarted: () -> Unit
+    ): ImageCapture.OutputFileResults {
+        delegate.takePicture(onCaptureStarted)
+        return ImageCapture.OutputFileResults(savedImageUri)
+    }
+
+    override suspend fun startVideoRecording(
+        saveLocation: SaveLocation,
+        onVideoRecord: (OnVideoRecordEvent) -> Unit
+    ) {
+        delegate.startVideoRecording(saveLocation, onVideoRecord)
+        val error = videoRecordError
+        if (error != null) {
+            onVideoRecord(OnVideoRecordEvent.OnVideoRecordError(error))
+        } else {
+            onVideoRecord(OnVideoRecordEvent.OnVideoRecorded(savedVideoUri))
+        }
+    }
+}
+
+private class FakeImageWellController : ImageWellController {
+    var updateLastCapturedMediaCallCount = 0
+    var lastMediaDescriptor: MediaDescriptor? = null
+
+    override fun imageWellToRepository(mediaDescriptor: MediaDescriptor) {
+        lastMediaDescriptor = mediaDescriptor
+    }
+
+    override fun updateLastCapturedMedia() {
+        updateLastCapturedMediaCallCount++
+    }
+}

--- a/ui/controller/testing/build.gradle.kts
+++ b/ui/controller/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.controller.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/debug/build.gradle.kts
+++ b/ui/debug/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.debug"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/debug/testing/build.gradle.kts
+++ b/ui/debug/testing/build.gradle.kts
@@ -20,7 +20,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.debug.testing"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/uistate/build.gradle.kts
+++ b/ui/uistate/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.uistate"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/uistate/capture/build.gradle.kts
+++ b/ui/uistate/capture/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.uistate.capture"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/uistate/postcapture/build.gradle.kts
+++ b/ui/uistate/postcapture/build.gradle.kts
@@ -19,7 +19,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.uistate.postcapture"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/uistateadapter/build.gradle.kts
+++ b/ui/uistateadapter/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.uistateadapter"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/uistateadapter/capture/build.gradle.kts
+++ b/ui/uistateadapter/capture/build.gradle.kts
@@ -22,7 +22,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.uistateadapter.capture"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()

--- a/ui/uistateadapter/postcapture/build.gradle.kts
+++ b/ui/uistateadapter/postcapture/build.gradle.kts
@@ -19,7 +19,11 @@ plugins {
 
 android {
     namespace = "com.google.jetpackcamera.ui.uistateadapter.postcapture"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()


### PR DESCRIPTION
Allow CaptureControllerImpl to be used in client applications  that manage their own media persistence and do not display an image well thumbnail by making mediaRepository and imageWellController optional parameters defaulting to null.