### PR TITLE
Refactor action controllers, state adapters, and CameraSystemRepository

### DIFF
--- a/app/src/main/java/com/google/jetpackcamera/MainActivity.kt
+++ b/app/src/main/java/com/google/jetpackcamera/MainActivity.kt
@@ -289,7 +289,6 @@ class MainActivity : ComponentActivity() {
     companion object {
         private const val KEY_REVIEW_AFTER_CAPTURE = "KEY_REVIEW_AFTER_CAPTURE"
 
-        private const val KEY_DEBUG_MODE = "KEY_DEBUG_MODE"
         const val KEY_DEBUG_SINGLE_LENS_MODE = "KEY_DEBUG_SINGLE_LENS_MODE"
         const val KEY_DISABLE_ANIMATIONS = "KEY_DISABLE_ANIMATIONS"
     }

--- a/app/src/main/java/com/google/jetpackcamera/MainActivity.kt
+++ b/app/src/main/java/com/google/jetpackcamera/MainActivity.kt
@@ -61,17 +61,18 @@ import androidx.tracing.Trace
 import com.google.jetpackcamera.MainActivityUiState.Loading
 import com.google.jetpackcamera.MainActivityUiState.Success
 import com.google.jetpackcamera.core.common.traceFirstFrameMainActivity
+import com.google.jetpackcamera.data.camera.CameraLaunchConfigProvider
 import com.google.jetpackcamera.model.CaptureEvent
 import com.google.jetpackcamera.model.DarkMode
 import com.google.jetpackcamera.model.DebugSettings
 import com.google.jetpackcamera.model.ExternalCaptureMode
 import com.google.jetpackcamera.model.ImageCaptureEvent
-import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.VideoCaptureEvent
 import com.google.jetpackcamera.ui.JcaApp
 import com.google.jetpackcamera.ui.components.capture.LocalDisableAnimations
 import com.google.jetpackcamera.ui.theme.JetpackCameraTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlin.collections.emptyList
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.collect
@@ -85,6 +86,7 @@ private const val TAG = "MainActivity"
  */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject lateinit var cameraLaunchConfigProvider: CameraLaunchConfigProvider
     private val viewModel: MainActivityViewModel by viewModels()
 
     @RequiresApi(Build.VERSION_CODES.M)
@@ -92,6 +94,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        cameraLaunchConfigProvider.setIntent(intent)
         var uiState: MainActivityUiState by mutableStateOf(Loading)
 
         lifecycleScope.launch {
@@ -178,38 +181,10 @@ class MainActivity : ComponentActivity() {
     }
 
     private val debugSettings: DebugSettings
-        get() = DebugSettings(
-            isDebugModeEnabled = intent?.getBooleanExtra(KEY_DEBUG_MODE, false) ?: false,
-            singleLensMode = intent?.getStringExtra(KEY_DEBUG_SINGLE_LENS_MODE)
-                ?.let {
-                    when (it.lowercase()) {
-                        "back" -> LensFacing.BACK
-                        "front" -> LensFacing.FRONT
-                        else -> {
-                            Log.e(
-                                TAG,
-                                "Invalid debug single lens mode argument: \"$it\". Valid values are \"FRONT\" or \"BACK\""
-                            )
-                            null
-                        }
-                    }
-                }
-        )
+        get() = cameraLaunchConfigProvider.config.value.debugSettings
 
     private val externalCaptureMode: ExternalCaptureMode
-        get() = intent?.action?.let { action ->
-            when (action) {
-                MediaStore.ACTION_IMAGE_CAPTURE -> ExternalCaptureMode.ImageCapture
-                MediaStore.ACTION_VIDEO_CAPTURE -> ExternalCaptureMode.VideoCapture
-                MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA ->
-                    ExternalCaptureMode.MultipleImageCapture
-
-                else -> {
-                    Log.w(TAG, "Ignoring external intent with unknown action: $action")
-                    ExternalCaptureMode.Standard
-                }
-            }
-        } ?: ExternalCaptureMode.Standard
+        get() = cameraLaunchConfigProvider.config.value.externalCaptureMode
 
     private val Intent.shouldReviewAfterCapture: Boolean
         get() = this.getBooleanExtra(KEY_REVIEW_AFTER_CAPTURE, false)

--- a/app/src/main/java/com/google/jetpackcamera/di/CameraModule.kt
+++ b/app/src/main/java/com/google/jetpackcamera/di/CameraModule.kt
@@ -26,9 +26,10 @@ import com.google.jetpackcamera.core.camera.lowlight.LowLightBoostFeatureKey
 import com.google.jetpackcamera.core.camera.postprocess.ImagePostProcessor
 import com.google.jetpackcamera.core.camera.postprocess.ImagePostProcessorFeatureKey
 import com.google.jetpackcamera.core.common.FilePathGenerator
+import com.google.jetpackcamera.data.camera.CameraLaunchConfigProvider
 import com.google.jetpackcamera.data.camera.CameraSystemRepository
 import com.google.jetpackcamera.data.camera.CameraXCameraSystemRepository
-import dagger.Binds
+import com.google.jetpackcamera.settings.SettingsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -37,55 +38,62 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import javax.inject.Provider
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Dagger [Module] for camera dependencies.
  */
 @Module
 @InstallIn(ActivityRetainedComponent::class)
-internal interface CameraModule {
+internal object CameraModule {
 
-    @Binds
+    @Provides
     @ActivityRetainedScoped
-    fun bindsCameraSystemRepository(
-        repository: CameraXCameraSystemRepository
-    ): CameraSystemRepository
+    fun providesCameraSystemRepository(
+        cameraXCameraSystemProvider: Provider<CameraXCameraSystem>,
+        settingsRepository: SettingsRepository,
+        launchConfigProvider: CameraLaunchConfigProvider,
+        @DefaultCoroutineScope scope: CoroutineScope
+    ): CameraSystemRepository = CameraXCameraSystemRepository(
+        cameraXCameraSystemProvider = cameraXCameraSystemProvider,
+        settingsRepository = settingsRepository,
+        launchConfigProvider = launchConfigProvider,
+        scope = scope
+    )
 
-    companion object {
-        @Provides
-        @ActivityRetainedScoped
-        fun providesCameraXCameraSystem(
-            @ApplicationContext context: Context,
-            @DefaultDispatcher defaultDispatcher: CoroutineDispatcher,
-            @IODispatcher ioDispatcher: CoroutineDispatcher,
-            @DefaultFilePathGenerator filePathGenerator: FilePathGenerator,
-            availabilityCheckers: Map<
-                LowLightBoostFeatureKey,
-                @JvmSuppressWildcards Provider<LowLightBoostAvailabilityChecker>
-                >,
-            effectProviders: Map<
-                LowLightBoostFeatureKey,
-                @JvmSuppressWildcards Provider<LowLightBoostEffectProvider>
-                >,
-            imagePostProcessors: Map<
-                ImagePostProcessorFeatureKey,
-                @JvmSuppressWildcards Provider<ImagePostProcessor>
-                >,
-            cameraEffectProviders: Map<
-                CameraEffectFeatureKey,
-                @JvmSuppressWildcards Provider<CameraEffectProvider>
-                >
-        ): CameraXCameraSystem {
-            return CameraXCameraSystem(
-                context as Application,
-                defaultDispatcher,
-                ioDispatcher,
-                filePathGenerator,
-                availabilityCheckers,
-                effectProviders,
-                imagePostProcessors,
-                cameraEffectProviders
-            )
-        }
+    @Provides
+    @ActivityRetainedScoped
+    fun providesCameraXCameraSystem(
+        @ApplicationContext context: Context,
+        @DefaultDispatcher defaultDispatcher: CoroutineDispatcher,
+        @IODispatcher ioDispatcher: CoroutineDispatcher,
+        @DefaultFilePathGenerator filePathGenerator: FilePathGenerator,
+        availabilityCheckers: Map<
+            LowLightBoostFeatureKey,
+            @JvmSuppressWildcards Provider<LowLightBoostAvailabilityChecker>
+            >,
+        effectProviders: Map<
+            LowLightBoostFeatureKey,
+            @JvmSuppressWildcards Provider<LowLightBoostEffectProvider>
+            >,
+        imagePostProcessors: Map<
+            ImagePostProcessorFeatureKey,
+            @JvmSuppressWildcards Provider<ImagePostProcessor>
+            >,
+        cameraEffectProviders: Map<
+            CameraEffectFeatureKey,
+            @JvmSuppressWildcards Provider<CameraEffectProvider>
+            >
+    ): CameraXCameraSystem {
+        return CameraXCameraSystem(
+            context as Application,
+            defaultDispatcher,
+            ioDispatcher,
+            filePathGenerator,
+            availabilityCheckers,
+            effectProviders,
+            imagePostProcessors,
+            cameraEffectProviders
+        )
     }
 }

--- a/data/camera/build.gradle.kts
+++ b/data/camera/build.gradle.kts
@@ -69,6 +69,7 @@ android {
 dependencies {
     implementation(libs.dagger.hilt.android)
     kapt(libs.dagger.hilt.compiler)
+    implementation(libs.camera.core)
     implementation(project(":core:camera"))
     implementation(project(":core:camera:low-light"))
     implementation(project(":core:camera:postprocess"))
@@ -76,6 +77,13 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":data:settings"))
     implementation(project(":core:settings"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(project(":core:camera:testing"))
+    testImplementation(project(":data:settings:testing"))
 }
 
 // Allow references to generated code

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraLaunchConfig.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraLaunchConfig.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.data.camera
+
+import android.content.Intent
+import android.provider.MediaStore
+import android.util.Log
+import com.google.jetpackcamera.model.DebugSettings
+import com.google.jetpackcamera.model.ExternalCaptureMode
+import com.google.jetpackcamera.model.LensFacing
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private const val TAG = "CameraLaunchConfig"
+const val KEY_DEBUG_MODE = "KEY_DEBUG_MODE"
+const val KEY_DEBUG_SINGLE_LENS_MODE = "KEY_DEBUG_SINGLE_LENS_MODE"
+
+/**
+ * Retained configuration options supplied at launch (such as from intent extras).
+ */
+data class CameraLaunchConfig(
+    val externalCaptureMode: ExternalCaptureMode = ExternalCaptureMode.Standard,
+    val debugSettings: DebugSettings = DebugSettings()
+)
+
+/**
+ * Parses [ExternalCaptureMode] from an [Intent].
+ */
+fun Intent.toExternalCaptureMode(): ExternalCaptureMode = when (action) {
+    MediaStore.ACTION_IMAGE_CAPTURE -> ExternalCaptureMode.ImageCapture
+    MediaStore.ACTION_VIDEO_CAPTURE -> ExternalCaptureMode.VideoCapture
+    MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA -> ExternalCaptureMode.MultipleImageCapture
+    else -> {
+        if (action != null) {
+            Log.w(TAG, "Ignoring external intent with unknown action: $action")
+        }
+        ExternalCaptureMode.Standard
+    }
+}
+
+/**
+ * Parses [DebugSettings] from an [Intent].
+ */
+fun Intent.toDebugSettings(): DebugSettings = DebugSettings(
+    isDebugModeEnabled = getBooleanExtra(KEY_DEBUG_MODE, false),
+    singleLensMode = getStringExtra(KEY_DEBUG_SINGLE_LENS_MODE)?.let {
+        when (it.lowercase()) {
+            "back" -> LensFacing.BACK
+            "front" -> LensFacing.FRONT
+            else -> {
+                Log.e(
+                    TAG,
+                    "Invalid debug single lens mode argument: \"$it\". Valid values are \"FRONT\" or \"BACK\""
+                )
+                null
+            }
+        }
+    }
+)
+
+/**
+ * Activity-retained provider that manages [CameraLaunchConfig] reactively.
+ */
+@ActivityRetainedScoped
+class CameraLaunchConfigProvider @Inject constructor() {
+    private val _config = MutableStateFlow(CameraLaunchConfig())
+    val config: StateFlow<CameraLaunchConfig> = _config.asStateFlow()
+
+    fun setIntent(intent: Intent?) {
+        if (intent == null) return
+        _config.value = CameraLaunchConfig(
+            externalCaptureMode = intent.toExternalCaptureMode(),
+            debugSettings = intent.toDebugSettings()
+        )
+    }
+
+    fun setConfig(config: CameraLaunchConfig) {
+        _config.value = config
+    }
+}

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraLaunchConfig.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraLaunchConfig.kt
@@ -80,8 +80,15 @@ fun Intent.toDebugSettings(): DebugSettings = DebugSettings(
 @ActivityRetainedScoped
 class CameraLaunchConfigProvider @Inject constructor() {
     private val _config = MutableStateFlow(CameraLaunchConfig())
+
+    /**
+     * The current [CameraLaunchConfig] state flow.
+     */
     val config: StateFlow<CameraLaunchConfig> = _config.asStateFlow()
 
+    /**
+     * Updates the configuration by parsing the provided [intent].
+     */
     fun setIntent(intent: Intent?) {
         if (intent == null) return
         _config.value = CameraLaunchConfig(
@@ -90,6 +97,9 @@ class CameraLaunchConfigProvider @Inject constructor() {
         )
     }
 
+    /**
+     * Directly sets a new [config] value.
+     */
     fun setConfig(config: CameraLaunchConfig) {
         _config.value = config
     }

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraLaunchConfig.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraLaunchConfig.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 private const val TAG = "CameraLaunchConfig"
-const val KEY_DEBUG_MODE = "KEY_DEBUG_MODE"
-const val KEY_DEBUG_SINGLE_LENS_MODE = "KEY_DEBUG_SINGLE_LENS_MODE"
+internal const val KEY_DEBUG_MODE = "KEY_DEBUG_MODE"
+internal const val KEY_DEBUG_SINGLE_LENS_MODE = "KEY_DEBUG_SINGLE_LENS_MODE"
 
 /**
  * Retained configuration options supplied at launch (such as from intent extras).
@@ -42,7 +42,7 @@ data class CameraLaunchConfig(
 /**
  * Parses [ExternalCaptureMode] from an [Intent].
  */
-fun Intent.toExternalCaptureMode(): ExternalCaptureMode = when (action) {
+internal fun Intent.toExternalCaptureMode(): ExternalCaptureMode = when (action) {
     MediaStore.ACTION_IMAGE_CAPTURE -> ExternalCaptureMode.ImageCapture
     MediaStore.ACTION_VIDEO_CAPTURE -> ExternalCaptureMode.VideoCapture
     MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA -> ExternalCaptureMode.MultipleImageCapture
@@ -57,7 +57,7 @@ fun Intent.toExternalCaptureMode(): ExternalCaptureMode = when (action) {
 /**
  * Parses [DebugSettings] from an [Intent].
  */
-fun Intent.toDebugSettings(): DebugSettings = DebugSettings(
+internal fun Intent.toDebugSettings(): DebugSettings = DebugSettings(
     isDebugModeEnabled = getBooleanExtra(KEY_DEBUG_MODE, false),
     singleLensMode = getStringExtra(KEY_DEBUG_SINGLE_LENS_MODE)?.let {
         when (it.lowercase()) {

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraSystemRepository.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraSystemRepository.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.StateFlow
  * Repository that manages camera system lifecycle, lazy initialization, and proxies camera data streams.
  */
 interface CameraSystemRepository {
-    val cameraSystem: CameraSystem
 
     /**
      * A [StateFlow] emitting the current [SurfaceRequest] when the camera is active.

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraSystemRepository.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraSystemRepository.kt
@@ -28,10 +28,29 @@ import kotlinx.coroutines.flow.StateFlow
 interface CameraSystemRepository {
     val cameraSystem: CameraSystem
 
+    /**
+     * A [StateFlow] emitting the current [SurfaceRequest] when the camera is active.
+     */
     val surfaceRequest: StateFlow<SurfaceRequest?>
+
+    /**
+     * A [StateFlow] emitting the current [CameraSystemConstraints] supported by the device.
+     */
     val systemConstraints: StateFlow<CameraSystemConstraints?>
+
+    /**
+     * A [StateFlow] emitting the current [CameraAppSettings].
+     */
     val currentSettings: StateFlow<CameraAppSettings?>
+
+    /**
+     * A [StateFlow] emitting the current [CameraState].
+     */
     val currentCameraState: StateFlow<CameraState>
+
+    /**
+     * A [StateFlow] emitting a JSON string representation of the camera properties.
+     */
     val cameraPropertiesJSON: StateFlow<String?>
 
     /**

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraSystemRepository.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraSystemRepository.kt
@@ -15,11 +15,32 @@
  */
 package com.google.jetpackcamera.data.camera
 
+import androidx.camera.core.SurfaceRequest
+import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.core.camera.CameraSystem
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
+import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Repository that holds an instance of [CameraSystem].
+ * Repository that manages camera system lifecycle, lazy initialization, and proxies camera data streams.
  */
 interface CameraSystemRepository {
     val cameraSystem: CameraSystem
+
+    val surfaceRequest: StateFlow<SurfaceRequest?>
+    val systemConstraints: StateFlow<CameraSystemConstraints?>
+    val currentSettings: StateFlow<CameraAppSettings?>
+    val currentCameraState: StateFlow<CameraState>
+    val cameraPropertiesJSON: StateFlow<String?>
+
+    /**
+     * Returns the initialized [CameraSystem], suspending until initialization completes.
+     */
+    suspend fun getCameraSystem(): CameraSystem
+
+    /**
+     * Returns supported MIME types once initialized.
+     */
+    suspend fun getSupportedMimeTypes(): List<String>
 }

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepository.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepository.kt
@@ -24,7 +24,6 @@ import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.applyExternalCaptureMode
 import com.google.jetpackcamera.settings.model.getSupportedMimeTypes
-import dagger.hilt.android.scopes.ActivityRetainedScoped
 import javax.inject.Provider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -42,7 +41,6 @@ import kotlinx.coroutines.flow.first
  * Implementation of [CameraSystemRepository] that manages [CameraXCameraSystem] initialization
  * and exposes camera streams.
  */
-@ActivityRetainedScoped
 class CameraXCameraSystemRepository(
     private val cameraXCameraSystemProvider: Provider<out CameraSystem>,
     private val settingsRepository: SettingsRepository,
@@ -62,7 +60,7 @@ class CameraXCameraSystemRepository(
         scope = scope
     )
 
-    override val cameraSystem: CameraSystem by lazy {
+    private val cameraSystem: CameraSystem by lazy {
         cameraXCameraSystemProvider.get()
     }
 

--- a/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepository.kt
+++ b/data/camera/src/main/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepository.kt
@@ -15,20 +15,95 @@
  */
 package com.google.jetpackcamera.data.camera
 
+import androidx.camera.core.SurfaceRequest
+import com.google.jetpackcamera.core.camera.CameraState
+import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.core.camera.CameraXCameraSystem
+import com.google.jetpackcamera.settings.SettingsRepository
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
+import com.google.jetpackcamera.settings.model.applyExternalCaptureMode
+import com.google.jetpackcamera.settings.model.getSupportedMimeTypes
 import dagger.hilt.android.scopes.ActivityRetainedScoped
-import javax.inject.Inject
 import javax.inject.Provider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 
 /**
- * Implementation of [CameraSystemRepository] that lazily constructs [CameraXCameraSystem].
+ * Implementation of [CameraSystemRepository] that manages [CameraXCameraSystem] initialization
+ * and exposes camera streams.
  */
 @ActivityRetainedScoped
-class CameraXCameraSystemRepository @Inject constructor(
-    private val cameraXCameraSystemProvider: Provider<CameraXCameraSystem>
+class CameraXCameraSystemRepository(
+    private val cameraXCameraSystemProvider: Provider<out CameraSystem>,
+    private val settingsRepository: SettingsRepository,
+    private val launchConfigProvider: CameraLaunchConfigProvider,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) : CameraSystemRepository {
 
-    override val cameraSystem: CameraXCameraSystem by lazy {
+    constructor(
+        cameraXCameraSystemProvider: Provider<out CameraSystem>,
+        settingsRepository: SettingsRepository,
+        launchConfig: CameraLaunchConfig = CameraLaunchConfig(),
+        scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    ) : this(
+        cameraXCameraSystemProvider = cameraXCameraSystemProvider,
+        settingsRepository = settingsRepository,
+        launchConfigProvider = CameraLaunchConfigProvider().apply { setConfig(launchConfig) },
+        scope = scope
+    )
+
+    override val cameraSystem: CameraSystem by lazy {
         cameraXCameraSystemProvider.get()
+    }
+
+    override val surfaceRequest: StateFlow<SurfaceRequest?> by lazy {
+        cameraSystem.getSurfaceRequest()
+    }
+
+    override val systemConstraints: StateFlow<CameraSystemConstraints?> by lazy {
+        cameraSystem.getSystemConstraints()
+    }
+
+    override val currentSettings: StateFlow<CameraAppSettings?> by lazy {
+        cameraSystem.getCurrentSettings()
+    }
+
+    override val currentCameraState: StateFlow<CameraState> by lazy {
+        cameraSystem.getCurrentCameraState()
+    }
+
+    private val _cameraPropertiesJSON = MutableStateFlow<String?>(null)
+    override val cameraPropertiesJSON: StateFlow<String?> = _cameraPropertiesJSON.asStateFlow()
+
+    private val initializationDeferred: Deferred<Unit> =
+        scope.async(start = CoroutineStart.LAZY) {
+            val launchConfig = launchConfigProvider.config.value
+            val initialSettings = settingsRepository.getCurrentDefaultCameraAppSettings()
+                .applyExternalCaptureMode(launchConfig.externalCaptureMode)
+                .copy(debugSettings = launchConfig.debugSettings)
+            cameraSystem.initialize(initialSettings) { properties ->
+                _cameraPropertiesJSON.value = properties
+            }
+        }
+
+    override suspend fun getCameraSystem(): CameraSystem {
+        initializationDeferred.await()
+        return cameraSystem
+    }
+
+    override suspend fun getSupportedMimeTypes(): List<String> {
+        initializationDeferred.await()
+        val constraints = systemConstraints.filterNotNull().first()
+        return constraints.getSupportedMimeTypes().values.flatten().distinct()
     }
 }

--- a/data/camera/src/test/java/com/google/jetpackcamera/data/camera/CameraLaunchConfigTest.kt
+++ b/data/camera/src/test/java/com/google/jetpackcamera/data/camera/CameraLaunchConfigTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.data.camera
+
+import android.content.Intent
+import android.provider.MediaStore
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.model.DebugSettings
+import com.google.jetpackcamera.model.ExternalCaptureMode
+import com.google.jetpackcamera.model.LensFacing
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CameraLaunchConfigTest {
+
+    @Test
+    fun defaultCameraLaunchConfig_hasDefaultValues() {
+        val config = CameraLaunchConfig()
+        assertThat(config.externalCaptureMode).isEqualTo(ExternalCaptureMode.Standard)
+        assertThat(config.debugSettings).isEqualTo(DebugSettings())
+    }
+
+    @Test
+    fun cameraLaunchConfigProvider_initiallyHasDefaultConfig() {
+        val provider = CameraLaunchConfigProvider()
+        assertThat(provider.config.value).isEqualTo(CameraLaunchConfig())
+    }
+
+    @Test
+    fun cameraLaunchConfigProvider_setConfig_updatesConfig() {
+        val provider = CameraLaunchConfigProvider()
+        val newConfig = CameraLaunchConfig(
+            externalCaptureMode = ExternalCaptureMode.ImageCapture,
+            debugSettings = DebugSettings(isDebugModeEnabled = true)
+        )
+        provider.setConfig(newConfig)
+        assertThat(provider.config.value).isEqualTo(newConfig)
+    }
+
+    @Test
+    fun toExternalCaptureMode_mapsIntentsCorrectly() {
+        assertThat(Intent(MediaStore.ACTION_IMAGE_CAPTURE).toExternalCaptureMode())
+            .isEqualTo(ExternalCaptureMode.ImageCapture)
+        assertThat(Intent(MediaStore.ACTION_VIDEO_CAPTURE).toExternalCaptureMode())
+            .isEqualTo(ExternalCaptureMode.VideoCapture)
+        assertThat(Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA).toExternalCaptureMode())
+            .isEqualTo(ExternalCaptureMode.MultipleImageCapture)
+        assertThat(Intent("UNKNOWN_ACTION").toExternalCaptureMode())
+            .isEqualTo(ExternalCaptureMode.Standard)
+        assertThat(Intent().toExternalCaptureMode())
+            .isEqualTo(ExternalCaptureMode.Standard)
+    }
+
+    @Test
+    fun toDebugSettings_mapsIntentsCorrectly() {
+        val intent = Intent().apply {
+            putExtra(KEY_DEBUG_MODE, true)
+            putExtra(KEY_DEBUG_SINGLE_LENS_MODE, "front")
+        }
+        val debugSettings = intent.toDebugSettings()
+        assertThat(debugSettings.isDebugModeEnabled).isTrue()
+        assertThat(debugSettings.singleLensMode).isEqualTo(LensFacing.FRONT)
+
+        val backIntent = Intent().apply {
+            putExtra(KEY_DEBUG_SINGLE_LENS_MODE, "back")
+        }
+        assertThat(backIntent.toDebugSettings().singleLensMode).isEqualTo(LensFacing.BACK)
+
+        val invalidIntent = Intent().apply {
+            putExtra(KEY_DEBUG_SINGLE_LENS_MODE, "invalid")
+        }
+        assertThat(invalidIntent.toDebugSettings().singleLensMode).isNull()
+    }
+
+    @Test
+    fun cameraLaunchConfigProvider_setIntent_updatesConfigFromIntent() {
+        val provider = CameraLaunchConfigProvider()
+        val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
+            putExtra(KEY_DEBUG_MODE, true)
+            putExtra(KEY_DEBUG_SINGLE_LENS_MODE, "back")
+        }
+        provider.setIntent(intent)
+
+        assertThat(provider.config.value).isEqualTo(
+            CameraLaunchConfig(
+                externalCaptureMode = ExternalCaptureMode.ImageCapture,
+                debugSettings = DebugSettings(
+                    isDebugModeEnabled = true,
+                    singleLensMode = LensFacing.BACK
+                )
+            )
+        )
+    }
+
+    @Test
+    fun cameraLaunchConfigProvider_setIntent_nullIntent_doesNotUpdate() {
+        val provider = CameraLaunchConfigProvider()
+        val originalConfig = provider.config.value
+        provider.setIntent(null)
+        assertThat(provider.config.value).isSameInstanceAs(originalConfig)
+    }
+}

--- a/data/camera/src/test/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepositoryTest.kt
+++ b/data/camera/src/test/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepositoryTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.data.camera
+
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.CameraSystem
+import com.google.jetpackcamera.core.camera.testing.FakeCameraSystem
+import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.DebugSettings
+import com.google.jetpackcamera.model.ExternalCaptureMode
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
+import com.google.jetpackcamera.settings.testing.FakeSettingsRepository
+import javax.inject.Provider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CameraXCameraSystemRepositoryTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private class TestCameraSystem(
+        private val delegate: FakeCameraSystem = FakeCameraSystem()
+    ) : CameraSystem by delegate {
+        var initializedSettings: CameraAppSettings? = null
+        var mockPropertiesJSON: String? = null
+
+        override suspend fun initialize(
+            cameraAppSettings: CameraAppSettings,
+            cameraPropertiesJSONCallback: (result: String) -> Unit
+        ) {
+            delegate.initialize(cameraAppSettings, cameraPropertiesJSONCallback)
+            delegate.setSystemConstraints(
+                CameraSystemConstraints(
+                    availableLenses = listOf(),
+                    concurrentCamerasSupported = false
+                )
+            )
+            initializedSettings = cameraAppSettings
+            mockPropertiesJSON?.let(cameraPropertiesJSONCallback)
+        }
+    }
+
+    @Test
+    fun getCameraSystem_lazilyInitializesCameraSystem() = testScope.runTest {
+        val testCamera = TestCameraSystem().apply {
+            mockPropertiesJSON = "{\"test\": true}"
+        }
+
+        val launchConfig = CameraLaunchConfig(
+            externalCaptureMode = ExternalCaptureMode.ImageCapture,
+            debugSettings = DebugSettings(isDebugModeEnabled = true)
+        )
+        val settingsRepository = FakeSettingsRepository()
+
+        val repository = CameraXCameraSystemRepository(
+            cameraXCameraSystemProvider = Provider { testCamera },
+            settingsRepository = settingsRepository,
+            launchConfig = launchConfig,
+            scope = testScope
+        )
+
+        // Before getCameraSystem is called, camera is not initialized
+        assertThat(testCamera.initializedSettings).isNull()
+        assertThat(repository.cameraPropertiesJSON.value).isNull()
+
+        // Calling getCameraSystem triggers lazy initialization
+        val cameraSystem = repository.getCameraSystem()
+        assertThat(cameraSystem).isEqualTo(testCamera)
+        assertThat(testCamera.initializedSettings).isNotNull()
+        assertThat(testCamera.initializedSettings?.captureMode).isEqualTo(CaptureMode.IMAGE_ONLY)
+        assertThat(testCamera.initializedSettings?.debugSettings?.isDebugModeEnabled).isTrue()
+        assertThat(repository.cameraPropertiesJSON.value).isEqualTo("{\"test\": true}")
+    }
+
+    @Test
+    fun getSupportedMimeTypes_initializesAndReturnsMimeTypes() = testScope.runTest {
+        val testCamera = TestCameraSystem()
+
+        val repository = CameraXCameraSystemRepository(
+            cameraXCameraSystemProvider = Provider { testCamera },
+            settingsRepository = FakeSettingsRepository(),
+            launchConfig = CameraLaunchConfig(),
+            scope = testScope
+        )
+
+        val mimeTypes = repository.getSupportedMimeTypes()
+        assertThat(mimeTypes).isNotNull()
+        assertThat(testCamera.initializedSettings).isNotNull()
+    }
+}

--- a/data/camera/src/test/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepositoryTest.kt
+++ b/data/camera/src/test/java/com/google/jetpackcamera/data/camera/CameraXCameraSystemRepositoryTest.kt
@@ -30,8 +30,11 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(JUnit4::class)
 class CameraXCameraSystemRepositoryTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -41,7 +41,6 @@ import com.google.jetpackcamera.model.VideoCaptureEvent
 import com.google.jetpackcamera.settings.SettableConstraintsRepository
 import com.google.jetpackcamera.settings.SettingsRepository
 import com.google.jetpackcamera.settings.model.CameraAppSettings
-import com.google.jetpackcamera.settings.model.applyExternalCaptureMode
 import com.google.jetpackcamera.ui.components.capture.R
 import com.google.jetpackcamera.ui.controller.CameraController
 import com.google.jetpackcamera.ui.controller.CaptureController
@@ -69,8 +68,6 @@ import com.google.jetpackcamera.ui.uistateadapter.capture.R as StateAdapterR
 import com.google.jetpackcamera.ui.uistateadapter.capture.compound.captureUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -79,7 +76,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -108,7 +104,7 @@ class PreviewViewModel @Inject constructor(
         _snackBarUiState.asStateFlow()
 
     val surfaceRequest: StateFlow<SurfaceRequest?> =
-        cameraSystemRepository.cameraSystem.getSurfaceRequest()
+        cameraSystemRepository.surfaceRequest
 
     private val outgoingCaptureEvents = Channel<CaptureEvent>(capacity = Channel.UNLIMITED)
     val captureEvents: ReceiveChannel<CaptureEvent> = outgoingCaptureEvents
@@ -120,29 +116,18 @@ class PreviewViewModel @Inject constructor(
 
     private val debugSettings: DebugSettings = savedStateHandle.getDebugSettings()
 
-    private var cameraPropertiesJSON = ""
-
     val screenFlashController: ScreenFlashController = ScreenFlashControllerImpl(
-        cameraSystem = cameraSystemRepository.cameraSystem,
+        cameraSystemProvider = cameraSystemRepository::getCameraSystem,
         trackedCaptureUiState = trackedCaptureUiState,
         coroutineContext = viewModelScope.coroutineContext
     )
 
-    // Eagerly initialize the CameraSystem and encapsulate in a Deferred that can be
-    // used to ensure we don't start the camera before initialization is complete.
-    private var initializationDeferred: Deferred<Unit> = viewModelScope.async {
-        cameraSystemRepository.cameraSystem.initialize(
-            cameraAppSettings = settingsRepository.defaultCameraAppSettings.first()
-                .applyExternalCaptureMode(externalCaptureMode)
-                .copy(debugSettings = debugSettings)
-        ) { cameraPropertiesJSON = it }
-    }
-
     val captureUiState: StateFlow<CaptureUiState> = captureUiState(
-        cameraSystemRepository.cameraSystem,
-        constraintsRepository,
-        trackedCaptureUiState,
-        externalCaptureMode
+        currentSettings = cameraSystemRepository.currentSettings,
+        systemConstraints = constraintsRepository.systemConstraints,
+        currentCameraState = cameraSystemRepository.currentCameraState,
+        trackedCaptureUiState = trackedCaptureUiState,
+        externalCaptureMode = externalCaptureMode
     )
         .stateIn(
             scope = viewModelScope,
@@ -150,11 +135,12 @@ class PreviewViewModel @Inject constructor(
             initialValue = CaptureUiState.NotReady
         )
     val debugUiState: StateFlow<DebugUiState> = debugUiState(
-        cameraSystemRepository.cameraSystem,
-        constraintsRepository,
-        debugSettings,
-        cameraPropertiesJSON,
-        trackedCaptureUiState
+        currentSettings = cameraSystemRepository.currentSettings,
+        systemConstraints = constraintsRepository.systemConstraints,
+        currentCameraState = cameraSystemRepository.currentCameraState,
+        debugSettings = debugSettings,
+        cameraPropertiesJSON = cameraSystemRepository.cameraPropertiesJSON,
+        trackedCaptureUiState = trackedCaptureUiState
     )
         .stateIn(
             scope = viewModelScope,
@@ -167,7 +153,7 @@ class PreviewViewModel @Inject constructor(
      */
     val quickSettingsController: QuickSettingsController = QuickSettingsControllerImpl(
         trackedCaptureUiState = trackedCaptureUiState,
-        cameraSystem = cameraSystemRepository.cameraSystem,
+        cameraSystemProvider = cameraSystemRepository::getCameraSystem,
         coroutineContext = viewModelScope.coroutineContext
     )
 
@@ -175,8 +161,9 @@ class PreviewViewModel @Inject constructor(
      * Controller for toggling and configuring debug features.
      */
     val debugController: DebugController = DebugControllerImpl(
-        cameraSystem = cameraSystemRepository.cameraSystem,
-        trackedCaptureUiState = trackedCaptureUiState
+        cameraSystemProvider = cameraSystemRepository::getCameraSystem,
+        trackedCaptureUiState = trackedCaptureUiState,
+        coroutineContext = viewModelScope.coroutineContext
     )
 
     /**
@@ -191,7 +178,7 @@ class PreviewViewModel @Inject constructor(
      * Controller for managing zoom operations and animations.
      */
     val zoomController: ZoomController = ZoomControllerImpl(
-        cameraSystem = cameraSystemRepository.cameraSystem,
+        cameraSystemProvider = cameraSystemRepository::getCameraSystem,
         trackedCaptureUiState = trackedCaptureUiState
     )
 
@@ -208,15 +195,14 @@ class PreviewViewModel @Inject constructor(
     )
 
     val cameraController: CameraController = CameraControllerImpl(
-        initializationDeferred = initializationDeferred,
+        cameraSystemProvider = cameraSystemRepository::getCameraSystem,
         captureUiState = captureUiState,
-        coroutineContext = viewModelScope.coroutineContext,
-        cameraSystem = cameraSystemRepository.cameraSystem
+        coroutineContext = viewModelScope.coroutineContext
     )
 
     val captureController: CaptureController = CaptureControllerImpl(
         trackedCaptureUiState = trackedCaptureUiState,
-        cameraSystem = cameraSystemRepository.cameraSystem,
+        cameraSystemProvider = cameraSystemRepository::getCameraSystem,
         saveMode = saveMode,
         externalCaptureMode = externalCaptureMode,
         externalCapturesCallback = {
@@ -256,7 +242,7 @@ class PreviewViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             launch {
-                cameraSystemRepository.cameraSystem.getSystemConstraints()
+                cameraSystemRepository.systemConstraints
                     .filterNotNull()
                     .collect { constraints ->
                         constraintsRepository.updateSystemConstraints(constraints)
@@ -268,14 +254,14 @@ class PreviewViewModel @Inject constructor(
                 settingsRepository.defaultCameraAppSettings
                     .collect { new ->
                         oldCameraAppSettings?.apply {
-                            applyDiffs(new, cameraSystemRepository.cameraSystem)
+                            applyDiffs(new, cameraSystemRepository.getCameraSystem())
                         }
                         oldCameraAppSettings = new
                     }
             }
 
             launch {
-                cameraSystemRepository.cameraSystem.getCurrentCameraState()
+                cameraSystemRepository.currentCameraState
                     .map { it.lowLightBoostState }
                     .distinctUntilChanged()
                     .collect { state ->

--- a/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
+++ b/feature/preview/src/main/java/com/google/jetpackcamera/feature/preview/PreviewViewModel.kt
@@ -179,7 +179,8 @@ class PreviewViewModel @Inject constructor(
      */
     val zoomController: ZoomController = ZoomControllerImpl(
         cameraSystemProvider = cameraSystemRepository::getCameraSystem,
-        trackedCaptureUiState = trackedCaptureUiState
+        trackedCaptureUiState = trackedCaptureUiState,
+        coroutineContext = viewModelScope.coroutineContext
     )
 
     val imageWellController: ImageWellController = ImageWellControllerImpl(

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -55,7 +55,6 @@ class PreviewViewModelTest {
 
     private val cameraSystem = FakeCameraSystem()
     private val cameraSystemRepository = object : CameraSystemRepository {
-        override val cameraSystem = this@PreviewViewModelTest.cameraSystem
         override val surfaceRequest = cameraSystem.getSurfaceRequest()
         override val systemConstraints = cameraSystem.getSystemConstraints()
         override val currentSettings = cameraSystem.getCurrentSettings()

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.core.camera.testing.FakeCameraSystem
 import com.google.jetpackcamera.data.camera.CameraSystemRepository
 import com.google.jetpackcamera.data.media.testing.FakeMediaRepository
@@ -27,6 +28,7 @@ import com.google.jetpackcamera.model.FlashMode
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.SaveMode
 import com.google.jetpackcamera.settings.SettableConstraintsRepositoryImpl
+import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.TYPICAL_SYSTEM_CONSTRAINTS
 import com.google.jetpackcamera.settings.testing.FakeSettingsRepository
 import com.google.jetpackcamera.ui.uistate.capture.FlashModeUiState
@@ -35,6 +37,8 @@ import com.google.jetpackcamera.ui.uistate.capture.compound.CaptureUiState
 import com.google.jetpackcamera.ui.uistate.capture.compound.QuickSettingsUiState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -52,6 +56,17 @@ class PreviewViewModelTest {
     private val cameraSystem = FakeCameraSystem()
     private val cameraSystemRepository = object : CameraSystemRepository {
         override val cameraSystem = this@PreviewViewModelTest.cameraSystem
+        override val surfaceRequest = cameraSystem.getSurfaceRequest()
+        override val systemConstraints = cameraSystem.getSystemConstraints()
+        override val currentSettings = cameraSystem.getCurrentSettings()
+        override val currentCameraState = cameraSystem.getCurrentCameraState()
+        override val cameraPropertiesJSON: StateFlow<String?> = MutableStateFlow(null)
+
+        override suspend fun getCameraSystem(): CameraSystem {
+            cameraSystem.initialize(CameraAppSettings()) {}
+            return cameraSystem
+        }
+        override suspend fun getSupportedMimeTypes(): List<String> = emptyList()
     }
     private val constraintsRepository = SettableConstraintsRepositoryImpl().apply {
         updateSystemConstraints(TYPICAL_SYSTEM_CONSTRAINTS)

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CameraControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CameraControllerImpl.kt
@@ -26,7 +26,6 @@ import com.google.jetpackcamera.ui.uistate.capture.compound.CaptureUiState
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
@@ -39,20 +38,19 @@ private const val TAG = "CameraControllerImpl"
 /**
  * Implementation of [CameraController] that manages the camera lifecycle.
  *
- * @param initializationDeferred A [Deferred] that completes when the camera system is initialized.
+ * @param cameraSystemProvider Provider for the initialized [CameraSystem].
  * @param captureUiState The [StateFlow] of the capture UI state.
  * @param coroutineContext The [CoroutineContext] for launching coroutines.
- * @param cameraSystem The [com.google.jetpackcamera.core.camera.CameraSystem] to interact with.
  */
 class CameraControllerImpl(
-    private val initializationDeferred: Deferred<Unit>,
+    private val cameraSystemProvider: suspend () -> CameraSystem,
     private val captureUiState: StateFlow<CaptureUiState>,
-    private val cameraSystem: CameraSystem,
     coroutineContext: CoroutineContext
 ) : CameraController {
     private var runningCameraJob: Job? = null
     private val job = Job(parent = coroutineContext[Job])
     private val scope = CoroutineScope(coroutineContext + job)
+
     override fun startCamera() {
         Log.d(TAG, "startCamera")
         stopCamera()
@@ -75,7 +73,7 @@ class CameraControllerImpl(
                 }
             }
             // Ensure CameraSystem is initialized before starting camera
-            initializationDeferred.await()
+            val cameraSystem = cameraSystemProvider()
             // TODO(yasith): Handle Exceptions from binding use cases
             cameraSystem.runCamera()
         }
@@ -93,13 +91,13 @@ class CameraControllerImpl(
     override fun tapToFocus(x: Float, y: Float) {
         Log.d(TAG, "tapToFocus")
         scope.launch {
-            cameraSystem.tapToFocus(x, y)
+            cameraSystemProvider().tapToFocus(x, y)
         }
     }
 
     override fun setDisplayRotation(deviceRotation: DeviceRotation) {
         scope.launch {
-            cameraSystem.setDeviceRotation(deviceRotation)
+            cameraSystemProvider().setDeviceRotation(deviceRotation)
         }
     }
 

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -51,7 +51,7 @@ private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
  * Implementation of [CaptureController] that interacts with [CameraSystem].
  *
  * @param trackedCaptureUiState State for tracking UI changes during capture.
- * @param cameraSystem The camera system to perform capture operations.
+ * @param cameraSystemProvider Provider for the initialized [CameraSystem].
  * @param saveMode Mode for saving captured media.
  * @param externalCaptureMode Mode for external capture requests.
  * @param externalCapturesCallback Callback for getting external capture information.

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImpl.kt
@@ -63,7 +63,7 @@ private const val IMAGE_CAPTURE_TRACE = "JCA Image Capture"
  */
 class CaptureControllerImpl(
     private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
-    private val cameraSystem: CameraSystem,
+    private val cameraSystemProvider: suspend () -> CameraSystem,
     private val saveMode: SaveMode,
     private val externalCaptureMode: ExternalCaptureMode,
     private val externalCapturesCallback: () -> Pair<SaveLocation, IntProgress?>,
@@ -95,7 +95,7 @@ class CaptureControllerImpl(
             captureImageInternal(
                 saveLocation = saveLocation,
                 doTakePicture = {
-                    cameraSystem.takePicture(contentResolver, saveLocation) {
+                    cameraSystemProvider().takePicture(contentResolver, saveLocation) {
                         trackedCaptureUiState.update { old ->
                             old.copy(lastBlinkTimeStamp = System.currentTimeMillis())
                         }
@@ -147,7 +147,7 @@ class CaptureControllerImpl(
                 externalCapturesCallback
             )
             try {
-                cameraSystem.startVideoRecording(saveLocation) {
+                cameraSystemProvider().startVideoRecording(saveLocation) {
                     when (it) {
                         is OnVideoRecordEvent.OnVideoRecorded -> {
                             Log.d(TAG, "cameraSystem.startRecording OnVideoRecorded")
@@ -184,7 +184,7 @@ class CaptureControllerImpl(
         recordingJob?.cancel()
         recordingJob = null
         scope.launch {
-            cameraSystem.stopVideoRecording()
+            cameraSystemProvider().stopVideoRecording()
         }
     }
 
@@ -216,16 +216,16 @@ class CaptureControllerImpl(
     override fun setPaused(shouldBePaused: Boolean) {
         scope.launch {
             if (shouldBePaused) {
-                cameraSystem.pauseVideoRecording()
+                cameraSystemProvider().pauseVideoRecording()
             } else {
-                cameraSystem.resumeVideoRecording()
+                cameraSystemProvider().resumeVideoRecording()
             }
         }
     }
 
     override fun setAudioEnabled(shouldEnableAudio: Boolean) {
         scope.launch {
-            cameraSystem.setAudioEnabled(shouldEnableAudio)
+            cameraSystemProvider().setAudioEnabled(shouldEnableAudio)
         }
 
         Log.d(

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/QuickSettingsControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/QuickSettingsControllerImpl.kt
@@ -38,16 +38,17 @@ import kotlinx.coroutines.launch
  * [trackedCaptureUiState].
  *
  * @param trackedCaptureUiState The state flow to update with quick settings information.
- * @param cameraSystem The camera system to control.
+ * @param cameraSystemProvider The suspending provider for the [CameraSystem].
  * @param coroutineContext The [CoroutineContext] for launching coroutines.
  */
 class QuickSettingsControllerImpl(
     private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
-    private val cameraSystem: CameraSystem,
+    private val cameraSystemProvider: suspend () -> CameraSystem,
     coroutineContext: CoroutineContext
 ) : QuickSettingsController {
     private val job = Job(parent = coroutineContext[Job.Key])
     private val scope = CoroutineScope(coroutineContext + job)
+
     override fun toggleQuickSettings() {
         trackedCaptureUiState.update { old ->
             old.copy(isQuickSettingsOpen = !old.isQuickSettingsOpen)
@@ -57,38 +58,38 @@ class QuickSettingsControllerImpl(
     override fun setLensFacing(lensFace: LensFacing) {
         scope.launch {
             // apply to cameraSystem
-            cameraSystem.setLensFacing(lensFace)
+            cameraSystemProvider().setLensFacing(lensFace)
         }
     }
 
     override fun setFlash(flashMode: FlashMode) {
         scope.launch {
             // apply to cameraSystem
-            cameraSystem.setFlashMode(flashMode)
+            cameraSystemProvider().setFlashMode(flashMode)
         }
     }
 
     override fun setAspectRatio(aspectRatio: AspectRatio) {
         scope.launch {
-            cameraSystem.setAspectRatio(aspectRatio)
+            cameraSystemProvider().setAspectRatio(aspectRatio)
         }
     }
 
     override fun setDynamicRange(dynamicRange: DynamicRange) {
         scope.launch {
-            cameraSystem.setDynamicRange(dynamicRange)
+            cameraSystemProvider().setDynamicRange(dynamicRange)
         }
     }
 
     override fun setImageFormat(imageOutputFormat: ImageOutputFormat) {
         scope.launch {
-            cameraSystem.setImageFormat(imageOutputFormat)
+            cameraSystemProvider().setImageFormat(imageOutputFormat)
         }
     }
 
     override fun setCaptureMode(captureMode: CaptureMode) {
         scope.launch {
-            cameraSystem.setCaptureMode(captureMode)
+            cameraSystemProvider().setCaptureMode(captureMode)
         }
     }
 

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/ScreenFlashControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/ScreenFlashControllerImpl.kt
@@ -31,12 +31,12 @@ import kotlinx.coroutines.launch
 /**
  * Implementation of [ScreenFlashController] that handles screen flash actions.
  *
- * @param cameraSystem The [CameraSystem] for accessing camera events.
+ * @param cameraSystemProvider Provider for the initialized [CameraSystem].
  * @param trackedCaptureUiState The [MutableStateFlow] of [TrackedCaptureUiState] to update the flash state.
  * @param coroutineContext The [CoroutineContext] for launching coroutines.
  */
 class ScreenFlashControllerImpl(
-    private val cameraSystem: CameraSystem,
+    private val cameraSystemProvider: suspend () -> CameraSystem,
     private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
     coroutineContext: CoroutineContext
 ) : ScreenFlashController {
@@ -45,7 +45,7 @@ class ScreenFlashControllerImpl(
 
     init {
         scope.launch {
-            for (event in cameraSystem.getScreenFlashEvents()) {
+            for (event in cameraSystemProvider().getScreenFlashEvents()) {
                 trackedCaptureUiState.update { old ->
                     val oldFlashState = old.screenFlashUiState
                     old.copy(

--- a/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/ZoomControllerImpl.kt
+++ b/ui/controller/impl/src/main/java/com/google/jetpackcamera/ui/controller/impl/ZoomControllerImpl.kt
@@ -19,24 +19,35 @@ import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.model.CameraZoomRatio
 import com.google.jetpackcamera.ui.controller.ZoomController
 import com.google.jetpackcamera.ui.uistate.capture.TrackedCaptureUiState
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 /**
  * Implementation of [ZoomController] that updates the camera's zoom and tracked UI state.
  *
- * @param cameraSystem The camera system to update zoom on.
+ * @param cameraSystemProvider Provider for the initialized [CameraSystem].
  * @param trackedCaptureUiState State for tracking zoom changes.
+ * @param coroutineContext The [CoroutineContext] for launching coroutines.
  */
 class ZoomControllerImpl(
-    private val cameraSystem: CameraSystem,
-    private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>
+    private val cameraSystemProvider: suspend () -> CameraSystem,
+    private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
+    coroutineContext: CoroutineContext = Dispatchers.Main.immediate
 ) : ZoomController {
+    private val job = Job(parent = coroutineContext[Job])
+    private val scope = CoroutineScope(coroutineContext + job)
 
     override fun setZoomRatio(zoomRatio: CameraZoomRatio) {
-        cameraSystem.changeZoomRatio(
-            newZoomState = zoomRatio
-        )
+        scope.launch {
+            cameraSystemProvider().changeZoomRatio(
+                newZoomState = zoomRatio
+            )
+        }
     }
 
     override fun setZoomAnimationState(targetValue: Float?) {

--- a/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImplTest.kt
+++ b/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/CaptureControllerImplTest.kt
@@ -90,7 +90,7 @@ class CaptureControllerImplTest {
     ): CaptureControllerImpl {
         return CaptureControllerImpl(
             trackedCaptureUiState = trackedCaptureUiState,
-            cameraSystem = testCameraSystem,
+            cameraSystemProvider = { testCameraSystem },
             saveMode = saveMode,
             externalCaptureMode = externalCaptureMode,
             externalCapturesCallback = externalCapturesCallback,

--- a/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/QuickSettingsControllerImplTest.kt
+++ b/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/QuickSettingsControllerImplTest.kt
@@ -49,7 +49,7 @@ internal class QuickSettingsControllerImplTest {
     fun setup() {
         controller = QuickSettingsControllerImpl(
             trackedCaptureUiState = trackedCaptureUiState,
-            cameraSystem = cameraSystem,
+            cameraSystemProvider = { cameraSystem },
             coroutineContext = testDispatcher
         )
     }

--- a/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/ScreenFlashControllerImplTest.kt
+++ b/ui/controller/impl/src/test/java/com/google/jetpackcamera/ui/controller/impl/ScreenFlashControllerImplTest.kt
@@ -66,9 +66,9 @@ class ScreenFlashControllerImplTest {
     @Before
     fun setup() = runTest(testDispatcher) {
         screenFlash = ScreenFlashControllerImpl(
-            cameraSystem,
-            trackedCaptureUiState,
-            testScope.coroutineContext
+            cameraSystemProvider = { cameraSystem },
+            trackedCaptureUiState = trackedCaptureUiState,
+            coroutineContext = testScope.coroutineContext
         )
     }
 

--- a/ui/debug/src/main/java/com/google/jetpackcamera/ui/debug/DebugControllerImpl.kt
+++ b/ui/debug/src/main/java/com/google/jetpackcamera/ui/debug/DebugControllerImpl.kt
@@ -18,20 +18,30 @@ package com.google.jetpackcamera.ui.debug
 import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.model.TestPattern
 import com.google.jetpackcamera.ui.uistate.capture.TrackedCaptureUiState
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 /**
  * Implementation of [DebugController] that interacts with [CameraSystem] and updates
  * [trackedCaptureUiState].
  *
- * @param cameraSystem The camera system to control.
+ * @param cameraSystemProvider Provider for the initialized [CameraSystem].
  * @param trackedCaptureUiState The state flow to update with debug information.
+ * @param coroutineContext The [CoroutineContext] for launching coroutines.
  */
 class DebugControllerImpl(
-    private val cameraSystem: CameraSystem,
-    private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>
+    private val cameraSystemProvider: suspend () -> CameraSystem,
+    private val trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
+    coroutineContext: CoroutineContext = Dispatchers.Main.immediate
 ) : DebugController {
+    private val job = Job(parent = coroutineContext[Job])
+    private val scope = CoroutineScope(coroutineContext + job)
+
     override fun toggleDebugHidingComponents() {
         trackedCaptureUiState.update { old ->
             old.copy(debugHidingComponents = !old.debugHidingComponents)
@@ -45,8 +55,10 @@ class DebugControllerImpl(
     }
 
     override fun setTestPattern(testPattern: TestPattern) {
-        cameraSystem.setTestPattern(
-            newTestPattern = testPattern
-        )
+        scope.launch {
+            cameraSystemProvider().setTestPattern(
+                newTestPattern = testPattern
+            )
+        }
     }
 }

--- a/ui/debug/src/main/java/com/google/jetpackcamera/ui/debug/DebugUiStateAdapter.kt
+++ b/ui/debug/src/main/java/com/google/jetpackcamera/ui/debug/DebugUiStateAdapter.kt
@@ -17,19 +17,18 @@ package com.google.jetpackcamera.ui.debug
 
 import android.util.Size
 import com.google.jetpackcamera.core.camera.CameraState
-import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.model.DebugSettings
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.TestPattern
-import com.google.jetpackcamera.settings.ConstraintsRepository
 import com.google.jetpackcamera.settings.model.CameraAppSettings
 import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.settings.model.forCurrentLens
 import com.google.jetpackcamera.ui.uistate.capture.TrackedCaptureUiState
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * Creates a [Flow] of [DebugUiState] for the debug overlay.
@@ -38,29 +37,32 @@ import kotlinx.coroutines.flow.filterNotNull
  * that drives the UI of the debug information overlay. It reacts to changes in camera settings,
  * system constraints, camera state, and user interactions with the debug UI.
  *
- * @param cameraSystem The [CameraSystem] providing real-time camera state and settings.
- * @param constraintsRepository The [ConstraintsRepository] for accessing system-wide constraints.
+ * @param currentSettings A [Flow] of the current camera app settings.
+ * @param systemConstraints A [StateFlow] of the current camera system constraints.
+ * @param currentCameraState A [StateFlow] of the current camera state.
  * @param debugSettings The current debug-specific settings.
- * @param cameraPropertiesJSON A JSON string containing detailed camera properties for display.
- * @param trackedCaptureUiState A [MutableStateFlow] representing user-interacted UI state,
+ * @param cameraPropertiesJSON A [Flow] of JSON string containing detailed camera properties for display.
+ * @param trackedCaptureUiState A [StateFlow] representing user-interacted UI state,
  * such as whether the debug overlay is open.
  *
  * @return A [Flow] that emits a new [DebugUiState] whenever any of its underlying data
  * sources change.
  */
 fun debugUiState(
-    cameraSystem: CameraSystem,
-    constraintsRepository: ConstraintsRepository,
+    currentSettings: Flow<CameraAppSettings?>,
+    systemConstraints: StateFlow<CameraSystemConstraints?>,
+    currentCameraState: StateFlow<CameraState>,
     debugSettings: DebugSettings,
-    cameraPropertiesJSON: String,
-    trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>
+    cameraPropertiesJSON: Flow<String?> = flowOf(null),
+    trackedCaptureUiState: StateFlow<TrackedCaptureUiState>
 ): Flow<DebugUiState> {
     return combine(
-        cameraSystem.getCurrentSettings().filterNotNull(),
-        constraintsRepository.systemConstraints.filterNotNull(),
-        cameraSystem.getCurrentCameraState(),
+        currentSettings.filterNotNull(),
+        systemConstraints.filterNotNull(),
+        currentCameraState,
+        cameraPropertiesJSON,
         trackedCaptureUiState
-    ) { cameraAppSettings, systemConstraints, cameraState, trackedUiState ->
+    ) { cameraAppSettings, systemConstraints, cameraState, propertiesJSON, trackedUiState ->
         DebugUiState.from(
             systemConstraints,
             cameraAppSettings,
@@ -68,7 +70,7 @@ fun debugUiState(
             trackedUiState.isDebugOverlayOpen,
             trackedUiState.debugHidingComponents,
             debugSettings,
-            cameraPropertiesJSON
+            propertiesJSON ?: ""
         )
     }
 }

--- a/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/compound/CaptureUiStateAdapter.kt
+++ b/ui/uistateadapter/capture/src/main/java/com/google/jetpackcamera/ui/uistateadapter/capture/compound/CaptureUiStateAdapter.kt
@@ -15,10 +15,11 @@
  */
 package com.google.jetpackcamera.ui.uistateadapter.capture.compound
 
-import com.google.jetpackcamera.core.camera.CameraSystem
+import com.google.jetpackcamera.core.camera.CameraState
 import com.google.jetpackcamera.core.camera.VideoRecordingState
 import com.google.jetpackcamera.model.ExternalCaptureMode
-import com.google.jetpackcamera.settings.ConstraintsRepository
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.CameraSystemConstraints
 import com.google.jetpackcamera.ui.uistate.capture.AspectRatioUiState
 import com.google.jetpackcamera.ui.uistate.capture.AudioUiState
 import com.google.jetpackcamera.ui.uistate.capture.CaptureButtonUiState
@@ -42,7 +43,7 @@ import com.google.jetpackcamera.ui.uistateadapter.capture.from
 import com.google.jetpackcamera.ui.uistateadapter.capture.updateFrom
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 
@@ -52,9 +53,10 @@ import kotlinx.coroutines.flow.filterNotNull
  * This function acts as a central adapter to transform low-level camera and UI states into a
  * comprehensive [CaptureUiState] that the UI can directly observe and react to.
  *
- * @param cameraSystem The [CameraSystem] providing real-time camera state and settings.
- * @param constraintsRepository The [ConstraintsRepository] for accessing system-wide constraints.
- * @param trackedCaptureUiState A [MutableStateFlow] representing the user-interacted UI state that
+ * @param currentSettings A [Flow] of the current camera app settings.
+ * @param systemConstraints A [StateFlow] of the current camera system constraints.
+ * @param currentCameraState A [StateFlow] of the current camera state.
+ * @param trackedCaptureUiState A [StateFlow] representing the user-interacted UI state that
  * needs to be tracked across recompositions (e.g., whether quick settings is open).
  * @param externalCaptureMode The [ExternalCaptureMode] influencing UI behavior based on how the
  * camera is launched (e.g., from an external intent).
@@ -64,9 +66,10 @@ import kotlinx.coroutines.flow.filterNotNull
  * data sources change.
  */
 fun captureUiState(
-    cameraSystem: CameraSystem,
-    constraintsRepository: ConstraintsRepository,
-    trackedCaptureUiState: MutableStateFlow<TrackedCaptureUiState>,
+    currentSettings: Flow<CameraAppSettings?>,
+    systemConstraints: StateFlow<CameraSystemConstraints?>,
+    currentCameraState: StateFlow<CameraState>,
+    trackedCaptureUiState: StateFlow<TrackedCaptureUiState>,
     externalCaptureMode: ExternalCaptureMode,
     timePrecision: TimeUnit = TimeUnit.SECONDS
 ): Flow<CaptureUiState> {
@@ -74,9 +77,9 @@ fun captureUiState(
     var focusMeteringUiState: FocusMeteringUiState? = null
 
     return combine(
-        cameraSystem.getCurrentSettings().filterNotNull(),
-        constraintsRepository.systemConstraints.filterNotNull(),
-        cameraSystem.getCurrentCameraState(),
+        currentSettings.filterNotNull(),
+        systemConstraints.filterNotNull(),
+        currentCameraState,
         trackedCaptureUiState
     ) { cameraAppSettings, systemConstraints, cameraState, trackedUiState ->
         val videoRecordingState = cameraState.videoRecordingState

--- a/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/CaptureUiStateAdapterTest.kt
+++ b/ui/uistateadapter/capture/src/test/java/com/google/jetpackcamera/ui/uistateadapter/capture/CaptureUiStateAdapterTest.kt
@@ -57,8 +57,9 @@ internal class CaptureUiStateAdapterTest {
     private val externalCaptureMode = ExternalCaptureMode.Standard
 
     private fun createCaptureUiStateFlow() = captureUiState(
-        cameraSystem = cameraSystem,
-        constraintsRepository = constraintsRepository,
+        currentSettings = cameraSystem.getCurrentSettings(),
+        systemConstraints = constraintsRepository.systemConstraints,
+        currentCameraState = cameraSystem.getCurrentCameraState(),
         trackedCaptureUiState = trackedCaptureUiState,
         externalCaptureMode = externalCaptureMode
     )


### PR DESCRIPTION
### Description
Refactor JCA action controllers (`CameraControllerImpl`, `ZoomControllerImpl`, `QuickSettingsControllerImpl`, `CaptureControllerImpl`, `ScreenFlashControllerImpl`, and `DebugControllerImpl`) to accept a suspending `cameraSystemProvider` dependency provider to eliminate temporal coupling between uninitialized CameraSystem instances and initialization deferreds.

Move `initializationDeferred`, lazy self-initialization, and `getCameraSystem()` into `CameraSystemRepository` along with stream proxies (`surfaceRequest`, `systemConstraints`, `currentSettings`, `currentCameraState`, `cameraPropertiesJSON`) to match CameraSystemManager architecture.

Introduce `CameraLaunchConfig` in `ActivityRetainedScope` to hold launch intent extras (`externalCaptureMode`, `debugSettings`) and self-initialize `CameraSystemRepository` lazily via `CoroutineStart.LAZY` on demand.

Remove manual `cameraSystemRepository.initialize` call from `PreviewViewModel.init`, completely decoupling the UI layer from hardware lifecycle management.

Update `captureUiState` and `debugUiState` to accept Settings, Constraints, and CameraState flows directly rather than requiring full `ConstraintsRepository` or `CameraSystem` instances.

Update `PreviewViewModel` and unit tests across JCA to use the new provider and stream-based signatures directly, eliminating legacy constructors and tech debt.

### Testing
- `./gradlew test`
- `./gradlew spotlessCheck`
- `./gradlew assembleDebug`