### PR TITLE
Bugfix: Propagate dynamic range and image format diffs to CameraSystem

### DIFF
--- a/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraSystemApplyDiffsDeviceTest.kt
+++ b/core/camera/src/androidTest/java/com/google/jetpackcamera/core/camera/CameraSystemApplyDiffsDeviceTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import android.app.Application
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import com.google.common.truth.Truth.assertWithMessage
+import com.google.common.truth.TruthJUnit.assume
+import com.google.jetpackcamera.core.camera.CameraSystem.Companion.applyDiffs
+import com.google.jetpackcamera.core.camera.utils.APP_REQUIRED_PERMISSIONS
+import com.google.jetpackcamera.core.camera.utils.provideUpdatingSurface
+import com.google.jetpackcamera.core.common.testing.FakeFilePathGenerator
+import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.DynamicRange
+import com.google.jetpackcamera.model.ImageOutputFormat
+import com.google.jetpackcamera.model.LensFacing
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import com.google.jetpackcamera.settings.model.DEFAULT_CAMERA_APP_SETTINGS
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.produceIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Instrumented tests for [CameraAppSettings.applyDiffs] executing across all available lenses
+ * with the [Parameterized] test runner.
+ *
+ * Each test runs independently per lens and skips gracefully via [assume] if the target device
+ * or lens does not support the setting.
+ */
+@LargeTest
+@RunWith(Parameterized::class)
+class CameraSystemApplyDiffsDeviceTest(private val lensFacing: LensFacing) {
+
+    companion object {
+        private const val CAMERA_START_TIMEOUT_MS = 10_000L
+        private const val GENERAL_TIMEOUT_MS = 3_000L
+
+        /**
+         * Provides the camera lens orientations to test.
+         */
+        @JvmStatic
+        @Parameterized.Parameters(name = "lensFacing={0}")
+        fun data(): Array<LensFacing> = arrayOf(LensFacing.BACK, LensFacing.FRONT)
+    }
+
+    @get:Rule
+    val permissionsRule: GrantPermissionRule =
+        GrantPermissionRule.grant(*(APP_REQUIRED_PERMISSIONS).toTypedArray())
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = instrumentation.targetContext
+    private val application = context.applicationContext as Application
+    private lateinit var cameraSystemScope: CoroutineScope
+    private var cameraJob: Job? = null
+
+    @Before
+    fun setup() {
+        cameraSystemScope = CoroutineScope(Dispatchers.Main)
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking {
+            cameraJob?.cancelAndJoin()
+        }
+        cameraSystemScope.cancel()
+    }
+
+    /**
+     * Verifies that [applyDiffs] propagates changes to [DynamicRange] to [CameraSystem]
+     * for the parameterized lens, or skips if the device/lens does not support HDR video.
+     */
+    @Test
+    fun applyDiffs_dynamicRange_propagatesChange(): Unit = runBlocking {
+        // Arrange. Initialize camera in VIDEO_ONLY mode (required for HDR video capture).
+        val cameraSystem = createAndInitCameraXCameraSystem(
+            appSettings = DEFAULT_CAMERA_APP_SETTINGS.copy(
+                cameraLensFacing = lensFacing,
+                captureMode = CaptureMode.VIDEO_ONLY,
+                dynamicRange = DynamicRange.SDR
+            )
+        )
+
+        val systemConstraints = cameraSystem.getSystemConstraints().value
+        val isLensAvailable = systemConstraints?.availableLenses?.contains(lensFacing) == true
+        assume().withMessage("Lens $lensFacing is not available on this device, skipping.")
+            .that(isLensAvailable).isTrue()
+
+        val lensConstraints = systemConstraints?.perLensConstraints?.get(lensFacing)
+        val supportsHdr = lensConstraints?.supportedDynamicRanges?.contains(
+            DynamicRange.HLG10
+        ) == true
+        assume().withMessage("HDR video (HLG10) is not supported on $lensFacing, skipping.")
+            .that(supportsHdr).isTrue()
+
+        cameraSystem.startCameraAndWaitUntilRunning()
+
+        val dynamicRangeCheck = cameraSystem.getCurrentSettings()
+            .filterNotNull()
+            .map { it.dynamicRange }
+            .produceIn(this)
+
+        try {
+            dynamicRangeCheck.awaitValue(DynamicRange.SDR)
+
+            // Act: Apply diff with HLG10
+            val currentSettings = checkNotNull(cameraSystem.getCurrentSettings().value) {
+                "Settings not initialized"
+            }
+            val newSettings = currentSettings.copy(dynamicRange = DynamicRange.HLG10)
+            currentSettings.applyDiffs(newSettings, cameraSystem)
+
+            // Assert: Dynamic range is updated to HLG10
+            dynamicRangeCheck.awaitValue(DynamicRange.HLG10)
+
+            // Act: Apply diff back to SDR
+            val updatedSettings = checkNotNull(cameraSystem.getCurrentSettings().value) {
+                "Settings not initialized"
+            }
+            val resetSettings = updatedSettings.copy(dynamicRange = DynamicRange.SDR)
+            updatedSettings.applyDiffs(resetSettings, cameraSystem)
+
+            // Assert: Dynamic range is reset to SDR
+            dynamicRangeCheck.awaitValue(DynamicRange.SDR)
+        } finally {
+            dynamicRangeCheck.cancel()
+        }
+    }
+
+    /**
+     * Verifies that [applyDiffs] propagates changes to [ImageOutputFormat] to [CameraSystem]
+     * for the parameterized lens, or skips if the device/lens does not support Ultra HDR.
+     */
+    @Test
+    fun applyDiffs_imageFormat_propagatesChange(): Unit = runBlocking {
+        // Arrange. Initialize camera in IMAGE_ONLY mode (required for Ultra HDR image capture).
+        val cameraSystem = createAndInitCameraXCameraSystem(
+            appSettings = DEFAULT_CAMERA_APP_SETTINGS.copy(
+                cameraLensFacing = lensFacing,
+                captureMode = CaptureMode.IMAGE_ONLY,
+                imageFormat = ImageOutputFormat.JPEG
+            )
+        )
+
+        val systemConstraints = cameraSystem.getSystemConstraints().value
+        val isLensAvailable = systemConstraints?.availableLenses?.contains(lensFacing) == true
+        assume().withMessage("Lens $lensFacing is not available on this device, skipping.")
+            .that(isLensAvailable).isTrue()
+
+        val lensConstraints = systemConstraints?.perLensConstraints?.get(lensFacing)
+        val supportsUltraHdr =
+            lensConstraints?.supportedImageFormatsMap?.get(false)
+                ?.contains(ImageOutputFormat.JPEG_ULTRA_HDR) == true
+        assume().withMessage("Ultra HDR is not supported on $lensFacing, skipping.")
+            .that(supportsUltraHdr).isTrue()
+
+        cameraSystem.startCameraAndWaitUntilRunning()
+
+        val imageFormatCheck = cameraSystem.getCurrentSettings()
+            .filterNotNull()
+            .map { it.imageFormat }
+            .produceIn(this)
+
+        try {
+            imageFormatCheck.awaitValue(ImageOutputFormat.JPEG)
+
+            // Act: Apply diff with Ultra HDR
+            val currentSettings = checkNotNull(cameraSystem.getCurrentSettings().value) {
+                "Settings not initialized"
+            }
+            val newSettings = currentSettings.copy(imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR)
+            currentSettings.applyDiffs(newSettings, cameraSystem)
+
+            // Assert: Image format is updated to JPEG_ULTRA_HDR
+            imageFormatCheck.awaitValue(ImageOutputFormat.JPEG_ULTRA_HDR)
+
+            // Act: Apply diff back to JPEG
+            val updatedSettings = checkNotNull(cameraSystem.getCurrentSettings().value) {
+                "Settings not initialized"
+            }
+            val resetSettings = updatedSettings.copy(imageFormat = ImageOutputFormat.JPEG)
+            updatedSettings.applyDiffs(resetSettings, cameraSystem)
+
+            // Assert: Image format is reset to JPEG
+            imageFormatCheck.awaitValue(ImageOutputFormat.JPEG)
+        } finally {
+            imageFormatCheck.cancel()
+        }
+    }
+
+    private suspend fun createAndInitCameraXCameraSystem(
+        appSettings: CameraAppSettings = DEFAULT_CAMERA_APP_SETTINGS
+    ) = CameraXCameraSystem(
+        application = application,
+        defaultDispatcher = Dispatchers.Default,
+        iODispatcher = Dispatchers.IO,
+        availabilityCheckers = emptyMap(),
+        effectProviders = emptyMap(),
+        imagePostProcessors = emptyMap(),
+        cameraEffectProviders = emptyMap(),
+        filePathGenerator = FakeFilePathGenerator()
+    ).apply {
+        initialize(appSettings) {}
+        providePreviewSurface()
+    }
+
+    private suspend fun <T> ReceiveChannel<T>.awaitValue(
+        expectedValue: T,
+        timeoutMs: Long = GENERAL_TIMEOUT_MS
+    ) {
+        val found = withTimeoutOrNull(timeoutMs) {
+            for (value in this@awaitValue) {
+                if (value == expectedValue) return@withTimeoutOrNull true
+            }
+            false
+        } ?: false
+        assertWithMessage("Expected value $expectedValue was not received within ${timeoutMs}ms")
+            .that(found)
+            .isTrue()
+    }
+
+    private fun CameraXCameraSystem.providePreviewSurface() {
+        cameraSystemScope.launch {
+            getSurfaceRequest().filterNotNull().collect {
+                it.provideUpdatingSurface()
+            }
+        }
+    }
+
+    private suspend fun CameraXCameraSystem.startCameraAndWaitUntilRunning() {
+        cameraJob = cameraSystemScope.launch { runCamera() }
+        val cameraStarted = withTimeoutOrNull(CAMERA_START_TIMEOUT_MS) {
+            getCurrentCameraState().filterNotNull().first {
+                it.isCameraRunning
+            }
+        } != null
+        assertWithMessage("Camera timed out while starting.").that(cameraStarted).isTrue()
+        instrumentation.waitForIdleSync()
+    }
+}

