### PR TITLE
Rename CaptureController cached callbacks to onImageCaptureComplete and onVideoCaptureComplete

### DIFF
--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -225,14 +225,14 @@ class PreviewViewModel @Inject constructor(
         },
         captureEvents = incomingCaptureEvents,
         imageWellController = imageWellController,
-        onImageCached = { uri ->
+        onImageCaptureComplete = { uri ->
             viewModelScope.launch {
                 mediaRepository.setCurrentMedia(
                     MediaDescriptor.Content.Image(uri, null, true)
                 )
             }
         },
-        onVideoCached = { uri ->
+        onVideoCaptureComplete = { uri ->
             viewModelScope.launch {
                 mediaRepository.setCurrentMedia(
                     MediaDescriptor.Content.Video(uri, null, true)

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -57,8 +57,8 @@ private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
  * @param externalCapturesCallback Callback for getting external capture information.
  * @property captureEvents Channel for sending capture-related events.
  * @param imageWellController Controller for managing the image well UI.
- * @param onImageCached Callback invoked when an image is saved to cache.
- * @param onVideoCached Callback invoked when a video is saved to cache.
+ * @param onImageCaptureComplete Callback invoked when an image capture completes.
+ * @param onVideoCaptureComplete Callback invoked when a video capture completes.
  * @param coroutineContext The [CoroutineContext] for launching coroutines.
  */
 class CaptureControllerImpl(
@@ -69,8 +69,8 @@ class CaptureControllerImpl(
     private val externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?>,
     override val captureEvents: Channel<CaptureEvent>,
     private val imageWellController: ImageWellController? = null,
-    private val onImageCached: ((Uri) -> Unit)? = null,
-    private val onVideoCached: ((Uri) -> Unit)? = null,
+    private val onImageCaptureComplete: ((Uri) -> Unit)? = null,
+    private val onVideoCaptureComplete: ((Uri) -> Unit)? = null,
     coroutineContext: CoroutineContext
 ) : CaptureController {
 
@@ -115,7 +115,7 @@ class CaptureControllerImpl(
                         imageWellController?.updateLastCapturedMedia()
                     } else {
                         savedUri?.let { uri ->
-                            onImageCached?.invoke(uri)
+                            onImageCaptureComplete?.invoke(uri)
                         }
                     }
                     captureEvents.trySend(event)
@@ -160,7 +160,7 @@ class CaptureControllerImpl(
                             if (saveLocation !is SaveLocation.Cache) {
                                 imageWellController?.updateLastCapturedMedia()
                             } else {
-                                onVideoCached?.invoke(it.savedUri)
+                                onVideoCaptureComplete?.invoke(it.savedUri)
                             }
 
                             captureEvents.trySend(event)

--- a/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImplTest.kt
+++ b/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImplTest.kt
@@ -85,8 +85,8 @@ class CaptureControllerImplTest {
             Pair(SaveLocation.Default, null)
         },
         imageWellController: ImageWellController? = fakeImageWellController,
-        onImageCached: ((Uri) -> Unit)? = null,
-        onVideoCached: ((Uri) -> Unit)? = null
+        onImageCaptureComplete: ((Uri) -> Unit)? = null,
+        onVideoCaptureComplete: ((Uri) -> Unit)? = null
     ): CaptureControllerImpl {
         return CaptureControllerImpl(
             trackedCaptureUiState = trackedCaptureUiState,
@@ -96,8 +96,8 @@ class CaptureControllerImplTest {
             externalCapturesCallback = externalCapturesCallback,
             captureEvents = captureEvents,
             imageWellController = imageWellController,
-            onImageCached = onImageCached,
-            onVideoCached = onVideoCached,
+            onImageCaptureComplete = onImageCaptureComplete,
+            onVideoCaptureComplete = onVideoCaptureComplete,
             coroutineContext = testScope.coroutineContext
         )
     }
@@ -105,17 +105,17 @@ class CaptureControllerImplTest {
     @Test
     fun captureImage_standardSaveLocation_updatesImageWellAndEmitsSingleImageSaved() =
         runCameraTest {
-            var imageCachedUri: Uri? = null
+            var imageCaptureCompleteUri: Uri? = null
             val controller = createCaptureController(
                 saveMode = SaveMode.Immediate,
-                onImageCached = { imageCachedUri = it }
+                onImageCaptureComplete = { imageCaptureCompleteUri = it }
             )
 
             controller.captureImage(contentResolver)
             advanceUntilIdle()
 
             assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(1)
-            assertThat(imageCachedUri).isNull()
+            assertThat(imageCaptureCompleteUri).isNull()
             val event = captureEvents.receive()
             assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageSaved::class.java)
             assertThat(
@@ -124,19 +124,19 @@ class CaptureControllerImplTest {
         }
 
     @Test
-    fun captureImage_cacheSaveLocation_invokesOnImageCachedAndEmitsSingleImageCached() =
+    fun captureImage_cacheSaveLocation_invokesOnImageCaptureCompleteAndEmitsSingleImageCached() =
         runCameraTest {
-            var imageCachedUri: Uri? = null
+            var imageCaptureCompleteUri: Uri? = null
             val controller = createCaptureController(
                 saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
-                onImageCached = { imageCachedUri = it }
+                onImageCaptureComplete = { imageCaptureCompleteUri = it }
             )
 
             controller.captureImage(contentResolver)
             advanceUntilIdle()
 
             assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(0)
-            assertThat(imageCachedUri).isEqualTo(testImageUri)
+            assertThat(imageCaptureCompleteUri).isEqualTo(testImageUri)
             val event = captureEvents.receive()
             assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageCached::class.java)
             assertThat(
@@ -149,7 +149,7 @@ class CaptureControllerImplTest {
         val controller = createCaptureController(
             saveMode = SaveMode.Immediate,
             imageWellController = null,
-            onImageCached = null
+            onImageCaptureComplete = null
         )
 
         controller.captureImage(contentResolver)
@@ -160,19 +160,20 @@ class CaptureControllerImplTest {
     }
 
     @Test
-    fun captureImage_cacheModeWithNullOnImageCached_succeedsWithoutError() = runCameraTest {
-        val controller = createCaptureController(
-            saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
-            imageWellController = null,
-            onImageCached = null
-        )
+    fun captureImage_cacheModeWithNullOnImageCaptureComplete_succeedsWithoutError() =
+        runCameraTest {
+            val controller = createCaptureController(
+                saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
+                imageWellController = null,
+                onImageCaptureComplete = null
+            )
 
-        controller.captureImage(contentResolver)
-        advanceUntilIdle()
+            controller.captureImage(contentResolver)
+            advanceUntilIdle()
 
-        val event = captureEvents.receive()
-        assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageCached::class.java)
-    }
+            val event = captureEvents.receive()
+            assertThat(event).isInstanceOf(ImageCaptureEvent.SingleImageCached::class.java)
+        }
 
     @Test
     fun captureImage_externalVideoCaptureMode_emitsImageCaptureExternalUnsupported() =
@@ -211,36 +212,36 @@ class CaptureControllerImplTest {
     @Test
     fun startVideoRecording_standardSaveLocation_updatesImageWellAndEmitsVideoSaved() =
         runCameraTest {
-            var videoCachedUri: Uri? = null
+            var videoCaptureCompleteUri: Uri? = null
             val controller = createCaptureController(
                 saveMode = SaveMode.Immediate,
-                onVideoCached = { videoCachedUri = it }
+                onVideoCaptureComplete = { videoCaptureCompleteUri = it }
             )
 
             controller.startVideoRecording()
             advanceUntilIdle()
 
             assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(1)
-            assertThat(videoCachedUri).isNull()
+            assertThat(videoCaptureCompleteUri).isNull()
             val event = captureEvents.receive()
             assertThat(event).isInstanceOf(VideoCaptureEvent.VideoSaved::class.java)
             assertThat((event as VideoCaptureEvent.VideoSaved).savedUri).isEqualTo(testVideoUri)
         }
 
     @Test
-    fun startVideoRecording_cacheSaveLocation_invokesOnVideoCachedAndEmitsVideoCached() =
+    fun startVideoRecording_cacheSaveLocation_invokesOnVideoCaptureCompleteAndEmitsVideoCached() =
         runCameraTest {
-            var videoCachedUri: Uri? = null
+            var videoCaptureCompleteUri: Uri? = null
             val controller = createCaptureController(
                 saveMode = SaveMode.CacheAndReview(cacheDir = testCacheDir),
-                onVideoCached = { videoCachedUri = it }
+                onVideoCaptureComplete = { videoCaptureCompleteUri = it }
             )
 
             controller.startVideoRecording()
             advanceUntilIdle()
 
             assertThat(fakeImageWellController.updateLastCapturedMediaCallCount).isEqualTo(0)
-            assertThat(videoCachedUri).isEqualTo(testVideoUri)
+            assertThat(videoCaptureCompleteUri).isEqualTo(testVideoUri)
             val event = captureEvents.receive()
             assertThat(event).isInstanceOf(VideoCaptureEvent.VideoCached::class.java)
             assertThat((event as VideoCaptureEvent.VideoCached).capturedUri).isEqualTo(testVideoUri)
@@ -251,7 +252,7 @@ class CaptureControllerImplTest {
         val controller = createCaptureController(
             saveMode = SaveMode.Immediate,
             imageWellController = null,
-            onVideoCached = null
+            onVideoCaptureComplete = null
         )
 
         controller.startVideoRecording()


### PR DESCRIPTION
Rename `onImageCached` to `onImageCaptureComplete` and `onVideoCached` to `onVideoCaptureComplete` in `CaptureControllerImpl`, `PreviewViewModel`, and `CaptureControllerImplTest` to more clearly reflect that these callbacks are invoked when capture operations have completed and the media is available.