--- a/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
+++ b/core/camera/src/main/java/com/google/jetpackcamera/core/camera/CameraSystem.kt
@@ -313,6 +313,8 @@ interface CameraSystem {
                 cameraSystem::setMaxVideoDuration
             )
             applyDiff(new, CameraAppSettings::videoQuality, cameraSystem::setVideoQuality)
+            applyDiff(new, CameraAppSettings::dynamicRange, cameraSystem::setDynamicRange)
+            applyDiff(new, CameraAppSettings::imageFormat, cameraSystem::setImageFormat)
             applyDiff(new, CameraAppSettings::audioEnabled, cameraSystem::setAudioEnabled)
             applyDiff(
                 new,

--- a/core/camera/src/test/java/com/google/jetpackcamera/core/camera/CameraSystemTest.kt
+++ b/core/camera/src/test/java/com/google/jetpackcamera/core/camera/CameraSystemTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jetpackcamera.core.camera
+
+import com.google.common.truth.Truth.assertThat
+import com.google.jetpackcamera.core.camera.CameraSystem.Companion.applyDiffs
+import com.google.jetpackcamera.core.camera.testing.FakeCameraSystem
+import com.google.jetpackcamera.model.DynamicRange
+import com.google.jetpackcamera.model.ImageOutputFormat
+import com.google.jetpackcamera.settings.model.CameraAppSettings
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Unit tests for [CameraSystem] extension functions, specifically [CameraAppSettings.applyDiffs].
+ */
+@RunWith(JUnit4::class)
+class CameraSystemTest {
+
+    private val fakeCameraSystem = FakeCameraSystem()
+
+    /**
+     * Verifies that when [CameraAppSettings.dynamicRange] changes, [applyDiffs] propagates
+     * the new dynamic range to the [CameraSystem].
+     */
+    @Test
+    fun applyDiffs_dynamicRangeChanged_propagatesToCameraSystem() = runTest {
+        val oldSettings = CameraAppSettings(dynamicRange = DynamicRange.SDR)
+        val newSettings = CameraAppSettings(dynamicRange = DynamicRange.HLG10)
+
+        oldSettings.applyDiffs(newSettings, fakeCameraSystem)
+
+        assertThat(fakeCameraSystem.getCurrentSettings().first()?.dynamicRange)
+            .isEqualTo(DynamicRange.HLG10)
+    }
+
+    /**
+     * Verifies that when [CameraAppSettings.imageFormat] changes, [applyDiffs] propagates
+     * the new image format to the [CameraSystem].
+     */
+    @Test
+    fun applyDiffs_imageFormatChanged_propagatesToCameraSystem() = runTest {
+        val oldSettings = CameraAppSettings(imageFormat = ImageOutputFormat.JPEG)
+        val newSettings = CameraAppSettings(imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR)
+
+        oldSettings.applyDiffs(newSettings, fakeCameraSystem)
+
+        assertThat(fakeCameraSystem.getCurrentSettings().first()?.imageFormat)
+            .isEqualTo(ImageOutputFormat.JPEG_ULTRA_HDR)
+    }
+
+    /**
+     * Verifies that when settings have not changed, [applyDiffs] does not alter the camera
+     * system settings.
+     */
+    @Test
+    fun applyDiffs_unchangedSettings_doesNotAlterCameraSystem() = runTest {
+        val initialSettings = CameraAppSettings(
+            dynamicRange = DynamicRange.HLG10,
+            imageFormat = ImageOutputFormat.JPEG_ULTRA_HDR
+        )
+        val newSettings = initialSettings.copy()
+
+        // fakeCameraSystem defaults to SDR and JPEG. If unchanged settings are properly
+        // skipped by applyDiffs, fakeCameraSystem's settings will remain unaltered.
+        initialSettings.applyDiffs(newSettings, fakeCameraSystem)
+
+        assertThat(fakeCameraSystem.getCurrentSettings().first()?.dynamicRange)
+            .isEqualTo(DynamicRange.SDR)
+        assertThat(fakeCameraSystem.getCurrentSettings().first()?.imageFormat)
+            .isEqualTo(ImageOutputFormat.JPEG)
+    }
+}

--- a/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
+++ b/feature/preview/src/test/java/com/google/jetpackcamera/feature/preview/PreviewViewModelTest.kt
@@ -24,7 +24,10 @@ import com.google.jetpackcamera.core.camera.CameraSystem
 import com.google.jetpackcamera.core.camera.testing.FakeCameraSystem
 import com.google.jetpackcamera.data.camera.CameraSystemRepository
 import com.google.jetpackcamera.data.media.testing.FakeMediaRepository
+import com.google.jetpackcamera.model.CaptureMode
+import com.google.jetpackcamera.model.DynamicRange
 import com.google.jetpackcamera.model.FlashMode
+import com.google.jetpackcamera.model.ImageOutputFormat
 import com.google.jetpackcamera.model.LensFacing
 import com.google.jetpackcamera.model.SaveMode
 import com.google.jetpackcamera.settings.SettableConstraintsRepositoryImpl
@@ -38,6 +41,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -64,11 +68,13 @@ class PreviewViewModelTest {
             cameraSystem.initialize(CameraAppSettings()) {}
             return cameraSystem
         }
+
         override suspend fun getSupportedMimeTypes(): List<String> = emptyList()
     }
     private val constraintsRepository = SettableConstraintsRepositoryImpl().apply {
         updateSystemConstraints(TYPICAL_SYSTEM_CONSTRAINTS)
     }
+    private val settingsRepository = FakeSettingsRepository()
     private lateinit var previewViewModel: PreviewViewModel
 
     @Before
@@ -77,7 +83,7 @@ class PreviewViewModelTest {
         previewViewModel = PreviewViewModel(
             cameraSystemRepository = cameraSystemRepository,
             constraintsRepository = constraintsRepository,
-            settingsRepository = FakeSettingsRepository(),
+            settingsRepository = settingsRepository,
             mediaRepository = FakeMediaRepository(),
             savedStateHandle = SavedStateHandle(),
             defaultSaveMode = SaveMode.Immediate
@@ -181,6 +187,67 @@ class PreviewViewModelTest {
             ).isEqualTo(LensFacing.FRONT)
         }
         assertThat(cameraSystem.isLensFacingFront).isTrue()
+    }
+
+    /**
+     * Verifies that when [DynamicRange] is updated in [SettingsRepository], the change propagates
+     * through [CameraAppSettings.applyDiffs] to the [CameraSystem].
+     *
+     * CaptureMode is switched to [CaptureMode.VIDEO_ONLY] since HDR video is not supported in
+     * standard capture mode.
+     */
+    @Test
+    fun updateDynamicRange_propagatesToCameraSystem() = runTest(StandardTestDispatcher()) {
+        enableHdrAndUltraHdrConstraints()
+        startCameraUntilRunning()
+        previewViewModel.quickSettingsController.setCaptureMode(CaptureMode.VIDEO_ONLY)
+        advanceUntilIdle()
+        settingsRepository.updateDynamicRange(DynamicRange.HLG10)
+        advanceUntilIdle()
+        assertThat(cameraSystem.getCurrentSettings().first()?.dynamicRange)
+            .isEqualTo(DynamicRange.HLG10)
+    }
+
+    /**
+     * Verifies that when [ImageOutputFormat] is updated in [SettingsRepository], the change
+     * propagates through [CameraAppSettings.applyDiffs] to the [CameraSystem].
+     *
+     * CaptureMode is switched to [CaptureMode.IMAGE_ONLY] since Ultra HDR is not supported in
+     * standard capture mode.
+     */
+    @Test
+    fun updateImageFormat_propagatesToCameraSystem() = runTest(StandardTestDispatcher()) {
+        enableHdrAndUltraHdrConstraints()
+        startCameraUntilRunning()
+        previewViewModel.quickSettingsController.setCaptureMode(CaptureMode.IMAGE_ONLY)
+        advanceUntilIdle()
+        settingsRepository.updateImageFormat(ImageOutputFormat.JPEG_ULTRA_HDR)
+        advanceUntilIdle()
+        assertThat(cameraSystem.getCurrentSettings().first()?.imageFormat)
+            .isEqualTo(ImageOutputFormat.JPEG_ULTRA_HDR)
+    }
+
+    private fun enableHdrAndUltraHdrConstraints() {
+        constraintsRepository.updateSystemConstraints(
+            TYPICAL_SYSTEM_CONSTRAINTS.copy(
+                perLensConstraints = TYPICAL_SYSTEM_CONSTRAINTS.perLensConstraints
+                    .mapValues { (_, constraints) ->
+                        constraints.copy(
+                            supportedDynamicRanges = setOf(DynamicRange.SDR, DynamicRange.HLG10),
+                            supportedImageFormatsMap = mapOf(
+                                false to setOf(
+                                    ImageOutputFormat.JPEG,
+                                    ImageOutputFormat.JPEG_ULTRA_HDR
+                                ),
+                                true to setOf(
+                                    ImageOutputFormat.JPEG,
+                                    ImageOutputFormat.JPEG_ULTRA_HDR
+                                )
+                            )
+                        )
+                    }
+            )
+        )
     }
 
     private fun TestScope.startCameraUntilRunning() {


### PR DESCRIPTION
TLDR: 
🐛 **Problem**: Currently, when settings are updated from SettingsRepository, `CameraAppSettings.applyDiffs` propagates changed preferences to CameraSystem. It currently **_omits_** `dynamicRange` and `imageFormat`.
✅ **Solution**: this PR includes `dynamicRange` and `imageFormat` in `CameraAppSettings.applyDiffs` tests.
❓ **note**: HDR controls aren't currently included in JCA's dedicated settings screen. 

Longer description:
- ⭐ Adds diff propagation for dynamicRange and imageFormat in `CameraAppSettings.applyDiffs`.
-  Adds unit tests in CameraSystemTest verifying applyDiffs correctly updates CameraSystem on setting changes and skips unchanged settings.
- Adds unit tests in PreviewViewModelTest confirming end-to-end propagation from SettingsRepository through applyDiffs to CameraSystem.
- Adds parameterized on-device tests in CameraSystemApplyDiffsDeviceTest executing across all available lenses (BACK, FRONT), verifying live diff application and skipping gracefully when unsupported by hardware constraints.
